### PR TITLE
Add std::unordered_set type casters and corresponding tests

### DIFF
--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -348,4 +348,16 @@ template <typename T> void list::append(T &&value) {
         detail::raise_python_error();
 }
 
+template <typename T>
+bool anyset::contains(T&& value) const
+{
+    return PySet_Contains(m_ptr, nanobind::cast(value).ptr()) == 1;
+}
+
+template <typename T>
+bool set::add(T&& value)
+{
+    return PySet_Add(m_ptr, nanobind::cast(value).ptr()) == 0;
+}
+
 NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -92,6 +92,7 @@
 #  define NB_LIST_GET_ITEM PyList_GetItem
 #  define NB_LIST_SET_ITEM PyList_SetItem
 #  define NB_DICT_GET_SIZE PyDict_Size
+#  define NB_SET_GET_SIZE PySet_Size
 #else
 #  define NB_TUPLE_GET_SIZE PyTuple_GET_SIZE
 #  define NB_TUPLE_GET_ITEM PyTuple_GET_ITEM
@@ -100,6 +101,7 @@
 #  define NB_LIST_GET_ITEM PyList_GET_ITEM
 #  define NB_LIST_SET_ITEM PyList_SET_ITEM
 #  define NB_DICT_GET_SIZE PyDict_GET_SIZE
+#  define NB_SET_GET_SIZE PySet_GET_SIZE
 #endif
 
 

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -358,7 +358,7 @@ class list : public object {
 class anyset : public object {
 public:
     NB_OBJECT(anyset, object, "anyset", PySet_Check)
-    size_t size() const { return static_cast<size_t>(PySet_Size(m_ptr)); }
+    size_t size() const { return NB_SET_GET_SIZE(m_ptr); }
     bool empty() const { return size() == 0; }
     template <typename T> bool contains(T&& val) const;
 };

--- a/include/nanobind/stl/detail/nb_set.h
+++ b/include/nanobind/stl/detail/nb_set.h
@@ -43,7 +43,7 @@ template <typename Value_, typename Key> struct set_caster {
         if (ret) {
             for (auto& key : src) {
                 object k = steal(
-                    KeyCaster::from_cpp(forward_like<typename T::key_type>(key), policy, cleanup));
+                    KeyCaster::from_cpp(forward_like<T>(key), policy, cleanup));
                 if (PySet_Add(ret.ptr(), k.ptr()) != 0) return handle();
                 if (!k.is_valid()) return handle();
             }

--- a/include/nanobind/stl/detail/nb_set.h
+++ b/include/nanobind/stl/detail/nb_set.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename Value_, typename Key> struct set_caster {
+    NB_TYPE_CASTER(Value_, const_name("set[") + make_caster<Key>::Name + const_name("]"));
+
+    using KeyCaster = make_caster<Key>;
+
+    bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+        value.clear();
+
+        PyObject* iter = obj_iter(src.ptr());
+        if (iter == nullptr) {
+            PyErr_Clear();
+            return false;
+        }
+
+        Py_ssize_t size = NB_SET_GET_SIZE(src.ptr());
+        bool success = (size >= 0);
+
+        KeyCaster key_caster;
+        while (PyObject* key = obj_iter_next(iter)) {
+            if (!key_caster.from_python(key, flags, cleanup)) {
+                success = false;
+                break;
+            }
+            value.emplace(((KeyCaster &&) key_caster).operator cast_t<Key&&>());
+            Py_DECREF(key);
+        }
+
+        Py_DECREF(iter);
+
+        return success;
+    }
+
+    template <typename T>
+    static handle from_cpp(T &&src, rv_policy policy, cleanup_list *cleanup) {
+        set ret;
+        if (ret) {
+            for (auto& key : src) {
+                object k = steal(
+                    KeyCaster::from_cpp(forward_like<typename T::key_type>(key), policy, cleanup));
+                if (PySet_Add(ret.ptr(), k.ptr()) != 0) return handle();
+                if (!k.is_valid()) return handle();
+            }
+        }
+        return ret.release();
+    }
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/unordered_set.h
+++ b/include/nanobind/stl/unordered_set.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "detail/nb_set.h"
+#include <unordered_set>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename Key, typename Hash, typename Compare, typename Alloc>
+struct type_caster<std::unordered_set<Key, Hash, Compare, Alloc>>
+    : set_caster<std::unordered_set<Key, Hash, Compare, Alloc>, Key>
+{
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -146,4 +146,10 @@ NB_MODULE(test_functions_ext, m) {
     m.def("test_16", [](const char *c) { return nb::bytes(c); });
     m.def("test_17", [](nb::bytes c) { return c.size(); });
     m.def("test_18", [](const char *c, int size) { return nb::bytes(c, size); });
+
+    // Test set construction
+    m.def("test_19", [](nb::set d) {
+        nb::set result(d);
+        return result;
+    });
 }

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -8,6 +8,7 @@
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/variant.h>
 #include <nanobind/stl/map.h>
+#include <nanobind/stl/unordered_set.h>
 
 NB_MAKE_OPAQUE(NB_TYPE(std::vector<float, std::allocator<float>>))
 
@@ -271,6 +272,35 @@ NB_MODULE(test_stl_ext, m) {
             std::string key(1, 'a' + i);
             if (x.find(key) == x.end()) fail();
             if (x[key]->value != i) fail();
+        }
+    }, nb::arg("x"));
+
+    // ----- test55-test58 ------ */
+    m.def("set_return_value", [](){
+        std::unordered_set<std::string> x;
+        for (int i = 0; i < 10; ++i)
+            x.emplace(std::string(1, 'a' + i));
+        return x;
+    });
+    m.def("set_in_value", [](std::unordered_set<std::string> x) {
+        if (x.size() != 10) fail();
+        for (int i = 0; i < 10; ++i) {
+            std::string key(1, 'a' + i);
+            if (x.find(key) == x.end()) fail();
+        }
+    }, nb::arg("x"));
+    m.def("set_in_lvalue_ref", [](std::unordered_set<std::string>& x) {
+        if (x.size() != 10) fail();
+        for (int i = 0; i < 10; ++i) {
+            std::string key(1, 'a' + i);
+            if (x.find(key) == x.end()) fail();
+        }
+    }, nb::arg("x"));
+    m.def("set_in_rvalue_ref", [](std::unordered_set<std::string>&& x) {
+        if (x.size() != 10) fail();
+        for (int i = 0; i < 10; ++i) {
+            std::string key(1, 'a' + i);
+            if (x.find(key) == x.end()) fail();
         }
     }, nb::arg("x"));
 }


### PR DESCRIPTION
This PR adds `std::unordered_set` type casters that converts from/to Python's `set`. Similar to the current implementation for `list` and `dict`, the common logic is in `detail/nb_set.h`.

Simple tests have been added to `test_functions_ext` and `test_stl_ext`.