### PR TITLE
Let `std::string` and `char *` casters also accept `bytes`

### DIFF
--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -161,11 +161,16 @@ template <> struct type_caster<bool> {
 template <> struct type_caster<char> {
     bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
         value = PyUnicode_AsUTF8AndSize(src.ptr(), nullptr);
-        if (!value) {
-            PyErr_Clear();
-            return false;
+        if (value) {
+            return true;
         }
-        return true;
+        PyErr_Clear();
+        value = PyBytes_AsString(src.ptr());
+        if (value) {
+            return true;
+        }
+        PyErr_Clear();
+        return false;
     }
 
     static handle from_cpp(const char *value, rv_policy,
@@ -177,7 +182,7 @@ template <> struct type_caster<char> {
         return PyUnicode_FromStringAndSize(&value, 1);
     }
 
-    NB_TYPE_CASTER(const char *, const_name("str"));
+    NB_TYPE_CASTER(const char *, const_name("str | bytes"));
 };
 
 template <typename T>

--- a/include/nanobind/stl/string.h
+++ b/include/nanobind/stl/string.h
@@ -7,17 +7,22 @@ NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
 template <> struct type_caster<std::string> {
-    NB_TYPE_CASTER(std::string, const_name("str"));
+    NB_TYPE_CASTER(std::string, const_name("str | bytes"));
 
     bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
         Py_ssize_t size;
         const char *str = PyUnicode_AsUTF8AndSize(src.ptr(), &size);
-        if (!str) {
-            PyErr_Clear();
-            return false;
+        if (str) {
+            value = std::string(str, (size_t) size);
+            return true;
         }
-        value = std::string(str, (size_t) size);
-        return true;
+        PyErr_Clear();
+        if (!PyBytes_AsStringAndSize(src.ptr(), const_cast<char **>(&str), &size)) {
+            value = std::string(str, (size_t) size);
+            return true;
+        }
+        PyErr_Clear();
+        return false;
     }
 
     static handle from_cpp(const std::string &value, rv_policy,


### PR DESCRIPTION
I don't quite know whether I like this. Ideally, we'd be able to tell from C++ whether something is intended to be UTF-8 or not. (Maybe an argument attribute? An entirely separate type?) Examples where this is relevant include Unix filenames (bytes, not really UTF-8). I encountered it for passing compiler options to OpenCL's `clBuildProgram`, where any implicit encoding change is a risk.

Still to do:
- [ ] Add some tests