### PR TITLE
Partial PyPy support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,8 @@ endif()
 # ---------------------------------------------------------------------------
 
 set(Python_FIND_FRAMEWORK LAST) # Prefer Brew/Conda to Apple framework python
-find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
+set(Python_FIND_IMPLEMENTATIONS CPython PyPy)
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
 
 # ---------------------------------------------------------------------------
 # Include nanobind cmake functionality

--- a/README.md
+++ b/README.md
@@ -164,9 +164,6 @@ Removed features include:
 - ○ Module-local types and exceptions are unsupported.
 - ○ Custom metaclasses are unsupported.
 - ● Many STL type caster have not yet been ported.
-- ● PyPy support is gone. (PyPy requires many workaround in _pybind11_ that
-  complicate the its internals. Making PyPy interoperate with _nanobind_ will
-  likely require changes to the PyPy CPython emulation layer.)
 - ◑ NumPy integration was replaced by a more general ``nb::tensor<>``
   integration that supports CPU/GPU tensors produced by various frameworks
   (NumPy, PyTorch, TensorFlow, JAX, ..).
@@ -254,9 +251,9 @@ _nanobind_ depends on recent versions of everything:
 
 - **C++17**: The `if constexpr` feature was crucial to simplify the internal
   meta-templating of this library.
-- **Python 3.8+**: _nanobind_ heavily relies on [PEP 590 vector
-  calls](https://www.python.org/dev/peps/pep-0590) that were introduced in
-  version 3.8.
+- **Python 3.8+** or **PyPy 3.9+**: _nanobind_ heavily relies on [PEP 590
+  vector calls](https://www.python.org/dev/peps/pep-0590) that were introduced
+  in Python version 3.8. Note that PyPy support is not stable yet.
 - **CMake 3.15+**: Recent CMake versions include important improvements to
   `FindPython` that this project depends on.
 - **Supported compilers**: Clang 7, GCC 8, MSVC2019 (or newer) are officially

--- a/include/nanobind/nb_call.h
+++ b/include/nanobind/nb_call.h
@@ -88,7 +88,7 @@ NB_INLINE void call_init(PyObject **args, PyObject *kwnames, size_t &nargs,
         args[0] = nullptr;                                                     \
         args_p = args + 1;                                                     \
     }                                                                          \
-    nargs |= PY_VECTORCALL_ARGUMENTS_OFFSET;                                   \
+    nargs |= NB_VECTORCALL_ARGUMENTS_OFFSET;                                   \
     return steal(obj_vectorcall(base, args_p, nargs, kwnames, method_call))
 
 template <typename Derived>

--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -69,11 +69,21 @@
 #if PY_VERSION_HEX < 0x03090000
 #  define NB_HAVE_VECTORCALL   _Py_TPFLAGS_HAVE_VECTORCALL
 #  define NB_VECTORCALL        _PyObject_Vectorcall
-#  define NB_VECTORCALL_METHOD  nb_vectorcall_method
 #else
 #  define NB_HAVE_VECTORCALL    Py_TPFLAGS_HAVE_VECTORCALL
 #  define NB_VECTORCALL         PyObject_Vectorcall
+#endif
+
+#if defined(PYPY_VERSION) || PY_VERSION_HEX < 0x03090000
+#  define NB_VECTORCALL_METHOD  nb_vectorcall_method
+#else
 #  define NB_VECTORCALL_METHOD  PyObject_VectorcallMethod
+#endif
+
+#if !defined(PYPY_VERSION)
+#  define NB_VECTORCALL_ARGUMENTS_OFFSET PY_VECTORCALL_ARGUMENTS_OFFSET
+#else
+#  define NB_VECTORCALL_ARGUMENTS_OFFSET 0
 #endif
 
 #define NB_MODULE(name, variable)                                              \

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -308,8 +308,11 @@ class list : public object {
 
     template <typename T, detail::enable_if_t<std::is_arithmetic_v<T>> = 1>
     detail::accessor<detail::num_item_list> operator[](T key) const;
+
+#if !defined(PYPY_VERSION)
     detail::fast_iterator begin() const;
     detail::fast_iterator end() const;
+#endif
 };
 
 class dict : public object {
@@ -498,6 +501,8 @@ inline detail::fast_iterator tuple::end() const {
     PyTupleObject *v = (PyTupleObject *) m_ptr;
     return v->ob_item + v->ob_base.ob_size;
 }
+
+#if !defined(PYPY_VERSION)
 inline detail::fast_iterator list::begin() const {
     return ((PyListObject *) m_ptr)->ob_item;
 }
@@ -505,6 +510,7 @@ inline detail::fast_iterator list::end() const {
     PyListObject *v = (PyListObject *) m_ptr;
     return v->ob_item + v->ob_base.ob_size;
 }
+#endif
 
 NAMESPACE_END(NB_NAMESPACE)
 

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -57,6 +57,7 @@ const char *python_error::what() const noexcept {
     if (m_value.is_valid())
         buf.put_dstr(str(m_value).c_str());
 
+#if !defined(PYPY_VERSION)
     if (m_trace.is_valid()) {
         PyTracebackObject *to = (PyTracebackObject *) m_trace.ptr();
 
@@ -84,6 +85,7 @@ const char *python_error::what() const noexcept {
             Py_DECREF(f_code);
         }
     }
+#endif
 
     m_what = buf.copy();
     return m_what;

--- a/src/internals.cpp
+++ b/src/internals.cpp
@@ -193,8 +193,7 @@ static void internals_make() {
         fail("nanobind::detail::internals_make(): type initialization failed!");
 
     if ((nb_type_type.tp_flags & Py_TPFLAGS_HEAPTYPE) != 0 ||
-        nb_type_type.tp_basicsize != sizeof(PyHeapTypeObject) + sizeof(type_data) ||
-        nb_type_type.tp_itemsize != sizeof(PyMemberDef))
+        nb_type_type.tp_basicsize != sizeof(PyHeapTypeObject) + sizeof(type_data))
         fail("nanobind::detail::internals_make(): initialized type invalid!");
 
     if (Py_AtExit(internals_cleanup))

--- a/src/internals.h
+++ b/src/internals.h
@@ -238,7 +238,7 @@ private:
     T *ptr{ nullptr };
 };
 
-#if PY_VERSION_HEX < 0x03090000
+#if defined(PYPY_VERSION) || PY_VERSION_HEX < 0x03090000
 extern PyObject *nb_vectorcall_method(PyObject *name, PyObject *const *args,
                                       size_t nargsf, PyObject *kwnames);
 #endif

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -499,7 +499,13 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
                         PyObject *hit = nullptr;
                         for (size_t j = 0; j < nkwargs_in; ++j) {
                             PyObject *key = PyTuple_GET_ITEM(kwargs_in, j);
-                            if (key == ad.name_py) {
+                            bool match;
+                            #if !defined(PYPY_VERSION)
+                                match = key == ad.name_py;
+                            #else
+                                match = PyUnicode_Compare(key, ad.name_py) == 0;
+                            #endif
+                            if (match) {
                                 hit = args_in[nargs_in + j];
                                 kwarg_used[j] = true;
                                 break;

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -395,7 +395,7 @@ found:
     PyObject *args[2] = { nullptr, src };
     PyObject *result =
         NB_VECTORCALL((PyObject *) dst_type->type_py, args + 1,
-                      PY_VECTORCALL_ARGUMENTS_OFFSET + 1, nullptr);
+                      NB_VECTORCALL_ARGUMENTS_OFFSET | 1, nullptr);
 
     if (result) {
         cleanup->append(result);

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -120,8 +120,12 @@ PyObject *inst_new(PyTypeObject *type, PyObject *, PyObject *) {
 
 static void inst_dealloc(PyObject *self) {
     nb_type *type = (nb_type *) Py_TYPE(self);
-    if (type->ht.ht_type.tp_flags & Py_TPFLAGS_HAVE_GC)
+    uint8_t *alloc = (uint8_t *) self;
+
+    if (type->ht.ht_type.tp_flags & Py_TPFLAGS_HAVE_GC) {
         PyObject_GC_UnTrack(self);
+        alloc -= sizeof(uintptr_t) * 2;
+    }
 
     nb_inst *inst = (nb_inst *) self;
     void *p = inst_ptr(inst);
@@ -170,7 +174,8 @@ static void inst_dealloc(PyObject *self) {
              "an unknown instance (%p)!", type->ht.ht_type.tp_name, p);
     internals.inst_c2p.erase(it);
 
-    type->ht.ht_type.tp_free(self);
+    PyObject_Free(alloc);
+
     Py_DECREF(type);
 }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -276,7 +276,7 @@ tensor_handle *tensor_import(PyObject *o, const tensor_req *req,
         str name("__dlpack__");
         PyObject *args[1] = { o };
         capsule = steal(NB_VECTORCALL_METHOD(
-            name.ptr(), args, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, nullptr));
+            name.ptr(), args, 1 | NB_VECTORCALL_ARGUMENTS_OFFSET, nullptr));
 
         if (!capsule.is_valid()) {
             PyErr_Clear();

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -5,9 +5,11 @@ import gc
 @pytest.fixture
 def clean():
     gc.collect()
+    gc.collect()
     t.reset()
 
 def assert_stats(**kwargs):
+    gc.collect()
     gc.collect()
     for k, v in t.stats().items():
         fail = False
@@ -330,8 +332,10 @@ def test16_keep_alive_custom(clean):
     assert t.keep_alive_arg(s, a) is a
     del s
     gc.collect()
+    gc.collect()
     assert constructed == 1 and destructed == 0
     del a
+    gc.collect()
     gc.collect()
     assert constructed == 1 and destructed == 1
 
@@ -340,8 +344,10 @@ def test16_keep_alive_custom(clean):
     assert t.keep_alive_ret(a, s) is s
     del a
     gc.collect()
+    gc.collect()
     assert constructed == 2 and destructed == 1
     del s
+    gc.collect()
     gc.collect()
     assert constructed == 2 and destructed == 2
 

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -5,9 +5,11 @@ import gc
 @pytest.fixture
 def clean():
     gc.collect()
+    gc.collect()
     t.reset()
 
 def assert_stats(**kwargs):
+    gc.collect()
     gc.collect()
     for k, v in t.stats().items():
         fail = False

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -200,15 +200,18 @@ def test12_implicit_conversion_jax():
 
 def test13_destroy_capsule():
     gc.collect()
+    gc.collect()
     dc = t.destruct_count()
     a = t.return_dlpack()
     assert dc == t.destruct_count()
     del a
     gc.collect()
+    gc.collect()
     assert t.destruct_count() - dc == 1
 
 
 def test14_consume_numpy():
+    gc.collect()
     gc.collect()
     class wrapper:
         def __init__(self, value):
@@ -227,15 +230,18 @@ def test14_consume_numpy():
 
     del a
     gc.collect()
+    gc.collect()
     assert x.shape == (2, 4)
     assert np.all(x == [[1, 2, 3, 4], [5, 6, 7, 8]])
     assert dc == t.destruct_count()
     del x
     gc.collect()
+    gc.collect()
     assert t.destruct_count() - dc == 1
 
 
 def test15_passthrough():
+    gc.collect()
     gc.collect()
     class wrapper:
         def __init__(self, value):
@@ -256,15 +262,18 @@ def test15_passthrough():
     del a
     del b
     gc.collect()
+    gc.collect()
     assert dc == t.destruct_count()
     assert y.shape == (2, 4)
     assert np.all(y == [[1, 2, 3, 4], [5, 6, 7, 8]])
     del y
     gc.collect()
+    gc.collect()
     assert t.destruct_count() - dc == 1
 
 
 def test16_return_numpy():
+    gc.collect()
     gc.collect()
     import numpy as np
     dc = t.destruct_count()
@@ -272,6 +281,7 @@ def test16_return_numpy():
     assert x.shape == (2, 4)
     assert np.all(x == [[1, 2, 3, 4], [5, 6, 7, 8]])
     del x
+    gc.collect()
     gc.collect()
     assert t.destruct_count() - dc == 1
 
@@ -283,11 +293,13 @@ def test17_return_pytorch():
     except:
         pytest.skip('pytorch is missing')
     gc.collect()
+    gc.collect()
     import numpy as np
     dc = t.destruct_count()
     x = t.ret_pytorch()
     assert x.shape == (2, 4)
     assert torch.all(x == torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]]))
     del x
+    gc.collect()
     gc.collect()
     assert t.destruct_count() - dc == 1


### PR DESCRIPTION
This PR introduces partial support for PyPy. There are still crashing testcases that may point to larger issues.

- PyPy seems to have issues with PY_VECTORCALL_ARGUMENTS_OFFSET, it is not able to perform vector calls when given this flag (workaround implemented).

- PyPy does not intern keyword names passed to C API vector calls, so a more costly comparison is needed (workaround implemented).

- nanobind co-locates binding-specific data with the Python type object. When PyPy subclasses a nanobind class, it does not allocate enough memory to store this additional information, which causes crashes