### PR TITLE
Apply more minor clang-tidy fixes

### DIFF
--- a/include/nanobind/nb_accessor.h
+++ b/include/nanobind/nb_accessor.h
@@ -16,7 +16,7 @@ public:
 
     template <typename Key>
     accessor(handle obj, Key &&key)
-        : m_base(obj.ptr()), m_cache(nullptr), m_key(std::move(key)) { }
+        : m_base(obj.ptr()),  m_key(std::move(key)) { }
     accessor(const accessor &) = delete;
     accessor(accessor &&) = delete;
     ~accessor() {
@@ -37,7 +37,7 @@ public:
 
 private:
     PyObject *m_base;
-    mutable PyObject *m_cache;
+    mutable PyObject *m_cache{nullptr};
     typename Impl::key_type m_key;
 };
 

--- a/include/nanobind/nb_accessor.h
+++ b/include/nanobind/nb_accessor.h
@@ -16,7 +16,7 @@ public:
 
     template <typename Key>
     accessor(handle obj, Key &&key)
-        : m_base(obj.ptr()),  m_key(std::move(key)) { }
+        : m_base(obj.ptr()), m_key(std::move(key)) { }
     accessor(const accessor &) = delete;
     accessor(accessor &&) = delete;
     ~accessor() {

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -20,6 +20,7 @@ public:
     static constexpr uint32_t Small = 6;
 
     cleanup_list(PyObject *self) :
+        m_size{1},
         m_capacity{Small},
         m_data{m_local} {
         m_local[0] = self;
@@ -46,7 +47,7 @@ protected:
     void expand() noexcept;
 
 protected:
-    uint32_t m_size{1};
+    uint32_t m_size;
     uint32_t m_capacity;
     PyObject **m_data;
     PyObject *m_local[Small];

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -19,9 +19,9 @@ struct NB_CORE cleanup_list {
 public:
     static constexpr uint32_t Small = 6;
 
-    cleanup_list(PyObject *self) : m_size{1},
-		   m_capacity{Small},
-		   m_data{m_local} {
+    cleanup_list(PyObject *self) :
+        m_capacity{Small},
+        m_data{m_local} {
         m_local[0] = self;
     }
 
@@ -46,7 +46,7 @@ protected:
     void expand() noexcept;
 
 protected:
-    uint32_t m_size;
+    uint32_t m_size{1};
     uint32_t m_capacity;
     PyObject **m_data;
     PyObject *m_local[Small];

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -10,8 +10,7 @@ public:
     Buffer &operator=(Buffer &&) = delete;
 
     Buffer(size_t size = 0)
-        : m_start(nullptr), m_cur(nullptr), m_end(nullptr) {
-        m_start = (char *) malloc(size);
+        : m_start((char *) malloc(size)) {
         if (!m_start) {
             fprintf(stderr, "Buffer::Buffer(): out of memory (unrecoverable error)!");
             abort();
@@ -155,7 +154,7 @@ private:
     }
 
 private:
-    char *m_start, *m_cur, *m_end;
+    char *m_start{nullptr}, *m_cur{nullptr}, *m_end{nullptr};
 };
 
 NAMESPACE_END(detail)

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -301,7 +301,7 @@ nb_func_error_overload(PyObject *self, PyObject *const *args_in,
         buf.put_uint32(i + 1);
         buf.put(". ");
         nb_func_render_signature(f + i);
-        buf.put("\n");
+        buf.put('\n');
     }
 
     buf.put("\nInvoked with types: ");
@@ -869,7 +869,7 @@ static PyObject *nb_func_get_doc(PyObject *self, void *) {
             return PyUnicode_FromString(fi->doc);
 
         nb_func_render_signature(fi);
-        buf.put("\n");
+        buf.put('\n');
         if ((fi->flags & (uint32_t) func_flags::has_doc) && fi->doc[0] != '\0')
             doc_count++;
     }


### PR DESCRIPTION
This PR adds in a couple of fixes up:
1. Simplifies a few new line string literals into chars.
2. Moves default initialization out of the constructors if they are always the same.