### PR TITLE
Add missing cstdio header from tests/object.cpp.

### DIFF
--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -1,4 +1,5 @@
 #include "object.h"
+#include <cstdio>
 #include <stdexcept>
 
 static void (*object_inc_ref_py)(PyObject *) noexcept = nullptr;


### PR DESCRIPTION
This file uses `fprintf`, and it should include what it uses.