### PR TITLE
Add failing tests with tensor default arguments

### DIFF
--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -8,6 +8,9 @@ using namespace nb::literals;
 
 int destruct_count = 0;
 
+const size_t default_shape[1] = {3};
+int default_content[3] = {42, 43, 44};
+
 NB_MODULE(test_tensor_ext, m) {
     m.def("get_shape", [](const nb::tensor<> &t) {
         nb::list l;
@@ -137,4 +140,19 @@ NB_MODULE(test_tensor_ext, m) {
 
             return nb::tensor<nb::numpy, float>(f, 0, shape, deleter);
         });
+
+    m.def("default_valid", [](const nb::tensor<nb::numpy> &t) {
+        return t;
+    }, "array"_a = nb::tensor<nb::numpy, int, nb::shape<3>>(default_content, 1,
+                                                            default_shape));
+
+    // Enabling this binding yields a segmentation fault when loading it.
+    //m.def("default_invalid", [](const nb::tensor<> &t) {
+    //    return t.is_valid();
+    //}, "array"_a.none() = nb::tensor<>());
+
+    m.def("default_none", [](const nb::tensor<> &t) {
+        return t.is_valid();
+    }, "array"_a = nb::none());
+
 }

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -327,6 +327,7 @@ def test17_return_pytorch():
     collect()
     assert t.destruct_count() - dc == 1
 
+
 @needs_numpy
 def test18_return_array_scalar():
     collect()
@@ -336,3 +337,36 @@ def test18_return_array_scalar():
     del x
     collect()
     assert t.destruct_count() - dc == 1
+
+
+@needs_numpy
+@pytest.mark.skip("Unexpected 'incompatible function arguments' error.")
+def test19_default_valid():
+    collect()
+    a = t.default_valid(np.array([[1, 2]]))
+    assert np.all(a == [[1, 2]])
+    collect()
+    a = t.default_valid()
+    assert np.all(a == [42, 43, 44])
+
+
+@needs_numpy
+@pytest.mark.skip("Binding is disabled due to a segfault")
+def test20_default_invalid():
+    collect()
+    valid = t.default_invalid(np.array([0]))
+    assert valid == True
+    collect()
+    valid = t.default_invalid()
+    assert valid == False
+
+
+@needs_numpy
+@pytest.mark.skip("Unexpected 'incompatible function arguments' error.")
+def test21_default_none():
+    collect()
+    valid = t.default_none(np.array([0]))
+    assert valid == True
+    collect()
+    valid = t.default_none()
+    assert valid == False


### PR DESCRIPTION
While trying out replacing pybind11 by nanobind, I noticed that using default values for tensor arguments does not work. I also found no tests for this feature.

This MR adds some (disabled) tests. Please let me know if the tests are correct, and if not, please let me know how to use default tensor argument values.