### PR TITLE
Dynamic attribute access

### DIFF
--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -47,14 +47,13 @@ template <typename... Ts> struct call_guard {
     using type = detail::tuple<Ts...>;
 };
 
+struct dynamic_attr {};
 struct is_method {};
 struct is_implicit {};
 struct is_operator {};
 struct is_arithmetic {};
-struct is_final { };
-struct is_enum {
-    bool is_signed;
-};
+struct is_final {};
+struct is_enum { bool is_signed; };
 
 template <size_t /* Nurse */, size_t /* Patient */> struct keep_alive {};
 template <typename T> struct supplement {};

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -379,4 +379,9 @@ NB_MODULE(test_classes_ext, m) {
     struct FinalType { };
     nb::class_<FinalType>(m, "FinalType", nb::is_final())
         .def(nb::init<>());
+
+    // test26_dynamic_attr
+    struct StructWithAttr : Struct { };
+    nb::class_<StructWithAttr, Struct>(m, "StructWithAttr", nb::dynamic_attr())
+        .def(nb::init<int>());
 }


### PR DESCRIPTION
This PR adds dynamic attribute access (analogous to pybind11's
``nb::dynamic_attr()`` flag) while using only ``Py_LIMITED_API``
functionality.