### PR TITLE
Support Python byte strings

### DIFF
--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -99,6 +99,17 @@ NB_CORE PyObject *str_from_cstr_and_size(const char *c, size_t n);
 
 // ========================================================================
 
+/// Convert a Python object into a Python byte string
+NB_CORE PyObject *bytes_from_obj(PyObject *o);
+
+/// Convert an UTF8 null-terminated C string into a Python byte string
+NB_CORE PyObject *bytes_from_cstr(const char *c);
+
+/// Convert an UTF8 C string + size into a Python byte string
+NB_CORE PyObject *bytes_from_cstr_and_size(const char *c, size_t n);
+
+// ========================================================================
+
 /// Get an object attribute or raise an exception
 NB_CORE PyObject *getattr(PyObject *obj, const char *key);
 NB_CORE PyObject *getattr(PyObject *obj, PyObject *key);

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -290,6 +290,23 @@ class str : public object {
     const char *c_str() { return PyUnicode_AsUTF8AndSize(m_ptr, nullptr); }
 };
 
+class bytes : public object {
+    NB_OBJECT_DEFAULT(bytes, object, "bytes", PyBytes_Check)
+
+    explicit bytes(handle h)
+        : object(detail::bytes_from_obj(h.ptr()), detail::steal_t{}) { }
+
+    explicit bytes(const char *c)
+        : object(detail::bytes_from_cstr(c), detail::steal_t{}) { }
+
+    explicit bytes(const char *c, size_t n)
+        : object(detail::bytes_from_cstr_and_size(c, n), detail::steal_t{}) { }
+
+    const char *c_str() { return PyBytes_AsString(m_ptr); }
+
+    size_t size() const { return PyBytes_Size(m_ptr); }
+};
+
 class tuple : public object {
     NB_OBJECT_DEFAULT(tuple, object, "tuple", PyTuple_Check)
     size_t size() const { return NB_TUPLE_GET_SIZE(m_ptr); }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -470,6 +470,29 @@ PyObject *str_from_cstr_and_size(const char *str, size_t size) {
 
 // ========================================================================
 
+PyObject *bytes_from_obj(PyObject *o) {
+    PyObject *result = PyBytes_FromObject(o);
+    if (!result)
+        raise_python_error();
+    return result;
+}
+
+PyObject *bytes_from_cstr(const char *str) {
+    PyObject *result = PyBytes_FromString(str);
+    if (!result)
+        raise("nanobind::detail::bytes_from_cstr(): conversion error!");
+    return result;
+}
+
+PyObject *bytes_from_cstr_and_size(const char *str, size_t size) {
+    PyObject *result = PyBytes_FromStringAndSize(str, (Py_ssize_t) size);
+    if (!result)
+        raise("nanobind::detail::bytes_from_cstr_and_size(): conversion error!");
+    return result;
+}
+
+// ========================================================================
+
 PyObject **seq_get(PyObject *seq, size_t *size_out, PyObject **temp_out) noexcept {
     PyObject *temp = nullptr;
     size_t size = 0;

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -140,4 +140,10 @@ NB_MODULE(test_functions_ext, m) {
     m.def("test_12", [](const char *c) { return nb::str(c); });
     m.def("test_13", []() -> const char * { return "test"; });
     m.def("test_14", [](nb::object o) -> const char * { return nb::cast<const char *>(o); });
+
+    // Test bytes type
+    m.def("test_15", [](nb::bytes o) -> const char * { return o.c_str(); });
+    m.def("test_16", [](const char *c) { return nb::bytes(c); });
+    m.def("test_17", [](nb::bytes c) { return c.size(); });
+    m.def("test_18", [](const char *c, int size) { return nb::bytes(c, size); });
 }

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -195,3 +195,11 @@ def test22_string_return():
     assert t.test_12("hello") == "hello"
     assert t.test_13() == "test"
     assert t.test_14("abc") == "abc"
+
+
+def test23_byte_return():
+    assert t.test_15(b"abc") == "abc"
+    assert t.test_16("hello") == b"hello"
+    assert t.test_17(b"four") == 4
+    assert t.test_17(b"\x00\x00\x00\x00") == 4
+    assert t.test_18("hello world", 5) == b"hello"


### PR DESCRIPTION
Added support for using the `bytes` type as an input or output to bound functions. This would be super helpful for me!