### PR TITLE
Add `MANIFEST.in`, vim files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cmake_install.cmake
 __pycache__
 nanobind.egg-info
 test_*_ext*
+
+*~
+.*.sw[op]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,13 @@
+recursive-include include *.h
+recursive-include src *.h *.cpp
+
+recursive-exclude src/nanobind/cmake *
+recursive-exclude src/nanobind/include *
+recursive-exclude src/nanobind/src *
+recursive-exclude src/nanobind/ext *
+
+recursive-include ext *.h
+recursive-include docs *.md *.svg *.ipynb
+recursive-include tests *.py *.cpp *.txt
+
+include CMakeLists.txt cmake/nanobind-config.cmake


### PR DESCRIPTION
The point of having `MANIFEST.in` is to let me easily roll packages to use with CI. I don't know how you make your releases, I found it convenient to have.

The other potential benefi of this is that, once it's in, you wouldn't have to keep approving CI on my other PRs. :slightly_smiling_face: 