### PR TITLE
Fix dict type caster compilation with `const &`

### DIFF
--- a/include/nanobind/stl/detail/nb_dict.h
+++ b/include/nanobind/stl/detail/nb_dict.h
@@ -54,9 +54,9 @@ template <typename Value_, typename Key, typename Element> struct dict_caster {
         if (ret) {
             for (auto &item : src) {
                 object k = steal(KeyCaster::from_cpp(
-                    forward_like<typename T::key_type>(item.first), policy, cleanup));
+                    forward_like<T>(item.first), policy, cleanup));
                 object e = steal(ElementCaster::from_cpp(
-                    forward_like<typename T::mapped_type>(item.second), policy, cleanup));
+                    forward_like<T>(item.second), policy, cleanup));
 
                 if (PyDict_SetItem(ret.ptr(), k.ptr(), e.ptr()) != 0) {
                     PyErr_Clear();

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -39,6 +39,10 @@ struct Copyable {
     ~Copyable() { destructed++; }
 };
 
+struct StructWithReadonlyMap {
+  std::map<std::string, uint64_t> map;
+};
+
 void fail() { throw std::exception(); }
 
 NB_MODULE(test_stl_ext, m) {
@@ -73,6 +77,10 @@ NB_MODULE(test_stl_ext, m) {
         .def(nb::init<>())
         .def(nb::init<int>())
         .def_readwrite("value", &Copyable::value);
+
+    nb::class_<StructWithReadonlyMap>(m, "StructWithReadonlyMap")
+        .def(nb::init<>())
+        .def_readonly("map", &StructWithReadonlyMap::map);
 
     // ----- test01-test12 ------ */
 
@@ -218,7 +226,7 @@ NB_MODULE(test_stl_ext, m) {
     m.def("variant_unbound_type", [](std::variant<std::monostate, nb::list, nb::tuple, int> &x) { return x; },
           nb::arg("x").none() = nb::none());
 
-    // ----- test48-test54 ------ */
+    // ----- test48-test55 ------ */
     m.def("map_return_movable_value", [](){
         std::map<std::string, Movable> x;
         for (int i = 0; i < 10; ++i)
@@ -273,4 +281,11 @@ NB_MODULE(test_stl_ext, m) {
             if (x[key]->value != i) fail();
         }
     }, nb::arg("x"));
+    m.def("map_return_readonly_value", [](){
+        StructWithReadonlyMap x;
+        for (int i = 0; i < 10; ++i) {
+            x.map.insert({std::string(1, 'a' + i), i});
+        }
+        return x;
+    });
 }

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -511,3 +511,11 @@ def test54_map_movable_in_ptr(clean):
     assert t.map_movable_in_ptr.__doc__ == (
         "map_movable_in_ptr(x: dict[str, test_stl_ext.Movable]) -> None"
     )
+
+def test55_map_return_readonly_value(clean):
+    for i, (k, v) in enumerate(sorted(t.map_return_readonly_value().map.items())):
+        assert k == chr(ord("a") + i)
+        assert v == i
+    assert t.map_return_readonly_value.__doc__ == (
+        "map_return_readonly_value() -> test_stl_ext.StructWithReadonlyMap"
+    )


### PR DESCRIPTION
The dictionary caster that I wrote has a compilation issue when the `std::map` is passed into the C++ caster as a `const &`. This change fixes it. I would also note that the same issue should probably be fixed in #84 as the conversion logic was modified from the dictionary caster.

```
nanobind/include/nanobind/stl/detail/nb_dict.h:57:43: error: type 'const std::map<std::__cxx11::basic_string<char>, std::vector<unsigned long, std::allocator<unsigned long>>, std::less<std::__cxx11::basic_string<char>>, std::allocator<std::pair<const std::__cxx11::basic_string<char>, std::vector<unsigned long, std::allocator<unsigned long>>>>> &' cannot be used prior to '::' because it has no members
                    forward_like<typename T::key_type>(item.first), policy, cleanup));
                                          ^
```