### PR TITLE
Include detail/nb_list.h in the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     package_data={'nanobind': [
         'include/nanobind/*.h',
         'include/nanobind/stl/*.h',
+        'include/nanobind/stl/detail/*.h',
         'ext/robin_map/include/tsl/*.h',
         'cmake/nanobind-config.cmake',
         'src/*.h',


### PR DESCRIPTION
When I use `#include <nanobind/stl/vector.h>`, I currently get

```
  /private/var/folders/k8/fypg6j5x187dmhbw3q_047s40000gp/T/pip-build-env-8kz_3qma/overlay/lib/python3.9/site-packages/nanobind/include/nanobind/stl/vector.h:3:10: fatal error: 'detail/nb_list.h' file not found
  #include "detail/nb_list.h"
```

I'm assuming this would fix it.