### PR TITLE
Add support for making nanobind classes weak-referenceable.

### DIFF
--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -48,6 +48,7 @@ template <typename... Ts> struct call_guard {
 };
 
 struct dynamic_attr {};
+struct weak_referenceable {};
 struct is_method {};
 struct is_implicit {};
 struct is_operator {};

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -72,7 +72,11 @@ enum class type_flags : uint32_t {
     intrusive_ptr            = (1 << 20),
 
     /// Is this a trampoline class meant to be overloaded in Python?
-    is_trampoline            = (1 << 21)
+    is_trampoline            = (1 << 21),
+
+    /// Instances of this type support weak references.
+    is_weak_referenceable    = (1 << 22),
+
 };
 
 struct type_data {
@@ -96,6 +100,7 @@ struct type_data {
     void (*set_self_py)(void *, PyObject *) noexcept;
 #if defined(Py_LIMITED_API)
     size_t dictoffset;
+    size_t weaklistoffset;
 #endif
 };
 
@@ -137,6 +142,10 @@ NB_INLINE void type_extra_apply(type_data &t, is_arithmetic) {
 
 NB_INLINE void type_extra_apply(type_data &t, dynamic_attr) {
     t.flags |= (uint32_t) type_flags::has_dynamic_attr;
+}
+
+NB_INLINE void type_extra_apply(type_data &t, weak_referenceable) {
+    t.flags |= (uint32_t) type_flags::is_weak_referenceable;
 }
 
 template <typename T>

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -424,4 +424,13 @@ NB_MODULE(test_classes_ext, m) {
     nb::class_<Wrapper>(m, "Wrapper", nb::type_slots(wrapper_slots))
         .def(nb::init<>())
         .def_readwrite("value", &Wrapper::value);
+
+    // test32_weak_referenceable
+    struct StructWithWeakrefs : Struct { };
+    nb::class_<StructWithWeakrefs, Struct>(m, "StructWithWeakrefs", nb::weak_referenceable())
+        .def(nb::init<int>());
+    struct StructWithWeakrefsAndDynamicAttrs : Struct { };
+    nb::class_<StructWithWeakrefsAndDynamicAttrs, Struct>(m, "StructWithWeakrefsAndDynamicAttrs",
+               nb::weak_referenceable(), nb::dynamic_attr())
+        .def(nb::init<int>());
 }

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,4 +1,6 @@
+import gc
 import sys
+import weakref
 import test_classes_ext as t
 import pytest
 from common import skip_on_pypy, collect
@@ -545,3 +547,22 @@ def test31_cycle():
     a = t.Wrapper()
     a.value = a
     del a
+
+
+def test32_weak_references():
+    o = t.StructWithWeakrefs(42)
+    w = weakref.ref(o)
+    assert w() is o
+    del o
+    gc.collect()
+    assert w() is None
+
+    p = t.StructWithWeakrefsAndDynamicAttrs(43)
+    p.a_dynamic_attr = 101
+    w = weakref.ref(p)
+    assert w() is p
+    assert w().a_dynamic_attr == 101
+    del p
+    gc.collect()
+    assert w() is None
+


### PR DESCRIPTION
Adds an optional nb::weak_referenceable attribute. If present, we allow space for a weak reference list in the object and set tp_weaklistoffset.

This change incorporates the changes from https://github.com/wjakob/nanobind/pull/99