### PR TITLE
Major improvements to the std::function<> caster (roundtrips, cyclic GC)

### DIFF
--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -17,7 +17,7 @@
 
 /// Tracks the ABI of nanobind
 #ifndef NB_INTERNALS_VERSION
-#  define NB_INTERNALS_VERSION 4
+#  define NB_INTERNALS_VERSION 5
 #endif
 
 /// On MSVC, debug and release builds are not ABI-compatible!

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -251,7 +251,5 @@ def test28_ellipsis():
 def test29_traceback():
     result = t.test_30(fail_fn)
     regexp = r'Traceback \(most recent call last\):\n.*\n  File "[^"]*", line 8, in fail_fn\n.*RuntimeError: Foo'
-    print("'%s'\n"%result)
-    print("'%s'\n"%regexp)
     matches = re.findall(regexp, result, re.MULTILINE | re.DOTALL)
     assert len(matches) == 1

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -323,18 +323,49 @@ def test30_std_function():
     f2()
     assert l == [1]
 
+def test31_std_function_roundtrip():
+    def f():
+        l.append(1)
+    f2 = t.return_void_function(f)
+    assert f2 is f
 
-def test31_vec_type_check():
+def test32_std_function_gc():
+    class A(t.FuncWrapper):
+        pass
+    assert t.FuncWrapper.alive == 0
+    a = A()
+    assert t.FuncWrapper.alive == 1
+    del a
+    assert t.FuncWrapper.alive == 0
+
+    # A class -> function -> class cyclic reference
+    class B(t.FuncWrapper):
+        def __init__(self):
+            super().__init__()
+            def f():
+                print(self.f)
+
+            self.f = f
+    assert t.FuncWrapper.alive == 0
+    b = B()
+    assert t.FuncWrapper.alive == 1
+    del b
+    import gc
+    gc.collect()
+    gc.collect()
+    assert t.FuncWrapper.alive == 0
+
+def test33_vec_type_check():
     with pytest.raises(TypeError) as excinfo:
         t.vec_moveable_in_value(0)
 
-def test32_list():
+def test34_list():
     assert t.identity_list([]) == []
     assert t.identity_list([1, 2, 3]) == [1, 2, 3]
     assert t.identity_list(()) == []
     assert t.identity_list((1, 2, 3)) == [1, 2, 3]
 
-def test33_string_and_string_view():
+def test35_string_and_string_view():
     assert t.identity_string("") == ""
     assert t.identity_string("orange") == "orange"
     assert t.identity_string("橘子") == "橘子"
@@ -349,7 +380,7 @@ def test33_string_and_string_view():
     assert t.identity_string_view("البرتقالي") == "البرتقالي"
     assert t.identity_string_view("🍊") == "🍊"
 
-def test34_std_optional_copyable(clean):
+def test36_std_optional_copyable(clean):
     t.optional_copyable(t.Copyable())
     assert t.optional_copyable.__doc__ == (
         "optional_copyable(x: Optional[test_stl_ext.Copyable]) -> None"
@@ -360,7 +391,7 @@ def test34_std_optional_copyable(clean):
         destructed=2
     )
 
-def test35_std_optional_copyable_ptr(clean):
+def test37_std_optional_copyable_ptr(clean):
     t.optional_copyable_ptr(t.Copyable())
     assert t.optional_copyable_ptr.__doc__ == (
         "optional_copyable_ptr(x: Optional[test_stl_ext.Copyable]) -> None"
@@ -370,10 +401,10 @@ def test35_std_optional_copyable_ptr(clean):
         destructed=1
     )
 
-def test36_std_optional_none():
+def test38_std_optional_none():
     t.optional_none(None)
 
-def test37_std_optional_ret_opt_movable(clean):
+def test39_std_optional_ret_opt_movable(clean):
     assert t.optional_ret_opt_movable().value == 5
     assert t.optional_ret_opt_movable.__doc__ == (
         "optional_ret_opt_movable() -> Optional[test_stl_ext.Movable]"
@@ -384,17 +415,17 @@ def test37_std_optional_ret_opt_movable(clean):
         destructed=3
     )
 
-def test38_std_optional_ret_opt_movable_ptr(clean):
+def test40_std_optional_ret_opt_movable_ptr(clean):
     assert t.optional_ret_opt_movable_ptr().value == 5
     assert_stats(
         default_constructed=1,
         destructed=1
     )
 
-def test39_std_optional_ret_opt_none():
+def test41_std_optional_ret_opt_none():
     assert t.optional_ret_opt_none() is None
 
-def test40_std_optional_unbound_type():
+def test42_std_optional_unbound_type():
     assert t.optional_unbound_type(3) == 3
     assert t.optional_unbound_type(None) is None
     assert t.optional_unbound_type() is None
@@ -402,7 +433,7 @@ def test40_std_optional_unbound_type():
         "optional_unbound_type(x: Optional[int] = None) -> Optional[int]"
     )
 
-def test41_std_variant_copyable(clean):
+def test43_std_variant_copyable(clean):
     t.variant_copyable(t.Copyable())
     t.variant_copyable(5)
     assert t.variant_copyable.__doc__ == (
@@ -414,7 +445,7 @@ def test41_std_variant_copyable(clean):
         destructed=3
     )
 
-def test42_std_variant_copyable_none(clean):
+def test44_std_variant_copyable_none(clean):
     t.variant_copyable_none(t.Copyable())
     t.variant_copyable_none(5)
     t.variant_copyable_none(None)
@@ -427,7 +458,7 @@ def test42_std_variant_copyable_none(clean):
         destructed=2
     )
 
-def test43_std_variant_copyable_ptr(clean):
+def test45_std_variant_copyable_ptr(clean):
     t.variant_copyable_ptr(t.Copyable())
     t.variant_copyable_ptr(5)
     assert t.variant_copyable_ptr.__doc__ == (
@@ -438,7 +469,7 @@ def test43_std_variant_copyable_ptr(clean):
         destructed=1
     )
 
-def test44_std_variant_copyable_ptr_none(clean):
+def test46_std_variant_copyable_ptr_none(clean):
     t.variant_copyable_ptr_none(t.Copyable())
     t.variant_copyable_ptr_none(5)
     t.variant_copyable_ptr_none(None)
@@ -450,19 +481,19 @@ def test44_std_variant_copyable_ptr_none(clean):
         destructed=1
     )
 
-def test45_std_variant_ret_var_copyable(clean):
+def test47_std_variant_ret_var_copyable():
     assert t.variant_ret_var_copyable().value == 5
     assert t.variant_ret_var_copyable.__doc__ == (
         "variant_ret_var_copyable() -> Union[test_stl_ext.Copyable, int]"
     )
 
-def test46_std_variant_ret_var_none(clean):
+def test48_std_variant_ret_var_none():
     assert t.variant_ret_var_none() is None
     assert t.variant_ret_var_none.__doc__ == (
         "variant_ret_var_none() -> Union[None, test_stl_ext.Copyable, int]"
     )
 
-def test47_std_variant_unbound_type(clean):
+def test49_std_variant_unbound_type():
     assert t.variant_unbound_type() is None
     assert t.variant_unbound_type(None) is None
     assert t.variant_unbound_type([5]) == [5]
@@ -473,7 +504,7 @@ def test47_std_variant_unbound_type(clean):
         " -> Union[None, list, tuple, int]"
     )
 
-def test48_map_return_movable_value(clean):
+def test50_map_return_movable_value():
     for i, (k, v) in enumerate(sorted(t.map_return_movable_value().items())):
         assert k == chr(ord("a") + i)
         assert v.value == i
@@ -481,7 +512,7 @@ def test48_map_return_movable_value(clean):
         "map_return_movable_value() -> dict[str, test_stl_ext.Movable]"
     )
 
-def test49_map_return_copyable_value(clean):
+def test51_map_return_copyable_value():
     for i, (k, v) in enumerate(sorted(t.map_return_copyable_value().items())):
         assert k == chr(ord("a") + i)
         assert v.value == i
@@ -489,37 +520,37 @@ def test49_map_return_copyable_value(clean):
         "map_return_copyable_value() -> dict[str, test_stl_ext.Copyable]"
     )
 
-def test50_map_movable_in_value(clean):
+def test52_map_movable_in_value():
     t.map_movable_in_value(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
     assert t.map_movable_in_value.__doc__ == (
         "map_movable_in_value(x: dict[str, test_stl_ext.Movable]) -> None"
     )
 
-def test51_map_copyable_in_value(clean):
+def test53_map_copyable_in_value():
     t.map_copyable_in_value(dict([(chr(ord("a") + i), t.Copyable(i)) for i in range(10)]))
     assert t.map_copyable_in_value.__doc__ == (
         "map_copyable_in_value(x: dict[str, test_stl_ext.Copyable]) -> None"
     )
 
-def test52_map_movable_in_lvalue_ref(clean):
+def test54_map_movable_in_lvalue_ref():
     t.map_movable_in_lvalue_ref(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
     assert t.map_movable_in_lvalue_ref.__doc__ == (
         "map_movable_in_lvalue_ref(x: dict[str, test_stl_ext.Movable]) -> None"
     )
 
-def test53_map_movable_in_rvalue_ref(clean):
+def test55_map_movable_in_rvalue_ref():
     t.map_movable_in_rvalue_ref(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
     assert t.map_movable_in_rvalue_ref.__doc__ == (
         "map_movable_in_rvalue_ref(x: dict[str, test_stl_ext.Movable]) -> None"
     )
 
-def test54_map_movable_in_ptr(clean):
+def test56_map_movable_in_ptr():
     t.map_movable_in_ptr(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
     assert t.map_movable_in_ptr.__doc__ == (
         "map_movable_in_ptr(x: dict[str, test_stl_ext.Movable]) -> None"
     )
 
-def test55_map_return_readonly_value(clean):
+def test57_map_return_readonly_value():
     for i, (k, v) in enumerate(sorted(t.map_return_readonly_value().map.items())):
         assert k == chr(ord("a") + i)
         assert v == i
@@ -527,7 +558,7 @@ def test55_map_return_readonly_value(clean):
         "map_return_readonly_value() -> test_stl_ext.StructWithReadonlyMap"
     )
 
-def test56_array(clean):
+def test58_array():
     o = t.array_out()
     assert isinstance(o, list) and o == [1, 2, 3]
     assert t.array_in([1, 2, 3]) == 6
@@ -536,12 +567,12 @@ def test56_array(clean):
         assert t.array_in((1, 2, 3, 4)) == 6
     assert 'incompatible function arguments' in str(excinfo.value)
 
-def test57_map_movable_in_failure(clean):
+def test59_map_movable_in_failure():
     with pytest.raises(TypeError) as excinfo:
         t.map_copyable_in_value({1:2})
     assert 'incompatible function arguments' in str(excinfo.value)
 
-def test58_set_return_value(clean):
+def test60_set_return_value():
     for i, k in enumerate(sorted(t.set_return_value())):
         assert k == chr(ord("a") + i)
     for i, k in enumerate(sorted(t.unordered_set_return_value())):
@@ -551,7 +582,7 @@ def test58_set_return_value(clean):
     assert t.unordered_set_return_value.__doc__ == (
         "unordered_set_return_value() -> set[str]")
 
-def test59_set_in_value(clean):
+def test61_set_in_value():
     t.set_in_value(set([chr(ord("a") + i) for i in range(10)]))
     t.unordered_set_in_value(set([chr(ord("a") + i) for i in range(10)]))
     assert t.set_in_value.__doc__ == (
@@ -559,19 +590,19 @@ def test59_set_in_value(clean):
     assert t.unordered_set_in_value.__doc__ == (
         "unordered_set_in_value(x: set[str]) -> None")
 
-def test60_set_in_lvalue_ref(clean):
+def test62_set_in_lvalue_ref():
     t.set_in_lvalue_ref(set([chr(ord("a") + i) for i in range(10)]))
     assert t.set_in_lvalue_ref.__doc__ == (
         "set_in_lvalue_ref(x: set[str]) -> None"
     )
 
-def test61_set_in_rvalue_ref(clean):
+def test63_set_in_rvalue_ref():
     t.set_in_rvalue_ref(set([chr(ord("a") + i) for i in range(10)]))
     assert t.set_in_rvalue_ref.__doc__ == (
         "set_in_rvalue_ref(x: set[str]) -> None"
     )
 
-def test62_set_in_failure(clean):
+def test64_set_in_failure():
     with pytest.raises(TypeError) as excinfo:
         t.set_in_value(set([i for i in range(10)]))
     assert 'incompatible function arguments' in str(excinfo.value)


### PR DESCRIPTION
This commit adds:

- Roundtrip support! When a Python function has been wrapped in a ``std::function<>``, subsequent conversion to a Python object will return the original Python function object.

  Note that this is the opposite of pybind11's ``std::function<>`` caster, where roundtrip support is implemented for C function pointers (which isn't possible in nanobind currently, and seems less useful in retrospect).

- Building on the previous point, the following C++ snippet
   ```cpp
   nb::object o = nb::cast(std_function_instance, nb::rv_policy::none); 
   ```
   can be used to attempt a conversion of a ``std::function<>`` instance into a Python object. This will either return the function object or an invalid (``!o.is_valid()``) object if the conversion fails.

What is the point of these changes? A useful feature of nanobind is that one can set callback methods on bound C++ instances that redirect control flow back to Python.

```python
a = MyCppClass()
a.f = lambda x: ...
```

A major potential issue here are reference leaks. What if the lambda function assigned to ``a.f`` captures some variables from the surrounding environment, which in turn reference the instance `a`? Then we have a reference cycle that spans the Python <-> C++ boundary, and that whole set of objects will never be deleted.

Fortunately, Python provides a garbage collector that can collect such cycles, but we must provide it with further information so that it can properly do its job. It must be able to traverse the C++ instance to discover contained Python objects.

Below is a fully worked out example that realizes such a traversal using the newly added features.

```cpp
// Type definition
struct MyCppClass {
    // A callback function that could be implemented in either language
    std::function<void(void>) f;
};

// Traversal method that may be invoked by Python's cyclic GC
int mycppclass_tp_traverse(PyObject *self, visitproc visit, void *arg) {
    MyCppClass *m = nb::cast<MyCppClass *>(nb::handle(self));
    if (m) {
        nb::object f = nb::cast(m->f, nb::rv_policy::none);

        // If 'f' is a Python function object, then traverse it recursively
        if (f.is_valid())
            Py_VISIT(f.ptr());
    }

    return 0;
};

// Callback to register additional type slots in the bindings
void mycppclass_type_callback = [](PyType_Slot **s) noexcept {
    *(*s)++ = { Py_tp_traverse, (void *) mycppclass_tp_traverse };
};

// .. binding code ...
nb::class_<MyCppClass>(m, "MyCppClass", nb::type_callback(mycppclass_type_callback))
    .def(nb::init<>())
    .def_readwrite("f", & MyCppClass::f);
```

This commit also adds an example of such a cycle to the test suite, which will fail if it cannot be garbage-collected.