### PR TITLE
Exploit move constructors in def_readwrite and def_readwrite_static

### DIFF
--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -385,9 +385,11 @@ public:
         static_assert(std::is_base_of_v<C, T>,
                       "def_readwrite() requires a (base) class member!");
 
+        using Q = std::conditional_t<detail::make_caster<D>::IsClass, const D &, D &&>;
+
         def_property(name,
             [pm](const T &c) -> const D & { return c.*pm; },
-            [pm](T &c, const D &value) { c.*pm = value; },
+            [pm](T &c, Q value) { c.*pm = (Q) value; },
             extra...);
 
         return *this;
@@ -396,9 +398,11 @@ public:
     template <typename D, typename... Extra>
     NB_INLINE class_ &def_readwrite_static(const char *name, D *pm,
                                            const Extra &...extra) {
+        using Q = std::conditional_t<detail::make_caster<D>::IsClass, const D &, D &&>;
+
         def_property_static(name,
             [pm](handle) -> const D & { return *pm; },
-            [pm](handle, const D &value) { *pm = value; }, extra...);
+            [pm](handle, Q value) { *pm = (Q) value; }, extra...);
 
         return *this;
     }

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -24,7 +24,7 @@ struct Struct {
     Struct(const Struct &s) : i(s.i) { copy_constructed++; }
     Struct(Struct &&s) noexcept : i(s.i) { s.i = 0; move_constructed++; }
     Struct &operator=(const Struct &s) { i = s.i; copy_assigned++; return *this; }
-    Struct &operator=(Struct &&s) noexcept { std::swap(i, s.i); move_assigned++; return *this; }
+    Struct &operator=(Struct &&s) noexcept { i = s.i; s.i = 0; move_assigned++; return *this; }
     ~Struct() { destructed++; }
 
     int value() const { return i; }

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -510,3 +510,16 @@ def test27_copy_rvp():
 def test28_pydoc():
     import pydoc
     assert "Some documentation" in pydoc.render_doc(t)
+
+
+def test29_property_assignment_instance():
+    s = t.PairStruct()
+    s1 = t.Struct(123)
+    s2 = t.Struct(456)
+    s.s1 = s1
+    s.s2 = s2
+    assert s2 is not s.s2 and s1 is not s.s1
+    assert s.s1.value() == 123
+    assert s.s2.value() == 456
+    assert s1.value() == 123
+    assert s2.value() == 456

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -369,4 +369,12 @@ NB_MODULE(test_stl_ext, m) {
             }
         },
         nb::arg("x"));
+
+    struct ClassWithMovableField {
+        std::vector<Movable> movable;
+    };
+
+    nb::class_<ClassWithMovableField>(m, "ClassWithMovableField")
+        .def(nb::init<>())
+        .def_readwrite("movable", &ClassWithMovableField::movable);
 }

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -575,3 +575,37 @@ def test62_set_in_failure(clean):
     with pytest.raises(TypeError) as excinfo:
         t.set_in_value(set([i for i in range(10)]))
     assert 'incompatible function arguments' in str(excinfo.value)
+
+def test65_class_with_movable_field(clean):
+    cwmf = t.ClassWithMovableField()
+    m1 = t.Movable(1)
+    m2 = t.Movable(2)
+
+    assert_stats(
+        value_constructed=2
+    )
+
+    cwmf.movable = [ m1, m2 ]
+
+    assert_stats(
+        value_constructed=2,
+        move_constructed=2
+    )
+
+    del m1, m2
+    gc.collect()
+
+    assert_stats(
+        value_constructed=2,
+        move_constructed=2,
+        destructed=2
+    )
+
+    del cwmf
+    gc.collect()
+
+    assert_stats(
+        value_constructed=2,
+        move_constructed=2,
+        destructed=4
+    )


### PR DESCRIPTION
This commit implements a simple optimization that applies when the following two conditions hold:

- A field in a bound C++ types is exposed as writeable Python property

- Setting the field involves an inter-language type conversion step (e.g., for `type_caster<std::vector<T>>` implemented in ``nanobind/stl/vector.h``)

In this case, we can avoid a superfluous copying step by move-constructing the constructed instance from the type caster directly into the field.

This commit also adds tests to verify that this actually happens under the hood.