### PR TITLE
Add nb::slice and nb::ellipsis types

### DIFF
--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -469,6 +469,31 @@ inline iterator iter(handle h) {
     return steal<iterator>(detail::obj_iter(h.ptr()));
 }
 
+class slice : public object {
+public:
+    NB_OBJECT_DEFAULT(slice, object, "slice", PySlice_Check)
+    slice(handle start, handle stop, handle step) {
+        m_ptr = PySlice_New(start.ptr(), stop.ptr(), step.ptr());
+        if (!m_ptr)
+            detail::raise_python_error();
+    }
+
+    template <typename T, detail::enable_if_t<std::is_arithmetic_v<T>> = 0>
+    explicit slice(T stop) : slice(Py_None, int_(stop), Py_None) {}
+    template <typename T, detail::enable_if_t<std::is_arithmetic_v<T>> = 0>
+    slice(T start, T stop) : slice(int_(start), int_(stop), Py_None) {}
+    template <typename T, detail::enable_if_t<std::is_arithmetic_v<T>> = 0>
+    slice(T start, T stop, T step) : slice(int_(start), int_(stop), int_(step)) {}
+};
+
+class ellipsis : public object {
+    static bool is_ellipsis(PyObject *obj) {return obj == Py_Ellipsis; }
+
+public:
+    NB_OBJECT(ellipsis, object, "EllipsisType", is_ellipsis)
+    ellipsis() : object(Py_Ellipsis, detail::borrow_t()) {}
+};
+
 template <typename T> class handle_t : public handle {
 public:
     static constexpr auto Name = detail::make_caster<T>::Name;

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -156,4 +156,13 @@ NB_MODULE(test_functions_ext, m) {
     m.def("test_22", []() -> void * { return (void*) 1; });
     m.def("test_23", []() -> void * { return nullptr; });
     m.def("test_24", [](void *p) { return (uintptr_t) p; }, "p"_a.none());
+
+    // Test slice
+    m.def("test_25", [](nb::slice s) { return s; });
+    m.def("test_26", []() { return nb::slice(4); });
+    m.def("test_27", []() { return nb::slice(1, 10); });
+    m.def("test_28", []() { return nb::slice(5, -5, -2); });
+
+    // Test ellipsis
+    m.def("test_29", [](nb::ellipsis) { return nb::ellipsis(); });
 }

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -226,3 +226,17 @@ def test26_capsule():
     p = t.test_23()
     assert p is None
     assert t.test_24(p) == 0
+
+
+def test27_slice():
+    s = slice(1, 10, 2)
+    assert t.test_25(s) is s
+    assert t.test_25.__doc__ == "test_25(arg: slice, /) -> slice"
+    assert t.test_26() == slice(4)
+    assert t.test_27() == slice(1, 10)
+    assert t.test_28() == slice(5, -5, -2)
+
+
+def test28_ellipsis():
+    assert t.test_29(...) is ...
+    assert t.test_29.__doc__ == "test_29(arg: EllipsisType, /) -> EllipsisType"


### PR DESCRIPTION
This PR adds support for the `slice` and `ellipsis` types. It would be useful for binding array-like classes. 

As a side note, the name `EllipsisType` is based on the [`typing.EllipsisType`](https://docs.python.org/dev/library/types.html#types.EllipsisType) introduced in Python 3.10.