### PR TITLE
Fix tensor creation for zero-dimensional arrays

### DIFF
--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -505,17 +505,19 @@ tensor_handle *tensor_create(void *value, size_t ndim, const size_t *shape_in,
     for (size_t i = 0; i < ndim; ++i)
         shape[i] = (int64_t) shape_in[i];
 
-    int64_t prod = 1;
-    for (size_t i = ndim - 1; ;) {
-        if (strides_in) {
-            strides[i] = strides_in[i];
-        } else {
-            strides[i] = prod;
-            prod *= (int64_t) shape_in[i];
+    if (ndim > 0) {
+        int64_t prod = 1;
+        for (size_t i = ndim - 1; ;) {
+            if (strides_in) {
+                strides[i] = strides_in[i];
+            } else {
+                strides[i] = prod;
+                prod *= (int64_t) shape_in[i];
+            }
+            if (i == 0)
+                break;
+            --i;
         }
-        if (i == 0)
-            break;
-        --i;
     }
 
     tensor->dl_tensor.data = (void *) value_rounded;

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -125,4 +125,16 @@ NB_MODULE(test_tensor_ext, m) {
         return nb::tensor<nb::pytorch, float, nb::shape<2, 4>>(f, 2, shape,
                                                                deleter);
     });
+
+    m.def("ret_array_scalar", []() {
+            float* f = new float[1] { 1 };
+            size_t shape[0] = {};
+
+            nb::capsule deleter(f, [](void* data) noexcept {
+                destruct_count++;
+                delete[] (float *) data;
+            });
+
+            return nb::tensor<nb::numpy, float>(f, 0, shape, deleter);
+        });
 }

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -128,7 +128,7 @@ NB_MODULE(test_tensor_ext, m) {
 
     m.def("ret_array_scalar", []() {
             float* f = new float[1] { 1 };
-            size_t shape[0] = {};
+            size_t shape[1] = {};
 
             nb::capsule deleter(f, [](void* data) noexcept {
                 destruct_count++;

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -325,3 +325,13 @@ def test17_return_pytorch():
     del x
     gc.collect()
     assert t.destruct_count() - dc == 1
+
+@needs_numpy
+def test18_return_array_scalar():
+    gc.collect()
+    dc = t.destruct_count()
+    x = t.ret_array_scalar()
+    assert np.array_equal(x, np.array(1))
+    del x
+    gc.collect()
+    assert t.destruct_count() - dc == 1


### PR DESCRIPTION
I found the following tensor creation for a 0-dim array ([array scalars in numpy](https://numpy.org/doc/stable/reference/arrays.scalars.html)) causes SIGSEGV.
This PR adds checking of array dimension to fix it and accept the creation. Could you please merge this?

```c++
nb::class_<Dummy>(module, "NanobindTest")
    .def(nb::init<>())
    .def(
        "ret_array_scalar", [](const Dummy&) {
            float* f = new float[1]{1};
            size_t shape[0] = {};

            nb::capsule deleter(f,
                                [](void* data) noexcept
                                {
                                    delete[](float*) data;
                                });

            return nb::tensor<nb::numpy, float>(f, 0, shape, deleter);
        });
```
