### PR TITLE
PEP 585 generics in type names

### DIFF
--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -86,8 +86,16 @@
 
 #if PY_VERSION_HEX < 0x03090000
 #  define NB_INTERPRETER_STATE_GET _PyInterpreterState_Get
+#  define NB_TYPING_DICT "Dict"
+#  define NB_TYPING_SET "Set"
+#  define NB_TYPING_TUPLE "Tuple"
+#  define NB_TYPING_TYPE "Type"
 #else
 #  define NB_INTERPRETER_STATE_GET PyInterpreterState_Get
+#  define NB_TYPING_DICT "dict"
+#  define NB_TYPING_SET "set"
+#  define NB_TYPING_TUPLE "tuple"
+#  define NB_TYPING_TYPE "type"
 #endif
 
 #if defined(Py_LIMITED_API)

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -513,7 +513,7 @@ public:
 
 template <typename T> class type_object_t : public type_object {
 public:
-    static constexpr auto Name = detail::const_name("type[") +
+    static constexpr auto Name = detail::const_name(NB_TYPING_TYPE "[") +
                                  detail::make_caster<T>::Name +
                                  detail::const_name("]");
 

--- a/include/nanobind/stl/detail/nb_dict.h
+++ b/include/nanobind/stl/detail/nb_dict.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
 template <typename Value_, typename Key, typename Element> struct dict_caster {
-    NB_TYPE_CASTER(Value_, const_name("dict[") + make_caster<Key>::Name +
+    NB_TYPE_CASTER(Value_, const_name(NB_TYPING_DICT "[") + make_caster<Key>::Name +
                                const_name(", ") + make_caster<Element>::Name +
                                const_name("]"));
 

--- a/include/nanobind/stl/detail/nb_set.h
+++ b/include/nanobind/stl/detail/nb_set.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
 template <typename Value_, typename Key> struct set_caster {
-    NB_TYPE_CASTER(Value_, const_name("set[") + make_caster<Key>::Name + const_name("]"));
+    NB_TYPE_CASTER(Value_, const_name(NB_TYPING_SET "[") + make_caster<Key>::Name + const_name("]"));
 
     using KeyCaster = make_caster<Key>;
 

--- a/include/nanobind/stl/pair.h
+++ b/include/nanobind/stl/pair.h
@@ -42,7 +42,7 @@ template <typename T1, typename T2> struct type_caster<std::pair<T1, T2>> {
 
     // Value name for docstring generation
     static constexpr auto Name =
-        const_name("tuple[") + concat(Caster1::Name, Caster2::Name) + const_name("]");
+        const_name(NB_TYPING_TUPLE "[") + concat(Caster1::Name, Caster2::Name) + const_name("]");
 
     /// Python -> C++ caster, populates `caster1` and `caster2` upon success
     bool from_python(handle src, uint8_t flags,

--- a/include/nanobind/stl/tuple.h
+++ b/include/nanobind/stl/tuple.h
@@ -23,7 +23,7 @@ template <typename... Ts> struct type_caster<std::tuple<Ts...>> {
     using Indices = std::make_index_sequence<N>;
 
     static constexpr bool IsClass = false;
-    static constexpr auto Name = const_name("tuple[") +
+    static constexpr auto Name = const_name(NB_TYPING_TUPLE "[") +
                                  concat(make_caster<Ts>::Name...) +
                                  const_name("]");
 

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,3 +1,4 @@
+import sys
 import test_classes_ext as t
 import pytest
 import gc
@@ -444,7 +445,11 @@ def test22_handle_t(clean):
 
 
 def test23_type_object_t(clean):
-    assert t.test_type_object_t.__doc__ == 'test_type_object_t(arg: type[test_classes_ext.Struct], /) -> object'
+    if sys.version_info < (3, 9):
+        assert t.test_type_object_t.__doc__ == 'test_type_object_t(arg: Type[test_classes_ext.Struct], /) -> object'
+    else:
+        assert t.test_type_object_t.__doc__ == 'test_type_object_t(arg: type[test_classes_ext.Struct], /) -> object'
+
     assert t.test_type_object_t(t.Struct) is t.Struct
 
     with pytest.raises(TypeError):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -51,9 +51,14 @@ def test05_signature():
         "\n"
         "doc_2")
 
-    assert t.test_07.__doc__ == (
-        "test_07(arg0: int, arg1: int, /, *args, **kwargs) -> tuple[int, int]\n"
-        "test_07(a: int, b: int, *myargs, **mykwargs) -> tuple[int, int]")
+    if sys.version_info < (3, 9):
+        assert t.test_07.__doc__ == (
+            "test_07(arg0: int, arg1: int, /, *args, **kwargs) -> Tuple[int, int]\n"
+            "test_07(a: int, b: int, *myargs, **mykwargs) -> Tuple[int, int]")
+    else:
+        assert t.test_07.__doc__ == (
+            "test_07(arg0: int, arg1: int, /, *args, **kwargs) -> tuple[int, int]\n"
+            "test_07(a: int, b: int, *myargs, **mykwargs) -> tuple[int, int]")
 
 def test06_signature_error():
     with pytest.raises(TypeError) as excinfo:

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -1,6 +1,7 @@
 import test_stl_ext as t
 import pytest
 import gc
+import sys
 
 @pytest.fixture
 def clean():
@@ -508,47 +509,82 @@ def test50_map_return_movable_value():
     for i, (k, v) in enumerate(sorted(t.map_return_movable_value().items())):
         assert k == chr(ord("a") + i)
         assert v.value == i
-    assert t.map_return_movable_value.__doc__ == (
-        "map_return_movable_value() -> dict[str, test_stl_ext.Movable]"
-    )
+    if sys.version_info < (3, 9):
+        assert t.map_return_movable_value.__doc__ == (
+            "map_return_movable_value() -> Dict[str, test_stl_ext.Movable]"
+        )
+    else:
+        assert t.map_return_movable_value.__doc__ == (
+            "map_return_movable_value() -> dict[str, test_stl_ext.Movable]"
+        )
 
 def test51_map_return_copyable_value():
     for i, (k, v) in enumerate(sorted(t.map_return_copyable_value().items())):
         assert k == chr(ord("a") + i)
         assert v.value == i
-    assert t.map_return_copyable_value.__doc__ == (
-        "map_return_copyable_value() -> dict[str, test_stl_ext.Copyable]"
-    )
+    if sys.version_info < (3, 9):
+        assert t.map_return_copyable_value.__doc__ == (
+            "map_return_copyable_value() -> Dict[str, test_stl_ext.Copyable]"
+        )
+    else:
+        assert t.map_return_copyable_value.__doc__ == (
+            "map_return_copyable_value() -> dict[str, test_stl_ext.Copyable]"
+        )
 
 def test52_map_movable_in_value():
     t.map_movable_in_value(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
-    assert t.map_movable_in_value.__doc__ == (
-        "map_movable_in_value(x: dict[str, test_stl_ext.Movable]) -> None"
-    )
+    if sys.version_info < (3, 9):
+        assert t.map_movable_in_value.__doc__ == (
+            "map_movable_in_value(x: Dict[str, test_stl_ext.Movable]) -> None"
+        )
+    else:
+        assert t.map_movable_in_value.__doc__ == (
+            "map_movable_in_value(x: dict[str, test_stl_ext.Movable]) -> None"
+        )
 
 def test53_map_copyable_in_value():
     t.map_copyable_in_value(dict([(chr(ord("a") + i), t.Copyable(i)) for i in range(10)]))
-    assert t.map_copyable_in_value.__doc__ == (
-        "map_copyable_in_value(x: dict[str, test_stl_ext.Copyable]) -> None"
-    )
+    if sys.version_info < (3, 9):
+        assert t.map_copyable_in_value.__doc__ == (
+            "map_copyable_in_value(x: Dict[str, test_stl_ext.Copyable]) -> None"
+        )
+    else:
+        assert t.map_copyable_in_value.__doc__ == (
+            "map_copyable_in_value(x: dict[str, test_stl_ext.Copyable]) -> None"
+        )
 
 def test54_map_movable_in_lvalue_ref():
     t.map_movable_in_lvalue_ref(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
-    assert t.map_movable_in_lvalue_ref.__doc__ == (
-        "map_movable_in_lvalue_ref(x: dict[str, test_stl_ext.Movable]) -> None"
-    )
+    if sys.version_info < (3, 9):
+        assert t.map_movable_in_lvalue_ref.__doc__ == (
+            "map_movable_in_lvalue_ref(x: Dict[str, test_stl_ext.Movable]) -> None"
+        )
+    else:
+        assert t.map_movable_in_lvalue_ref.__doc__ == (
+            "map_movable_in_lvalue_ref(x: dict[str, test_stl_ext.Movable]) -> None"
+        )
 
 def test55_map_movable_in_rvalue_ref():
     t.map_movable_in_rvalue_ref(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
-    assert t.map_movable_in_rvalue_ref.__doc__ == (
-        "map_movable_in_rvalue_ref(x: dict[str, test_stl_ext.Movable]) -> None"
-    )
+    if sys.version_info < (3, 9):
+        assert t.map_movable_in_rvalue_ref.__doc__ == (
+            "map_movable_in_rvalue_ref(x: Dict[str, test_stl_ext.Movable]) -> None"
+        )
+    else:
+        assert t.map_movable_in_rvalue_ref.__doc__ == (
+            "map_movable_in_rvalue_ref(x: dict[str, test_stl_ext.Movable]) -> None"
+        )
 
 def test56_map_movable_in_ptr():
     t.map_movable_in_ptr(dict([(chr(ord("a") + i), t.Movable(i)) for i in range(10)]))
-    assert t.map_movable_in_ptr.__doc__ == (
-        "map_movable_in_ptr(x: dict[str, test_stl_ext.Movable]) -> None"
-    )
+    if sys.version_info < (3, 9):
+        assert t.map_movable_in_ptr.__doc__ == (
+            "map_movable_in_ptr(x: Dict[str, test_stl_ext.Movable]) -> None"
+        )
+    else:
+        assert t.map_movable_in_ptr.__doc__ == (
+            "map_movable_in_ptr(x: dict[str, test_stl_ext.Movable]) -> None"
+        )
 
 def test57_map_return_readonly_value():
     for i, (k, v) in enumerate(sorted(t.map_return_readonly_value().map.items())):
@@ -577,30 +613,52 @@ def test60_set_return_value():
         assert k == chr(ord("a") + i)
     for i, k in enumerate(sorted(t.unordered_set_return_value())):
         assert k == chr(ord("a") + i)
-    assert t.set_return_value.__doc__ == (
-        "set_return_value() -> set[str]")
-    assert t.unordered_set_return_value.__doc__ == (
-        "unordered_set_return_value() -> set[str]")
+    if sys.version_info < (3, 9):
+        assert t.set_return_value.__doc__ == (
+            "set_return_value() -> Set[str]")
+        assert t.unordered_set_return_value.__doc__ == (
+            "unordered_set_return_value() -> Set[str]")
+    else:
+        assert t.set_return_value.__doc__ == (
+            "set_return_value() -> set[str]")
+        assert t.unordered_set_return_value.__doc__ == (
+            "unordered_set_return_value() -> set[str]")
 
 def test61_set_in_value():
     t.set_in_value(set([chr(ord("a") + i) for i in range(10)]))
     t.unordered_set_in_value(set([chr(ord("a") + i) for i in range(10)]))
-    assert t.set_in_value.__doc__ == (
-        "set_in_value(x: set[str]) -> None")
-    assert t.unordered_set_in_value.__doc__ == (
-        "unordered_set_in_value(x: set[str]) -> None")
+    if sys.version_info < (3, 9):
+        assert t.set_in_value.__doc__ == (
+            "set_in_value(x: Set[str]) -> None")
+        assert t.unordered_set_in_value.__doc__ == (
+            "unordered_set_in_value(x: Set[str]) -> None")
+    else:
+        assert t.set_in_value.__doc__ == (
+            "set_in_value(x: set[str]) -> None")
+        assert t.unordered_set_in_value.__doc__ == (
+            "unordered_set_in_value(x: set[str]) -> None")
 
 def test62_set_in_lvalue_ref():
     t.set_in_lvalue_ref(set([chr(ord("a") + i) for i in range(10)]))
-    assert t.set_in_lvalue_ref.__doc__ == (
-        "set_in_lvalue_ref(x: set[str]) -> None"
-    )
+    if sys.version_info < (3, 9):
+        assert t.set_in_lvalue_ref.__doc__ == (
+            "set_in_lvalue_ref(x: Set[str]) -> None"
+        )
+    else:
+        assert t.set_in_lvalue_ref.__doc__ == (
+            "set_in_lvalue_ref(x: set[str]) -> None"
+        )
 
 def test63_set_in_rvalue_ref():
     t.set_in_rvalue_ref(set([chr(ord("a") + i) for i in range(10)]))
-    assert t.set_in_rvalue_ref.__doc__ == (
-        "set_in_rvalue_ref(x: set[str]) -> None"
-    )
+    if sys.version_info < (3, 9):
+        assert t.set_in_rvalue_ref.__doc__ == (
+            "set_in_rvalue_ref(x: Set[str]) -> None"
+        )
+    else:
+        assert t.set_in_rvalue_ref.__doc__ == (
+            "set_in_rvalue_ref(x: set[str]) -> None"
+        )
 
 def test64_set_in_failure():
     with pytest.raises(TypeError) as excinfo:


### PR DESCRIPTION
This is a very minor change: this PR unifies the type names of collection types appearing in STL casters, depending on the Python version.  
According to the [PEP 585](https://peps.python.org/pep-0585/), Python 3.9 or later allows built-in collection types to be used for type annotations.