### PR TITLE
Add std::map and std::unordered_map type casters

### DIFF
--- a/include/nanobind/stl/detail/nb_dict.h
+++ b/include/nanobind/stl/detail/nb_dict.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename Value_, typename Key, typename Element> struct dict_caster {
+    NB_TYPE_CASTER(Value_, const_name("dict[") + make_caster<Key>::Name +
+                               const_name(", ") + make_caster<Element>::Name +
+                               const_name("]"));
+
+    using KeyCaster = make_caster<Key>;
+    using ElementCaster = make_caster<Element>;
+
+    bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+        value.clear();
+
+        PyObject *items = PyDict_Items(src.ptr());
+        if (items == nullptr) return false;
+
+        Py_ssize_t size = PyList_Size(items);
+        bool success = (size >= 0);
+
+        KeyCaster key_caster;
+        ElementCaster element_caster;
+        for (Py_ssize_t i = 0; i < size; ++i) {
+            PyObject *item = PyList_GetItem(items, i);
+            PyObject *key = PyTuple_GetItem(item, 0);
+            PyObject *element = PyTuple_GetItem(item, 1);
+            if (!key_caster.from_python(key, flags, cleanup)) {
+                success = false;
+                break;
+            }
+            if (!element_caster.from_python(element, flags, cleanup)) {
+                success = false;
+                break;
+            }
+            value.emplace(((KeyCaster &&) key_caster).operator cast_t<Key &&>(),
+                          ((ElementCaster &&) element_caster).operator cast_t<Element &&>());
+        }
+
+        Py_XDECREF(items);
+
+        return success;
+    }
+
+    template <typename T>
+    static handle from_cpp(T &&src, rv_policy policy, cleanup_list *cleanup) {
+        object dict = steal(PyDict_New());
+        if (dict) {
+            for (auto &item : src) {
+                object k = steal(KeyCaster::from_cpp(
+                    forward_like<typename T::key_type>(item.first), policy, cleanup));
+                object e = steal(ElementCaster::from_cpp(
+                    forward_like<typename T::mapped_type>(item.second), policy, cleanup));
+                if (PyDict_SetItem(dict.ptr(), k.ptr(), e.ptr()) != 0) return handle();
+                if (!k.is_valid() || !e.is_valid()) return handle();
+            }
+        }
+        return dict.release();
+    }
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/map.h
+++ b/include/nanobind/stl/map.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "detail/nb_dict.h"
+#include <map>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename Key, typename T, typename Compare, typename Alloc>
+struct type_caster<std::map<Key, T, Compare, Alloc>>
+ : dict_caster<std::map<Key, T, Compare, Alloc>, Key, T> { };
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/unordered_map.h
+++ b/include/nanobind/stl/unordered_map.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "detail/nb_dict.h"
+#include <unordered_map>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename Key, typename T, typename Compare, typename Alloc>
+struct type_caster<std::unordered_map<Key, T, Compare, Alloc>>
+ : dict_caster<std::unordered_map<Key, T, Compare, Alloc>, Key, T> { };
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -466,3 +466,48 @@ def test47_std_variant_unbound_type(clean):
         " -> Union[None, list, tuple, int]"
     )
 
+def test48_map_return_movable_value(clean):
+    for i, (k, v) in enumerate(sorted(t.map_return_movable_value().items())):
+        assert k == chr(ord("a") + i)
+        assert v.value == i
+    assert t.map_return_movable_value.__doc__ == (
+        "map_return_movable_value() -> dict[str, test_stl_ext.Movable]"
+    )
+
+def test49_map_return_copyable_value(clean):
+    for i, (k, v) in enumerate(sorted(t.map_return_copyable_value().items())):
+        assert k == chr(ord("a") + i)
+        assert v.value == i
+    assert t.map_return_copyable_value.__doc__ == (
+        "map_return_copyable_value() -> dict[str, test_stl_ext.Copyable]"
+    )
+
+def test50_map_movable_in_value(clean):
+    t.map_movable_in_value(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
+    assert t.map_movable_in_value.__doc__ == (
+        "map_movable_in_value(x: dict[str, test_stl_ext.Movable]) -> None"
+    )
+
+def test51_map_movable_in_value(clean):
+    t.map_copyable_in_value(dict([(chr(ord("a") + i), t.Copyable(i)) for i in range(10)]))
+    assert t.map_copyable_in_value.__doc__ == (
+        "map_copyable_in_value(x: dict[str, test_stl_ext.Copyable]) -> None"
+    )
+
+def test52_map_movable_in_lvalue_ref(clean):
+    t.map_movable_in_lvalue_ref(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
+    assert t.map_movable_in_lvalue_ref.__doc__ == (
+        "map_movable_in_lvalue_ref(x: dict[str, test_stl_ext.Movable]) -> None"
+    )
+
+def test53_map_movable_in_rvalue_ref(clean):
+    t.map_movable_in_rvalue_ref(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
+    assert t.map_movable_in_rvalue_ref.__doc__ == (
+        "map_movable_in_rvalue_ref(x: dict[str, test_stl_ext.Movable]) -> None"
+    )
+
+def test54_map_movable_in_ptr(clean):
+    t.map_movable_in_ptr(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
+    assert t.map_movable_in_ptr.__doc__ == (
+        "map_movable_in_ptr(x: dict[str, test_stl_ext.Movable]) -> None"
+    )


### PR DESCRIPTION
I've implemented a `std::map` and `std::unordered_map` type caster that converts to/from a Python `dict`. I've extracted the common logic into `detail/nb_dict.h` similar to the current implementation for `std::list` and `std::vector` in `detail/nb_list.h`.