### PR TITLE
Draft: force buffer protocol in tensor creation for `numpy` to avoid read/write constraints with `dlpack`.

### DIFF
--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -349,7 +349,7 @@ NB_CORE dlpack::tensor *tensor_inc_ref(tensor_handle *) noexcept;
 NB_CORE void tensor_dec_ref(tensor_handle *) noexcept;
 
 /// Wrap a tensor_handle* into a PyCapsule
-NB_CORE PyObject *tensor_wrap(tensor_handle *, int framework) noexcept;
+NB_CORE PyObject *tensor_wrap(tensor_handle *, int framework, bool writeable) noexcept;
 
 // ========================================================================
 

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -138,4 +138,10 @@ NB_MODULE(test_tensor_ext, m) {
         return nb::tensor<nb::numpy, float, nb::shape<2, 4>, nb::writeable>(f, 2, shape,
                                                              deleter);
     });
+
+    m.def("passthrough", [](nb::tensor<> a) { return a; });
+    m.def("accept_numpy_readonly",
+          []([[maybe_unused]] nb::tensor<nb::numpy, nb::readonly> ro,
+              [[maybe_unused]] nb::tensor<nb::numpy, nb::writeable> rw) {
+    });
 }

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -125,4 +125,17 @@ NB_MODULE(test_tensor_ext, m) {
         return nb::tensor<nb::pytorch, float, nb::shape<2, 4>>(f, 2, shape,
                                                                deleter);
     });
+
+    m.def("ret_numpy_writeable", []() {
+        float *f = new float[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        size_t shape[2] = { 2, 4 };
+
+        nb::capsule deleter(f, [](void *data) noexcept {
+            destruct_count++;
+            delete[] (float *) data;
+        });
+
+        return nb::tensor<nb::numpy, float, nb::shape<2, 4>, nb::writeable>(f, 2, shape,
+                                                             deleter);
+    });
 }

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -335,9 +335,27 @@ def test18_return_numpy_writeable():
     x = t.ret_numpy_writeable()
     assert x.shape == (2, 4)
     assert np.all(x == [[1, 2, 3, 4], [5, 6, 7, 8]])
+    # Check the flags.
     assert x.flags['WRITEABLE']
-    # Check we can actual write.
+    # Check we can actually write.
     x[0, 0] = 1
     del x
     gc.collect()
     assert t.destruct_count() - dc == 1
+
+
+@needs_numpy
+def test19_pass_numpy_readonly():
+    rw = np.zeros((2, 2))
+    ro = np.zeros((2, 2))
+    ro.setflags(write=False)
+
+    assert rw.flags["WRITEABLE"]
+    assert not ro.flags["WRITEABLE"]
+
+    # Only first parameter accepts readonly, so this should throw.
+    with pytest.raises(TypeError):
+        t.accept_numpy_readonly(ro, ro)
+
+    # This works though.
+    t.accept_numpy_readonly(ro, rw)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -306,6 +306,7 @@ def test16_return_numpy():
     x = t.ret_numpy()
     assert x.shape == (2, 4)
     assert np.all(x == [[1, 2, 3, 4], [5, 6, 7, 8]])
+    assert not x.flags['WRITEABLE']
     del x
     gc.collect()
     assert t.destruct_count() - dc == 1
@@ -322,6 +323,21 @@ def test17_return_pytorch():
     x = t.ret_pytorch()
     assert x.shape == (2, 4)
     assert torch.all(x == torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]]))
+    del x
+    gc.collect()
+    assert t.destruct_count() - dc == 1
+
+
+@needs_numpy
+def test18_return_numpy_writeable():
+    gc.collect()
+    dc = t.destruct_count()
+    x = t.ret_numpy_writeable()
+    assert x.shape == (2, 4)
+    assert np.all(x == [[1, 2, 3, 4], [5, 6, 7, 8]])
+    assert x.flags['WRITEABLE']
+    # Check we can actual write.
+    x[0, 0] = 1
     del x
     gc.collect()
     assert t.destruct_count() - dc == 1


### PR DESCRIPTION
This PR overcomes two current limitations with tensors in nanobind when using numpy (it does not affect torch or jax).
* returning tensors from C++ always results in read-only arrays. See #46.
* passing read-only arrays from python results in an error. See #42.

- [x] Allow returning writeable arrays from c++ to python. 
- [x] Allow passing read-only arrays to from python to c++.
- [x] clean up tests.
- [ ] Add documentation.
