### PR TITLE
Support named capsules

### DIFF
--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -188,10 +188,6 @@ NB_CORE PyObject **seq_get(PyObject *seq, size_t *size,
 
 // ========================================================================
 
-/// Create a new capsule object
-NB_CORE PyObject *capsule_new(const void *ptr,
-                              void (*free)(void *) noexcept) noexcept;
-
 /// Create a new capsule object with a name
 NB_CORE PyObject *capsule_new(const void *ptr, const char * name,
                               void (*free)(void *) noexcept) noexcept;

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -192,6 +192,10 @@ NB_CORE PyObject **seq_get(PyObject *seq, size_t *size,
 NB_CORE PyObject *capsule_new(const void *ptr,
                               void (*free)(void *) noexcept) noexcept;
 
+/// Create a new capsule object with a name
+NB_CORE PyObject *capsule_new(const void *ptr, const char * name,
+                              void (*free)(void *) noexcept) noexcept;
+
 // ========================================================================
 
 /// Create a Python function object for the given function record

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -269,7 +269,7 @@ class capsule : public object {
     NB_OBJECT_DEFAULT(capsule, object, "capsule", PyCapsule_CheckExact)
 
     capsule(const void *ptr, void (*free)(void *) noexcept = nullptr) {
-        m_ptr = detail::capsule_new(ptr, free);
+        m_ptr = detail::capsule_new(ptr, nullptr, free);
     }
 
     capsule(const void *ptr, const char *name,

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -272,6 +272,11 @@ class capsule : public object {
         m_ptr = detail::capsule_new(ptr, free);
     }
 
+    capsule(const void *ptr, const char *name,
+            void (*free)(void *) noexcept = nullptr) {
+        m_ptr = detail::capsule_new(ptr, name, free);
+    }
+
     void *data() const { return PyCapsule_GetPointer(m_ptr, nullptr); }
 };
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -55,10 +55,6 @@ void fail(const char *fmt, ...) noexcept {
     abort();
 }
 
-PyObject *capsule_new(const void *ptr, void (*free)(void *) noexcept) noexcept {
-    return capsule_new(ptr, nullptr, free);
-}
-
 PyObject *capsule_new(const void *ptr, const char *name,
         void (*free)(void *) noexcept) noexcept {
     auto capsule_free = [](PyObject *o) {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -56,13 +56,18 @@ void fail(const char *fmt, ...) noexcept {
 }
 
 PyObject *capsule_new(const void *ptr, void (*free)(void *) noexcept) noexcept {
+    return capsule_new(ptr, nullptr, free);
+}
+
+PyObject *capsule_new(const void *ptr, const char *name,
+        void (*free)(void *) noexcept) noexcept {
     auto capsule_free = [](PyObject *o) {
         auto free_2 = (void (*)(void *))(PyCapsule_GetContext(o));
         if (free_2)
-            free_2(PyCapsule_GetPointer(o, nullptr));
+            free_2(PyCapsule_GetPointer(o, PyCapsule_GetName(o)));
     };
 
-    PyObject *c = PyCapsule_New((void *) ptr, nullptr, capsule_free);
+    PyObject *c = PyCapsule_New((void *) ptr, name, capsule_free);
 
     if (!c)
         fail("nanobind::detail::capsule_new(): allocation failed!");


### PR DESCRIPTION
Hi!

Small PR, just added support for assigning non-null names to capsules.

This is helpful for a bunch of things, eg:
- Taking advantage of `scipy.LowLevelCallable` (name needs to be set to a function signature)
- Creating "custom call" targets for XLA/JAX (name needs to be set to `xla._CUSTOM_CALL_TARGET`)