### PR TITLE
Add (failing) test for `__eq__`-in-baseclass

### DIFF
--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -180,7 +180,8 @@ NB_MODULE(test_classes_ext, m) {
     auto animal = nb::class_<Animal, PyAnimal>(m, "Animal")
         .def(nb::init<>())
         .def("name", &Animal::name)
-        .def("what", &Animal::what);
+        .def("what", &Animal::what)
+        .def("__eq__", [](Animal const &self, Animal const &other) { return &self == &other; });
 
     nb::class_<Dog, Animal>(m, "Dog")
         .def(nb::init<const std::string &>());

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -138,6 +138,7 @@ def test08_inheritance():
     assert isinstance(cat, t.Animal) and isinstance(cat, t.Cat)
     assert t.go(dog) == 'Dog says woof'
     assert t.go(cat) == 'Cat says meow'
+    assert not dog == cat
 
 
 def test09_method_vectorcall():


### PR DESCRIPTION
This is a bug report masquerading as a PR. With the code changes described below, there is a test failure
```
Traceback (most recent call last):
  File "/home/andreas/pack/nanobind/build/tests/test_classes.py", line 141, in test08_inheritance
    assert not dog == cat
RecursionError: maximum recursion depth exceeded while calling a Python object
```
I *believe* this is a regression, I recall code like this working at a point with nanobind. If it's important, I can try to bisect.