### PR TITLE
Guarantee a copy is made with rv_policy::copy

### DIFF
--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -767,7 +767,7 @@ PyObject *nb_type_put(const std::type_info *cpp_type, void *value,
     nb_internals &internals = internals_get();
     auto it = internals.inst_c2p.find(
         std::pair<void *, std::type_index>(value, *cpp_type));
-    if (it != internals.inst_c2p.end()) {
+    if (it != internals.inst_c2p.end() && rvp != rv_policy::copy) {
         PyObject *result = (PyObject *) it->second;
         Py_INCREF(result);
         return result;

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -86,7 +86,7 @@ NB_MODULE(test_classes_ext, m) {
         .def(nb::init<int>())
         .def("value", &Struct::value)
         .def("set_value", &Struct::set_value, "value"_a)
-        .def("self", &Struct::self)
+        .def("self", &Struct::self, nb::rv_policy::none)
         .def("none", [](Struct &) -> const Struct * { return nullptr; })
         .def_static("static_test", nb::overload_cast<int>(&Struct::static_test))
         .def_static("static_test", nb::overload_cast<float>(&Struct::static_test))

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -499,3 +499,8 @@ def test26_dynamic_attr(clean):
         value_constructed=100,
         destructed=100
     )
+
+def test27_copy_rvp():
+    a = t.Struct.create_reference()
+    b = t.Struct.create_copy()
+    assert a is not b


### PR DESCRIPTION
The return value policy specifications in pybind11 and nanobind involve a troublesome corner case: the policy is ignored if an object with the specified reference already exists, since ownership is then unproblematic.

This can lead to to the puzzling situation, in which `v1` and `v2` in the below Python script refer to the same object.

```cpp
// C++ bindings
nb::class<Struct>(m, "Struct")
    .def("get1", [](Struct &s){ return s.data; }, rv_policy::reference_internal)
    .def("get2", [](Struct &s){ return s.data; });
```

```python
s = Struct()
v1 = s.get1()
v2 = s.get2()
```

One would ordinarily expect that the bindings of the `get2()` lambda function (which returns a reference) will create a copy based on the default (`rv_policy::automatic`) return value policy. But the returned reference is already known given the previous call to `get1()`, and the same instance is returned. This implies that `v2` can be used to mutate the contents of `s`, but _only_ if the call to `get1()` previously took place.

This is obviously deeply confusing. The change here makes it so that `rv_policy::copy` consistently makes copies, even if the associated reference is already associated with a Python object.

It would be nice to make a similar change in pybind11, but it is likely that other software has come to depend on this behavior. But let's at least fix this in nanobind.
