### PR TITLE
Apply clang-tidy fixes

### DIFF
--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -21,14 +21,14 @@ struct name {
 
 struct arg_v;
 struct arg {
-    NB_INLINE constexpr explicit arg(const char *name = nullptr) : name(name), convert_(true), none_(false) { }
+    NB_INLINE constexpr explicit arg(const char *name = nullptr) : name(name) { }
     template <typename T> NB_INLINE arg_v operator=(T &&value) const;
     NB_INLINE arg &noconvert(bool value = true) { convert_ = !value; return *this; }
     NB_INLINE arg &none(bool value = true) { none_ = value; return *this; }
 
     const char *name;
-    uint8_t convert_;
-    bool none_;
+    uint8_t convert_{true};
+    bool none_{false};
 };
 
 struct arg_v : arg {

--- a/include/nanobind/nb_call.h
+++ b/include/nanobind/nb_call.h
@@ -59,7 +59,7 @@ NB_INLINE void call_init(PyObject **args, PyObject *kwnames, size_t &nargs,
         for (size_t i = 0, l = len(value); i < l; ++i)
             args[nargs++] = borrow(value[i]).release().ptr();
     } else if constexpr (std::is_same_v<D, kwargs_proxy>) {
-        PyObject *key, *entry;
+        PyObject *key = nullptr, *entry = nullptr;
         Py_ssize_t pos = 0;
 
         while (PyDict_Next(value.ptr(), &pos, &key, &entry)) {

--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -233,7 +233,7 @@ template <typename Type_> struct type_caster_base {
     template <typename T>
     NB_INLINE static handle from_cpp(T &&value, rv_policy policy,
                                      cleanup_list *cleanup) noexcept {
-        Type *value_p;
+        Type *value_p = nullptr;
         if constexpr (is_pointer_v<T>)
             value_p = (Type *) value;
         else

--- a/include/nanobind/nb_error.h
+++ b/include/nanobind/nb_error.h
@@ -22,7 +22,7 @@ public:
     python_error();
     python_error(const python_error &);
     python_error(python_error &&) noexcept;
-    virtual ~python_error();
+    ~python_error() override;
 
     /// Move the error back into the Python domain
     void restore();
@@ -31,7 +31,7 @@ public:
     const handle value() const { return m_value; }
     const handle trace() const { return m_trace; }
 
-    virtual const char *what() const noexcept override;
+    const char *what() const noexcept override;
 
 private:
     object m_type, m_value, m_trace;
@@ -42,7 +42,7 @@ private:
 class NB_EXPORT next_overload : public std::exception {
 public:
     next_overload();
-    virtual ~next_overload();
+    ~next_overload() override;
 };
 
 // Base interface used to expose common Python exceptions in C++

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -100,7 +100,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
                 cleanup_list *cleanup) -> PyObject * {
         (void)p; (void)args; (void)args_flags; (void)policy; (void)cleanup;
 
-        const capture *cap;
+        const capture *cap = nullptr;
         if constexpr (sizeof(capture) <= sizeof(f.capture))
             cap = (capture *) p;
         else
@@ -113,7 +113,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
                                                 cleanup) || ...))
             return NB_NEXT_OVERLOAD;
 
-        PyObject *result;
+        PyObject *result = nullptr;
         if constexpr (std::is_void_v<Return>) {
             cap->func(((make_caster<Args>&&) in.template get<Is>()).operator cast_t<Args>()...);
             Py_INCREF(Py_None);

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -19,10 +19,9 @@ struct NB_CORE cleanup_list {
 public:
     static constexpr uint32_t Small = 6;
 
-    cleanup_list(PyObject *self) {
-        m_size = 1;
-        m_capacity = Small;
-        m_data = m_local;
+    cleanup_list(PyObject *self) : m_size{1},
+		   m_capacity{Small},
+		   m_data{m_local} {
         m_local[0] = self;
     }
 

--- a/include/nanobind/nb_misc.h
+++ b/include/nanobind/nb_misc.h
@@ -30,7 +30,7 @@ private:
 // Deleter for std::unique_ptr<T> (handles ownership by both C++ and Python)
 template <typename T> struct deleter {
     /// Instance should be cleared using a delete expression
-    deleter() : o(nullptr) { }
+    deleter()  = default;
 
     /// Instance owned by Python, reduce reference count upon deletion
     deleter(handle h) : o(h.ptr()) { }
@@ -51,7 +51,7 @@ template <typename T> struct deleter {
         }
     }
 
-    PyObject *o;
+    PyObject *o{nullptr};
 };
 
 NAMESPACE_END(NB_NAMESPACE)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -137,7 +137,7 @@ PyObject *module_new_submodule(PyObject *base, const char *name,
                                const char *doc) noexcept {
 
     PyObject *base_name = PyModule_GetNameObject(base),
-             *name_py, *res;
+             *name_py = nullptr, *res = nullptr;
     if (!base_name)
         goto fail;
 
@@ -354,7 +354,7 @@ void getitem_maybe(PyObject *obj, const char *key_, PyObject **out) {
     if (*out)
         return;
 
-    PyObject *key, *res;
+    PyObject *key = nullptr, *res = nullptr;
 
     key = PyUnicode_FromString(key_);
     if (!key)

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -25,18 +25,18 @@ python_error::~python_error() {
     free(m_what);
 }
 
-python_error::python_error(const python_error &e) : std::exception(e) {
-    m_type = e.m_type;
-    m_value = e.m_value;
-    m_trace = e.m_trace;
+python_error::python_error(const python_error &e) : std::exception(e),
+    m_type{e.m_type},
+    m_value{e.m_value},
+    m_trace{e.m_trace} {
     if (e.m_what)
         m_what = NB_STRDUP(e.m_what);
 }
 
-python_error::python_error(python_error &&e) noexcept : std::exception(e) {
-    m_type = std::move(e.m_type);
-    m_value = std::move(e.m_value);
-    m_trace = std::move(e.m_trace);
+python_error::python_error(python_error &&e) noexcept : std::exception(e),
+    m_type{std::move(e.m_type)},
+    m_value{std::move(e.m_value)},
+    m_trace{std::move(e.m_trace)} {
     std::swap(m_what, e.m_what);
 }
 
@@ -95,7 +95,7 @@ void python_error::restore() {
 }
 
 next_overload::next_overload() : std::exception() { }
-next_overload::~next_overload() { }
+next_overload::~next_overload() = default;
 
 #define NB_EXCEPTION(name, type)                                               \
     name::name() : builtin_exception("") { }                                   \

--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -90,7 +90,7 @@ static PyObject *nb_enum_int(PyObject *o) {
 
     const void *p = inst_data(&e->inst);
     if (t->t.flags & (uint32_t) type_flags::is_unsigned_enum) {
-        unsigned long long value;
+        unsigned long long value = 0;
         switch (t->t.size) {
             case 1: value = (unsigned long long) *(const uint8_t *)  p; break;
             case 2: value = (unsigned long long) *(const uint16_t *) p; break;
@@ -101,7 +101,7 @@ static PyObject *nb_enum_int(PyObject *o) {
         }
         return PyLong_FromUnsignedLongLong(value);
     } else if (t->t.flags & (uint32_t) type_flags::is_signed_enum) {
-        long long value;
+        long long value = 0;
         switch (t->t.size) {
             case 1: value = (long long) *(const int8_t *)  p; break;
             case 2: value = (long long) *(const int16_t *) p; break;
@@ -118,7 +118,7 @@ static PyObject *nb_enum_int(PyObject *o) {
 }
 
 static PyObject *nb_enum_init(PyTypeObject *subtype, PyObject *args, PyObject *kwds) {
-    PyObject *arg;
+    PyObject *arg = nullptr;
 
     if (kwds || PyTuple_GET_SIZE(args) != 1)
         goto error;
@@ -232,7 +232,7 @@ void nb_enum_prepare(PyTypeObject *tp, bool is_arithmetic) {
 
 void nb_enum_put(PyObject *type, const char *name, const void *value,
                  const char *doc) noexcept {
-    PyObject *name_py, *int_val, *dict;
+    PyObject *name_py = nullptr, *int_val = nullptr, *dict = nullptr;
     nb_enum *inst = (nb_enum *) inst_new_impl((PyTypeObject *) type, nullptr);
     if (!inst)
         goto error;

--- a/src/trampoline.cpp
+++ b/src/trampoline.cpp
@@ -64,8 +64,8 @@ PyObject *trampoline_lookup(void **data, size_t size, const char *name,
     }
 
     // Sill no luck -- perform a lookup and populate the trampoline
-    const char *error;
-    bool is_nb_func;
+    const char *error = nullptr;
+    bool is_nb_func = false;
 
     size_t offset = 0;
     for (; offset < size; offset++) {

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -138,7 +138,7 @@ NB_MODULE(test_classes_ext, m) {
             default_constructed++;
         }
 
-        ~PyAnimal() {
+        ~PyAnimal() override {
             destructed++;
         }
 


### PR DESCRIPTION
Applies various clang-tidy fixes that either follows best practices (ie. initializes pointers to nullptr) or uses modern C++ constructs (like using member initializers that can, reduce the amount of code, increase readability and make some constructors trivial. This also initializes some trivial types likes raw pointers, floats, and booleans since this makes debugging easier and reduces UB.