### PR TITLE
add support to unordered_set

### DIFF
--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -92,7 +92,6 @@
 #  define NB_LIST_GET_ITEM PyList_GetItem
 #  define NB_LIST_SET_ITEM PyList_SetItem
 #  define NB_DICT_GET_SIZE PyDict_Size
-#  define NB_SET_GET_SIZE PySet_Size
 #else
 #  define NB_TUPLE_GET_SIZE PyTuple_GET_SIZE
 #  define NB_TUPLE_GET_ITEM PyTuple_GET_ITEM
@@ -101,7 +100,6 @@
 #  define NB_LIST_GET_ITEM PyList_GET_ITEM
 #  define NB_LIST_SET_ITEM PyList_SET_ITEM
 #  define NB_DICT_GET_SIZE PyDict_GET_SIZE
-#  define NB_SET_GET_SIZE PySet_GET_SIZE
 #endif
 
 

--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -92,6 +92,7 @@
 #  define NB_LIST_GET_ITEM PyList_GetItem
 #  define NB_LIST_SET_ITEM PyList_SetItem
 #  define NB_DICT_GET_SIZE PyDict_Size
+#  define NB_SET_GET_SIZE PySet_Size
 #else
 #  define NB_TUPLE_GET_SIZE PyTuple_GET_SIZE
 #  define NB_TUPLE_GET_ITEM PyTuple_GET_ITEM
@@ -100,6 +101,7 @@
 #  define NB_LIST_GET_ITEM PyList_GET_ITEM
 #  define NB_LIST_SET_ITEM PyList_SET_ITEM
 #  define NB_DICT_GET_SIZE PyDict_GET_SIZE
+#  define NB_SET_GET_SIZE PySet_GET_SIZE
 #endif
 
 

--- a/include/nanobind/stl/detail/nb_set.h
+++ b/include/nanobind/stl/detail/nb_set.h
@@ -15,16 +15,16 @@ template <typename Value_, typename Key> struct set_caster {
 
         PyObject* iter = obj_iter(src.ptr());
         if (iter == nullptr) {
-            PyErr_Print();
+            PyErr_Clear();
             return false;
         }
 
-        Py_ssize_t size = NB_SET_GET_SIZE(src.ptr());
-        bool success = (size >= 0);
+        bool success = true;
 
         KeyCaster key_caster;
         for (PyObject* key = PyIter_Next(iter); key; key = PyIter_Next(iter)) {
             if (!key_caster.from_python(key, flags, cleanup)) {
+                Py_DECREF(key);
                 success = false;
                 break;
             }
@@ -32,7 +32,7 @@ template <typename Value_, typename Key> struct set_caster {
             Py_DECREF(key);
         }
         if (PyErr_Occurred()) {
-            PyErr_Print();
+            PyErr_Clear();
             success = false;
         }
 
@@ -50,14 +50,14 @@ template <typename Value_, typename Key> struct set_caster {
                     KeyCaster::from_cpp(forward_like<T>(key), policy, cleanup));
                 if (PySet_Add(ret.ptr(), k.ptr()) != 0) {
                     if (PyErr_Occurred()) {
-                        PyErr_Print();
+                        PyErr_Clear();
                     }
                     return handle();
                 }
                 if (!k.is_valid()) return handle();
             }
         } else if (PyErr_Occurred()) {
-            PyErr_Print();
+            PyErr_Clear();
         }
         return ret.release();
     }

--- a/include/nanobind/stl/detail/nb_set.h
+++ b/include/nanobind/stl/detail/nb_set.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename Value_, typename Key> struct set_caster {
+    NB_TYPE_CASTER(Value_, const_name("set[") + make_caster<Key>::Name + const_name("]"));
+
+    using KeyCaster = make_caster<Key>;
+
+    bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+        value.clear();
+
+        PyObject* iter = obj_iter(src.ptr());
+        if (iter == nullptr) {
+            PyErr_Clear();
+            return false;
+        }
+
+        Py_ssize_t size = NB_SET_GET_SIZE(src.ptr());
+        bool success = (size >= 0);
+
+        KeyCaster key_caster;
+        while (PyObject* key = obj_iter_next(iter)) {
+            if (!key_caster.from_python(key, flags, cleanup)) {
+                success = false;
+                break;
+            }
+            value.emplace(((KeyCaster &&) key_caster).operator cast_t<Key&&>());
+            Py_DECREF(key);
+        }
+
+        Py_DECREF(iter);
+
+        return success;
+    }
+
+    template <typename T>
+    static handle from_cpp(T &&src, rv_policy policy, cleanup_list *cleanup) {
+        object ret = steal(PySet_New(nullptr));
+        if (ret) {
+            for (auto& key : src) {
+                object k = steal(
+                    KeyCaster::from_cpp(forward_like<T>(key), policy, cleanup));
+                if (PySet_Add(ret.ptr(), k.ptr()) != 0) return handle();
+                if (!k.is_valid()) return handle();
+            }
+        }
+        return ret.release();
+    }
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/unordered_set.h
+++ b/include/nanobind/stl/unordered_set.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "detail/nb_set.h"
+#include <unordered_set>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename Key, typename Hash, typename Compare, typename Alloc>
+struct type_caster<std::unordered_set<Key, Hash, Compare, Alloc>>
+    : set_caster<std::unordered_set<Key, Hash, Compare, Alloc>, Key>
+{
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -8,6 +8,7 @@
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/variant.h>
 #include <nanobind/stl/map.h>
+#include <nanobind/stl/unordered_set.h>
 
 NB_MAKE_OPAQUE(NB_TYPE(std::vector<float, std::allocator<float>>))
 
@@ -271,6 +272,35 @@ NB_MODULE(test_stl_ext, m) {
             std::string key(1, 'a' + i);
             if (x.find(key) == x.end()) fail();
             if (x[key]->value != i) fail();
+        }
+    }, nb::arg("x"));
+
+    // ----- test55-test58 ------ */
+    m.def("set_return_value", [](){
+        std::unordered_set<std::string> x;
+        for (int i = 0; i < 10; ++i)
+            x.emplace(std::string(1, 'a' + i));
+        return x;
+    });
+    m.def("set_in_value", [](std::unordered_set<std::string> x) {
+        if (x.size() != 10) fail();
+        for (int i = 0; i < 10; ++i) {
+            std::string key(1, 'a' + i);
+            if (x.find(key) == x.end()) fail();
+        }
+    }, nb::arg("x"));
+    m.def("set_in_lvalue_ref", [](std::unordered_set<std::string>& x) {
+        if (x.size() != 10) fail();
+        for (int i = 0; i < 10; ++i) {
+            std::string key(1, 'a' + i);
+            if (x.find(key) == x.end()) fail();
+        }
+    }, nb::arg("x"));
+    m.def("set_in_rvalue_ref", [](std::unordered_set<std::string>&& x) {
+        if (x.size() != 10) fail();
+        for (int i = 0; i < 10; ++i) {
+            std::string key(1, 'a' + i);
+            if (x.find(key) == x.end()) fail();
         }
     }, nb::arg("x"));
 }

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -302,7 +302,7 @@ NB_MODULE(test_stl_ext, m) {
     m.def("array_out", [](){ return std::array<int, 3>{1, 2, 3}; });
     m.def("array_in", [](std::array<int, 3> x) { return x[0] + x[1] + x[2]; });
 
-    // ----- test55-test58 ------ */
+    // ----- test58-test62 ------ */
     m.def("set_return_value", []() {
         std::unordered_set<std::string> x;
         for (int i = 0; i < 10; ++i)

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -488,7 +488,7 @@ def test50_map_movable_in_value(clean):
         "map_movable_in_value(x: dict[str, test_stl_ext.Movable]) -> None"
     )
 
-def test51_map_movable_in_value(clean):
+def test51_map_copyable_in_value(clean):
     t.map_copyable_in_value(dict([(chr(ord("a") + i), t.Copyable(i)) for i in range(10)]))
     assert t.map_copyable_in_value.__doc__ == (
         "map_copyable_in_value(x: dict[str, test_stl_ext.Copyable]) -> None"
@@ -532,4 +532,34 @@ def test56_array(clean):
 def test57_map_movable_in_failure(clean):
     with pytest.raises(TypeError) as excinfo:
         t.map_copyable_in_value({1:2})
+    assert 'incompatible function arguments' in str(excinfo.value)
+
+def test58_set_return_value(clean):
+    for i, k in enumerate(sorted(t.set_return_value())):
+        assert k == chr(ord("a") + i)
+    assert t.set_return_value.__doc__ == (
+        "set_return_value() -> set[str]"
+    )
+
+def test59_set_in_value(clean):
+    t.set_in_value(set([chr(ord("a") + i) for i in range(10)]))
+    assert t.set_in_value.__doc__ == (
+        "set_in_value(x: set[str]) -> None"
+    )
+
+def test60_set_in_lvalue_ref(clean):
+    t.set_in_lvalue_ref(set([chr(ord("a") + i) for i in range(10)]))
+    assert t.set_in_lvalue_ref.__doc__ == (
+        "set_in_lvalue_ref(x: set[str]) -> None"
+    )
+
+def test61_set_in_rvalue_ref(clean):
+    t.set_in_rvalue_ref(set([chr(ord("a") + i) for i in range(10)]))
+    assert t.set_in_rvalue_ref.__doc__ == (
+        "set_in_rvalue_ref(x: set[str]) -> None"
+    )
+
+def test62_set_in_failure(clean):
+    with pytest.raises(TypeError) as excinfo:
+        t.set_in_value(set([i for i in range(10)]))
     assert 'incompatible function arguments' in str(excinfo.value)


### PR DESCRIPTION
This PR adds type castor for `std::unordered_set`, and is part of #84, which is split into two parts. Here we don't do the same for `std::set` since Python doesn't have an ordered set by default.