### PR TITLE
Apply noexcept to appropiate std::move constructors

### DIFF
--- a/include/nanobind/nb_error.h
+++ b/include/nanobind/nb_error.h
@@ -12,7 +12,7 @@ class NB_EXPORT python_error : public std::exception {
 public:
     python_error();
     python_error(const python_error &);
-    python_error(python_error &&);
+    python_error(python_error &&) noexcept;
     virtual ~python_error();
 
     /// Move the error back into the Python domain

--- a/include/nanobind/nb_tuple.h
+++ b/include/nanobind/nb_tuple.h
@@ -12,8 +12,8 @@ template <typename T, typename... Ts> struct nb_tuple<T, Ts...> : nb_tuple<Ts...
 
     nb_tuple() = default;
     nb_tuple(const nb_tuple &) = default;
-    nb_tuple(nb_tuple &&) = default;
-    nb_tuple& operator=(nb_tuple &&) = default;
+    nb_tuple(nb_tuple &&) noexcept = default;
+    nb_tuple& operator=(nb_tuple &&) noexcept = default;
     nb_tuple& operator=(const nb_tuple &) = default;
 
     NB_INLINE nb_tuple(const T& value, const Ts&... ts)

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -24,8 +24,7 @@ python_error::python_error(const python_error &e) : std::exception(e) {
         m_what = strdup(e.m_what);
 }
 
-python_error::python_error(python_error &&e)
-    : std::exception(std::move(e)) {
+python_error::python_error(python_error &&e) noexcept : std::exception(e) {
     m_type = std::move(e.m_type);
     m_value = std::move(e.m_value);
     m_trace = std::move(e.m_trace);

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -19,9 +19,9 @@ struct Struct {
     Struct() { default_constructed++; }
     Struct(int i) : i(i) { value_constructed++; }
     Struct(const Struct &s) : i(s.i) { copy_constructed++; }
-    Struct(Struct &&s) : i(s.i) { s.i = 0; move_constructed++; }
+    Struct(Struct &&s) noexcept : i(s.i) { s.i = 0; move_constructed++; }
     Struct &operator=(const Struct &s) { i = s.i; copy_assigned++; return *this; }
-    Struct &operator=(Struct &&s) { std::swap(i, s.i); move_assigned++; return *this; }
+    Struct &operator=(Struct &&s) noexcept { std::swap(i, s.i); move_assigned++; return *this; }
     ~Struct() { destructed++; }
 
     int value() const { return i; }


### PR DESCRIPTION
I did some brief static analysis with clang-tidy and found some code improvements (a reason I suggested adding basic clang-tidy checks). Mainly it adds noexcepts which can make certain STL constructs able to use their move constructors. It also removed a useless std::move in the move constructor for src/error.cp since the base class std::exception apparently does not have a move constructor.