### PR TITLE
std::optional and std::variant casters

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -80,6 +80,8 @@ function (nanobuild_build_library TARGET_NAME TARGET_TYPE)
     ${NB_DIR}/include/nanobind/stl/function.h
     ${NB_DIR}/include/nanobind/stl/vector.h
     ${NB_DIR}/include/nanobind/stl/list.h
+    ${NB_DIR}/include/nanobind/stl/optional.h
+    ${NB_DIR}/include/nanobind/stl/variant.h
 
     ${NB_DIR}/src/buffer.h
     ${NB_DIR}/src/nb_internals.h

--- a/include/nanobind/nanobind.h
+++ b/include/nanobind/nanobind.h
@@ -32,6 +32,7 @@
 #include <typeinfo>
 #include <utility>
 #include <new>
+#include <optional>
 
 // Implementation. The nb_*.h files should only be included through nanobind.h
 #include "nb_python.h"

--- a/include/nanobind/nanobind.h
+++ b/include/nanobind/nanobind.h
@@ -32,8 +32,6 @@
 #include <typeinfo>
 #include <utility>
 #include <new>
-#include <optional>
-#include <variant>
 
 // Implementation. The nb_*.h files should only be included through nanobind.h
 #include "nb_python.h"

--- a/include/nanobind/nanobind.h
+++ b/include/nanobind/nanobind.h
@@ -33,6 +33,7 @@
 #include <utility>
 #include <new>
 #include <optional>
+#include <variant>
 
 // Implementation. The nb_*.h files should only be included through nanobind.h
 #include "nb_python.h"

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -56,9 +56,9 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
     // Collect function signature information for the docstring
     using cast_out = make_caster<
         std::conditional_t<std::is_void_v<Return>, void_type, Return>>;
-    constexpr auto descr =
-        const_name("(") + concat(type_descr(make_caster<Args>::Name)...) +
-        const_name(") -> ") + cast_out::Name;
+    constexpr auto descr = const_name("(") +
+                           concat(type_descr(make_caster<remove_optional_t<intrinsic_t<Args>>>::Name)...) +
+                           const_name(") -> ") + cast_out::Name;
     const std::type_info* descr_types[descr.type_count() + 1];
     descr.put_types(descr_types);
 

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -57,7 +57,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
     using cast_out = make_caster<
         std::conditional_t<std::is_void_v<Return>, void_type, Return>>;
     constexpr auto descr = const_name("(") +
-                           concat(type_descr(make_caster<remove_optional_t<intrinsic_t<Args>>>::Name)...) +
+                           concat(type_descr(make_caster<remove_opt_mono_t<intrinsic_t<Args>>>::Name)...) +
                            const_name(") -> ") + cast_out::Name;
     const std::type_info* descr_types[descr.type_count() + 1];
     descr.put_types(descr_types);

--- a/include/nanobind/nb_traits.h
+++ b/include/nanobind/nb_traits.h
@@ -114,6 +114,9 @@ template <template <typename> typename Op, typename Arg>
 struct detector<std::void_t<Op<Arg>>, Op, Arg>
     : std::true_type { };
 
+template<typename T> struct remove_optional { using type = T; };
+template<typename T> struct remove_optional<std::optional<T>> : remove_optional<T> {};
+
 NAMESPACE_END(detail)
 
 template <typename... Args>
@@ -122,5 +125,8 @@ static constexpr auto const_ = std::true_type{};
 
 template <template<typename> class Op, typename Arg>
 constexpr bool is_detected_v = detail::detector<void, Op, Arg>::value;
+
+template<typename T>
+using remove_optional_t = typename detail::remove_optional<T>::type;
 
 NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/nb_traits.h
+++ b/include/nanobind/nb_traits.h
@@ -114,16 +114,11 @@ template <template <typename> typename Op, typename Arg>
 struct detector<std::void_t<Op<Arg>>, Op, Arg>
     : std::true_type { };
 
-template <typename T, typename...>
-struct concat_variant { using type = T; };
-template <typename... Ts1, typename... Ts2, typename... Ts3>
-struct concat_variant<std::variant<Ts1...>, std::variant<Ts2...>, Ts3...>
-    : concat_variant<std::variant<Ts1..., Ts2...>, Ts3...> {};
-
-template<typename T> struct remove_opt_mono { using type = T; };
-template<typename T> struct remove_opt_mono<std::optional<T>> : remove_opt_mono<T> {};
-template <typename... Ts> struct remove_opt_mono<std::variant<Ts...>>
-    : concat_variant<std::conditional_t<std::is_same_v<std::monostate, Ts>, std::variant<>, std::variant<Ts>>...> {};
+/* This template is used for docstring generation and specialized in
+   ``stl/{variant,optional.h}`` to strip away std::optional and
+   ``std::variant<std::monostate>`` in top-level argument types and
+   avoid redundancy when combined with nb::arg(...).none(). */
+template <typename T> struct remove_opt_mono { using type = T; };
 
 NAMESPACE_END(detail)
 
@@ -134,7 +129,7 @@ static constexpr auto const_ = std::true_type{};
 template <template<typename> class Op, typename Arg>
 constexpr bool is_detected_v = detail::detector<void, Op, Arg>::value;
 
-template<typename T>
+template <typename T>
 using remove_opt_mono_t = typename detail::remove_opt_mono<T>::type;
 
 NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/optional.h
+++ b/include/nanobind/stl/optional.h
@@ -21,23 +21,20 @@ struct type_caster<std::optional<T>> {
     Value value = std::nullopt;
 
     bool from_python(handle src, uint8_t flags, cleanup_list* cleanup) noexcept {
-        if (src.is_none()) return true;
+        if (src.is_none())
+            return true;
 
         Caster caster;
-        if (!caster.from_python(src, flags, cleanup)) return false;
+        if (!caster.from_python(src, flags, cleanup))
+            return false;
 
-        if constexpr (is_pointer_v<T>)
-        {
+        if constexpr (is_pointer_v<T>) {
             static_assert(Caster::IsClass,
                             "Binding 'optional<T*>' requires that 'T' can also be bound by nanobind.");
             value = caster.operator cast_t<T>();
-        }
-        else if constexpr (Caster::IsClass)
-        {
+        } else if constexpr (Caster::IsClass) {
             value = caster.operator cast_t<T&>();
-        }
-        else
-        {
+        } else {
             value = std::move(caster).operator cast_t<T&&>();
         }
 
@@ -46,13 +43,15 @@ struct type_caster<std::optional<T>> {
 
     template <typename T_>
     static handle from_cpp(T_ *value, rv_policy policy, cleanup_list *cleanup) noexcept {
-        if (!value) return none().release();
+        if (!value)
+            return none().release();
         return from_cpp(*value, policy, cleanup);
     }
 
     template <typename T_>
     static handle from_cpp(T_ &&value, rv_policy policy, cleanup_list *cleanup) noexcept {
-        if (!value) return none().release();
+        if (!value)
+            return none().release();
         return Caster::from_cpp(forward_like<T_>(*value), policy, cleanup);
     }
 

--- a/include/nanobind/stl/optional.h
+++ b/include/nanobind/stl/optional.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <nanobind/nanobind.h>
+#include <optional>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename T>
+struct type_caster<std::optional<T>> {
+    using Value = std::optional<T>;
+    using Ti = detail::intrinsic_t<T>;
+    using Caster = make_caster<Ti>;
+
+    static constexpr auto Name = const_name("Optional[") + concat(Caster::Name) + const_name("]");;
+    static constexpr bool IsClass = false;
+
+    template <typename T_>
+    using Cast = movable_cast_t<T_>;
+
+    Value value = std::nullopt;
+
+    bool from_python(handle src, uint8_t flags, cleanup_list* cleanup) noexcept {
+        if (src.is_none()) return true;
+
+        Caster caster;
+        if (!caster.from_python(src, flags, cleanup)) return false;
+
+        if constexpr (is_pointer_v<T>)
+        {
+            static_assert(Caster::IsClass,
+                            "Binding 'optional<T*>' requires that 'T' can also be bound by nanobind.");
+            value = caster.operator cast_t<T>();
+        }
+        else if constexpr (Caster::IsClass)
+        {
+            value = caster.operator cast_t<T&>();
+        }
+        else
+        {
+            value = std::move(caster).operator cast_t<T&&>();
+        }
+
+        return true;
+    }
+
+    template <typename T_>
+    static handle from_cpp(T_ *value, rv_policy policy, cleanup_list *cleanup) noexcept {
+        if (!value) return none().release();
+        return from_cpp(*value, policy, cleanup);
+    }
+
+    template <typename T_>
+    static handle from_cpp(T_ &&value, rv_policy policy, cleanup_list *cleanup) noexcept {
+        if (!value) return none().release();
+        return Caster::from_cpp(forward_like<T_>(*value), policy, cleanup);
+    }
+
+    explicit operator Value *() { return &value; }
+    explicit operator Value &() { return value; }
+    explicit operator Value &&() && { return (Value &&) value; }
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/optional.h
+++ b/include/nanobind/stl/optional.h
@@ -6,6 +6,8 @@
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
+template <typename T> struct remove_opt_mono<std::optional<T>> : remove_opt_mono<T> {};
+
 template <typename T>
 struct type_caster<std::optional<T>> {
     using Value = std::optional<T>;

--- a/include/nanobind/stl/variant.h
+++ b/include/nanobind/stl/variant.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <nanobind/nanobind.h>
+#include <tuple>
+#include <variant>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <>
+struct type_caster<std::monostate> {
+    NB_TYPE_CASTER(std::monostate, const_name("None"));
+
+    bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
+        if (src.is_none()) return true;
+        return false;
+    }
+
+    static handle from_cpp(const std::monostate &, rv_policy, cleanup_list *) noexcept { return none().release(); }
+};
+
+template <typename... Ts>
+class type_caster<std::variant<Ts...>>
+{
+    template <typename T>
+    using Caster = make_caster<detail::intrinsic_t<T>>;
+
+    template <typename T>
+    bool variadic_caster(const handle &src, uint8_t flags, cleanup_list *cleanup) {
+        Caster<T> caster;
+        if (!caster.from_python(src, flags, cleanup))
+            return false;
+
+        if constexpr (is_pointer_v<T>)
+        {
+            static_assert(Caster<T>::IsClass,
+                          "Binding 'variant<T*,...>' requires that 'T' can also be bound by nanobind.");
+            value = caster.operator cast_t<T>();
+        }
+        else if constexpr (Caster<T>::IsClass)
+        {
+            // Non-pointer classes do not accept a null pointer
+            if (src.is_none()) return false;
+            value = caster.operator cast_t<T &>();
+        }
+        else
+        {
+            value = std::move(caster).operator cast_t<T &&>();
+        }
+        return true;
+    }
+
+public:
+    using Value = std::variant<Ts...>;
+
+    static constexpr auto Name = const_name("Union[") + concat(Caster<Ts>::Name...) + const_name("]");
+    static constexpr bool IsClass = false;
+
+    template <typename T>
+    using Cast = movable_cast_t<T>;
+
+    Value value;
+
+    bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+        return (variadic_caster<Ts>(src, flags, cleanup) || ...);
+    }
+
+    template <typename T>
+    static handle from_cpp(T *value, rv_policy policy, cleanup_list *cleanup) noexcept {
+        if (!value) return none().release();
+        return from_cpp(*value, policy, cleanup);
+    }
+
+    template <typename T>
+    static handle from_cpp(T &&value, rv_policy policy, cleanup_list *cleanup) noexcept {
+        return std::visit(
+            [&](auto &&v) {
+                return Caster<decltype(v)>::from_cpp(std::forward<decltype(v)>(v), policy, cleanup);
+            }, std::forward<T>(value));
+    }
+
+    explicit operator Value *() { return &value; }
+    explicit operator Value &() { return value; }
+    explicit operator Value &&() && { return (Value &&) value; }
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/variant.h
+++ b/include/nanobind/stl/variant.h
@@ -1,11 +1,19 @@
 #pragma once
 
 #include <nanobind/nanobind.h>
-#include <tuple>
 #include <variant>
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
+
+template <typename T, typename...>
+struct concat_variant { using type = T; };
+template <typename... Ts1, typename... Ts2, typename... Ts3>
+struct concat_variant<std::variant<Ts1...>, std::variant<Ts2...>, Ts3...>
+    : concat_variant<std::variant<Ts1..., Ts2...>, Ts3...> {};
+
+template <typename... Ts> struct remove_opt_mono<std::variant<Ts...>>
+    : concat_variant<std::conditional_t<std::is_same_v<std::monostate, Ts>, std::variant<>, std::variant<Ts>>...> {};
 
 template <>
 struct type_caster<std::monostate> {
@@ -21,8 +29,7 @@ struct type_caster<std::monostate> {
 };
 
 template <typename... Ts>
-class type_caster<std::variant<Ts...>>
-{
+class type_caster<std::variant<Ts...>> {
     template <typename T>
     using Caster = make_caster<detail::intrinsic_t<T>>;
 

--- a/include/nanobind/stl/variant.h
+++ b/include/nanobind/stl/variant.h
@@ -12,7 +12,8 @@ struct type_caster<std::monostate> {
     NB_TYPE_CASTER(std::monostate, const_name("None"));
 
     bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
-        if (src.is_none()) return true;
+        if (src.is_none())
+            return true;
         return false;
     }
 
@@ -31,20 +32,16 @@ class type_caster<std::variant<Ts...>>
         if (!caster.from_python(src, flags, cleanup))
             return false;
 
-        if constexpr (is_pointer_v<T>)
-        {
+        if constexpr (is_pointer_v<T>) {
             static_assert(Caster<T>::IsClass,
                           "Binding 'variant<T*,...>' requires that 'T' can also be bound by nanobind.");
             value = caster.operator cast_t<T>();
-        }
-        else if constexpr (Caster<T>::IsClass)
-        {
+        } else if constexpr (Caster<T>::IsClass) {
             // Non-pointer classes do not accept a null pointer
-            if (src.is_none()) return false;
+            if (src.is_none())
+                return false;
             value = caster.operator cast_t<T &>();
-        }
-        else
-        {
+        } else {
             value = std::move(caster).operator cast_t<T &&>();
         }
         return true;
@@ -67,14 +64,14 @@ public:
 
     template <typename T>
     static handle from_cpp(T *value, rv_policy policy, cleanup_list *cleanup) noexcept {
-        if (!value) return none().release();
+        if (!value)
+            return none().release();
         return from_cpp(*value, policy, cleanup);
     }
 
     template <typename T>
     static handle from_cpp(T &&value, rv_policy policy, cleanup_list *cleanup) noexcept {
-        return std::visit(
-            [&](auto &&v) {
+        return std::visit([&](auto &&v) {
                 return Caster<decltype(v)>::from_cpp(std::forward<decltype(v)>(v), policy, cleanup);
             }, std::forward<T>(value));
     }

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -6,6 +6,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
 
 NB_MAKE_OPAQUE(NB_TYPE(std::vector<float, std::allocator<float>>))
 
@@ -205,4 +206,14 @@ NB_MODULE(test_stl_ext, m) {
     m.def("optional_ret_opt_movable_ptr", []() { return new std::optional<Movable *>(new Movable()); });
     m.def("optional_ret_opt_none", []() { return std::optional<Movable>(); });
     m.def("optional_unbound_type", [](std::optional<int> &x) { return x; }, nb::arg("x").none() = nb::none());
+
+    // ----- test41-test47 ------ */
+    m.def("variant_copyable", [](std::variant<Copyable, int> &) {});
+    m.def("variant_copyable_none", [](std::variant<std::monostate, Copyable, int> &) {}, nb::arg("x").none());
+    m.def("variant_copyable_ptr", [](std::variant<Copyable *, int> &) {});
+    m.def("variant_copyable_ptr_none", [](std::variant<Copyable *, int> &) {}, nb::arg("x").none());
+    m.def("variant_ret_var_copyable", []() { return std::variant<Copyable, int>(); });
+    m.def("variant_ret_var_none", []() { return std::variant<std::monostate, Copyable, int>(); });
+    m.def("variant_unbound_type", [](std::variant<std::monostate, nb::list, nb::tuple, int> &x) { return x; },
+          nb::arg("x").none() = nb::none());
 }

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -5,6 +5,7 @@
 #include <nanobind/stl/list.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
+#include <nanobind/stl/optional.h>
 
 NB_MAKE_OPAQUE(NB_TYPE(std::vector<float, std::allocator<float>>))
 
@@ -195,4 +196,13 @@ NB_MODULE(test_stl_ext, m) {
     // ----- test33 ------ */
     m.def("identity_string", [](std::string& x) { return x; });
     m.def("identity_string_view", [](std::string_view& x) { return x; });
+
+    // ----- test34-test40 ------ */
+    m.def("optional_copyable", [](std::optional<Copyable> &) {}, nb::arg("x").none());
+    m.def("optional_copyable_ptr", [](std::optional<Copyable *> &) {}, nb::arg("x").none());
+    m.def("optional_none", [](std::optional<Copyable> &x) { if(x) fail(); }, nb::arg("x").none());
+    m.def("optional_ret_opt_movable", []() { return std::optional<Movable>(Movable()); });
+    m.def("optional_ret_opt_movable_ptr", []() { return new std::optional<Movable *>(new Movable()); });
+    m.def("optional_ret_opt_none", []() { return std::optional<Movable>(); });
+    m.def("optional_unbound_type", [](std::optional<int> &x) { return x; }, nb::arg("x").none() = nb::none());
 }

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -394,3 +394,75 @@ def test40_std_optional_unbound_type():
     assert t.optional_unbound_type.__doc__ == (
         "optional_unbound_type(x: Optional[int] = None) -> Optional[int]"
     )
+
+def test41_std_variant_copyable(clean):
+    t.variant_copyable(t.Copyable())
+    t.variant_copyable(5)
+    assert t.variant_copyable.__doc__ == (
+        "variant_copyable(arg: Union[test_stl_ext.Copyable, int], /) -> None"
+    )
+    assert_stats(
+        default_constructed=3,
+        copy_assigned=1,
+        destructed=3
+    )
+
+def test42_std_variant_copyable_none(clean):
+    t.variant_copyable_none(t.Copyable())
+    t.variant_copyable_none(5)
+    t.variant_copyable_none(None)
+    assert t.variant_copyable_none.__doc__ == (
+        "variant_copyable_none(x: Optional[Union[test_stl_ext.Copyable, int]]) -> None"
+    )
+    assert_stats(
+        default_constructed=1,
+        copy_constructed=1,
+        destructed=2
+    )
+
+def test43_std_variant_copyable_ptr(clean):
+    t.variant_copyable_ptr(t.Copyable())
+    t.variant_copyable_ptr(5)
+    assert t.variant_copyable_ptr.__doc__ == (
+        "variant_copyable_ptr(arg: Union[test_stl_ext.Copyable, int], /) -> None"
+    )
+    assert_stats(
+        default_constructed=1,
+        destructed=1
+    )
+
+def test44_std_variant_copyable_ptr_none(clean):
+    t.variant_copyable_ptr_none(t.Copyable())
+    t.variant_copyable_ptr_none(5)
+    t.variant_copyable_ptr_none(None)
+    assert t.variant_copyable_ptr_none.__doc__ == (
+        "variant_copyable_ptr_none(x: Optional[Union[test_stl_ext.Copyable, int]]) -> None"
+    )
+    assert_stats(
+        default_constructed=1,
+        destructed=1
+    )
+
+def test45_std_variant_ret_var_copyable(clean):
+    assert t.variant_ret_var_copyable().value == 5
+    assert t.variant_ret_var_copyable.__doc__ == (
+        "variant_ret_var_copyable() -> Union[test_stl_ext.Copyable, int]"
+    )
+
+def test46_std_variant_ret_var_none(clean):
+    assert t.variant_ret_var_none() is None
+    assert t.variant_ret_var_none.__doc__ == (
+        "variant_ret_var_none() -> Union[None, test_stl_ext.Copyable, int]"
+    )
+
+def test47_std_variant_unbound_type(clean):
+    assert t.variant_unbound_type() is None
+    assert t.variant_unbound_type(None) is None
+    assert t.variant_unbound_type([5]) == [5]
+    assert t.variant_unbound_type((1,2,3)) == (1,2,3)
+    assert t.variant_unbound_type(5) == 5
+    assert t.variant_unbound_type.__doc__ == (
+        "variant_unbound_type(x: Optional[Union[list, tuple, int]] = None)"
+        " -> Union[None, list, tuple, int]"
+    )
+

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -341,3 +341,56 @@ def test33_string_and_string_view():
     assert t.identity_string_view("ส้ม") == "ส้ม"
     assert t.identity_string_view("البرتقالي") == "البرتقالي"
     assert t.identity_string_view("🍊") == "🍊"
+
+def test34_std_optional_copyable(clean):
+    t.optional_copyable(t.Copyable())
+    assert t.optional_copyable.__doc__ == (
+        "optional_copyable(x: Optional[test_stl_ext.Copyable]) -> None"
+    )
+    assert_stats(
+        default_constructed=1,
+        copy_constructed=1,
+        destructed=2
+    )
+
+def test35_std_optional_copyable_ptr(clean):
+    t.optional_copyable_ptr(t.Copyable())
+    assert t.optional_copyable_ptr.__doc__ == (
+        "optional_copyable_ptr(x: Optional[test_stl_ext.Copyable]) -> None"
+    )
+    assert_stats(
+        default_constructed=1,
+        destructed=1
+    )
+
+def test36_std_optional_none():
+    t.optional_none(None)
+
+def test37_std_optional_ret_opt_movable(clean):
+    assert t.optional_ret_opt_movable().value == 5
+    assert t.optional_ret_opt_movable.__doc__ == (
+        "optional_ret_opt_movable() -> Optional[test_stl_ext.Movable]"
+    )
+    assert_stats(
+        default_constructed=1,
+        move_constructed=2,
+        destructed=3
+    )
+
+def test38_std_optional_ret_opt_movable_ptr(clean):
+    assert t.optional_ret_opt_movable_ptr().value == 5
+    assert_stats(
+        default_constructed=1,
+        destructed=1
+    )
+
+def test39_std_optional_ret_opt_none():
+    assert t.optional_ret_opt_none() is None
+
+def test40_std_optional_unbound_type():
+    assert t.optional_unbound_type(3) == 3
+    assert t.optional_unbound_type(None) is None
+    assert t.optional_unbound_type() is None
+    assert t.optional_unbound_type.__doc__ == (
+        "optional_unbound_type(x: Optional[int] = None) -> Optional[int]"
+    )


### PR DESCRIPTION
The `std::optional` and `std::variant` casters are implemented. This makes it easy to handle overloading of some types that contain `None` as an argument or return value, and also simplifies function signatures. I would be grateful if this would be accepted.

### std::optional

```cpp
m.def("optional_copyable", [](std::optional<Copyable> &) {}, nb::arg("x").none());
m.def("optional_unbound_type", [](std::optional<int> &x) { return x; }, nb::arg("x").none() = nb::none());
```

```python
# optional_copyable(x: Optional[test_stl_ext.Copyable]) -> None
t.optional_copyable(t.Copyable())
t.optional_copyable(None)

# optional_unbound_type(x: Optional[int] = None) -> Optional[int]
t.optional_unbound_type(3)
t.optional_unbound_type(None)
t.optional_unbound_type()
```

In particular, if the argument of a non-bound type such as `nb::list` or `int` can take `None`, the `std::optional` caster can simplify overloading and function signatures.

Note that, receiving as `std::optional` occurs a copy from an input. Using `std::optional` of a pointer type can avoid a copy but it may not very useful since a normal pointer can receive `None` as `nullptr`.

### std::variant

```cpp
m.def("variant_copyable", [](std::variant<Copyable, int> &) {});
m.def("variant_copyable_none", [](std::variant<std::monostate, Copyable, int> &) {}, nb::arg("x").none());
m.def("variant_unbound_type", [](std::variant<std::monostate, nb::list, nb::tuple, int> &x) { return x; }, nb::arg("x").none() = nb::none());
```

```python
# variant_copyable(arg: Union[test_stl_ext.Copyable, int], /) -> None
t.variant_copyable(t.Copyable())
t.variant_copyable(5)

# variant_copyable_none(x: Optional[Union[test_stl_ext.Copyable, int]]) -> None
t.variant_copyable_none(t.Copyable())
t.variant_copyable_none(5)
t.variant_copyable_none(None)

# variant_unbound_type(x: Optional[Union[list, tuple, int]] = None) -> Union[None, list, tuple, int]
t.variant_unbound_type([1])
t.variant_unbound_type((1,2,3))
t.variant_unbound_type(5)
t.variant_unbound_type(None)
t.variant_unbound_type()
```

`std::monostate` is cast as `None`. This allows accepting multiple types, including `None`, by adding `std::monostate` to the argument types of `std::variant`. Multiple types can also be returned by wrapping with `std::variant`.