### PR TITLE
Add compile-time variable to suppress leak warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ improvements for developers:
 - When the python interpreter shuts down, _nanobind_ reports instance, type,
   and function leaks related to bindings, which is useful for tracking down
   reference counting issues.  
-  If these warnings are undesired, define the variable `NB_SUPPRESS_LEAK_WARN`
-  during compilation of the nanobind module.
+  If these warnings are undesired, call `nb::set_leak_warnings(false)` from
+  any one of the loaded extension modules.
 
 - _nanobind_ deletes its internal data structures when the Python interpreter
   terminates, which avoids memory leak reports in tools like _valgrind_.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ improvements for developers:
 
 - When the python interpreter shuts down, _nanobind_ reports instance, type,
   and function leaks related to bindings, which is useful for tracking down
-  reference counting issues.
+  reference counting issues.  
+  If these warnings are undesired, define the variable `NB_SUPPRESS_LEAK_WARN`
+  during compilation of the nanobind module.
 
 - _nanobind_ deletes its internal data structures when the Python interpreter
   terminates, which avoids memory leak reports in tools like _valgrind_.

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -408,7 +408,7 @@ NB_CORE void decref_checked(PyObject *o) noexcept;
 
 // ========================================================================
 
-void set_leak_warnings(bool print_leak_warnings) noexcept;
+NB_CORE void set_leak_warnings(bool print_leak_warnings) noexcept;
 
 NAMESPACE_END(detail)
 NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -398,5 +398,9 @@ NB_CORE bool load_u64(PyObject *o, uint8_t flags, uint64_t *out) noexcept;
 NB_CORE bool load_f32(PyObject *o, uint8_t flags, float *out) noexcept;
 NB_CORE bool load_f64(PyObject *o, uint8_t flags, double *out) noexcept;
 
+// ========================================================================
+
+void set_leak_warnings(bool print_leak_warnings) noexcept;
+
 NAMESPACE_END(detail)
 NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/nb_misc.h
+++ b/include/nanobind/nb_misc.h
@@ -54,4 +54,6 @@ template <typename T> struct deleter {
     PyObject *o{nullptr};
 };
 
+void set_leak_warnings(bool print_leak_warnings) noexcept;
+
 NAMESPACE_END(NB_NAMESPACE)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -870,7 +870,7 @@ NAMESPACE_END(detail)
 // ========================================================================
 
 void set_leak_warnings(bool print_leak_warnings) noexcept {
-    const nb_internals &internals = internals_get();
+    const detail::nb_internals &internals = internals_get();
     internals.print_leak_warnings = print_leak_warnings;
 }
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -866,4 +866,14 @@ bool load_i64(PyObject *o, uint8_t flags, int64_t *out) noexcept {
 }
 
 NAMESPACE_END(detail)
+
+// ========================================================================
+
+void set_leak_warnings(bool print_leak_warnings) noexcept {
+    const nb_internals &internals = internals_get();
+    internals.print_leak_warnings = print_leak_warnings;
+}
+
+// ========================================================================
+
 NAMESPACE_END(NB_NAMESPACE)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -865,15 +865,17 @@ bool load_i64(PyObject *o, uint8_t flags, int64_t *out) noexcept {
     return load_int(o, flags, out);
 }
 
-NAMESPACE_END(detail)
-
 // ========================================================================
 
 void set_leak_warnings(bool print_leak_warnings) noexcept {
-    const detail::nb_internals &internals = internals_get();
+    nb_internals &internals = internals_get();
     internals.print_leak_warnings = print_leak_warnings;
 }
 
-// ========================================================================
+NAMESPACE_END(detail)
+
+void set_leak_warnings(bool print_leak_warnings) noexcept {
+    detail::set_leak_warnings(print_leak_warnings);
+}
 
 NAMESPACE_END(NB_NAMESPACE)

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -325,18 +325,23 @@ static void internals_cleanup() {
     bool leak = false;
 
     if (!internals_p->inst_c2p.empty()) {
+#if !defined(NB_SUPPRESS_LEAK_WARN)
         fprintf(stderr, "nanobind: leaked %zu instances!\n",
                 internals_p->inst_c2p.size());
+#endif
         leak = true;
     }
 
     if (!internals_p->keep_alive.empty()) {
+#if !defined(NB_SUPPRESS_LEAK_WARN)
         fprintf(stderr, "nanobind: leaked %zu keep_alive records!\n",
                 internals_p->keep_alive.size());
+#endif
         leak = true;
     }
 
     if (!internals_p->type_c2p.empty()) {
+#if !defined(NB_SUPPRESS_LEAK_WARN)
         fprintf(stderr, "nanobind: leaked %zu types!\n",
                 internals_p->type_c2p.size());
         int ctr = 0;
@@ -347,10 +352,12 @@ static void internals_cleanup() {
                 break;
             }
         }
+#endif
         leak = true;
     }
 
     if (!internals_p->funcs.empty()) {
+#if !defined(NB_SUPPRESS_LEAK_WARN)
         fprintf(stderr, "nanobind: leaked %zu functions!\n",
                 internals_p->funcs.size());
         int ctr = 0;
@@ -362,6 +369,7 @@ static void internals_cleanup() {
                 break;
             }
         }
+#endif
         leak = true;
     }
 
@@ -369,8 +377,10 @@ static void internals_cleanup() {
         delete internals_p;
         internals_p = nullptr;
     } else {
+#if !defined(NB_SUPPRESS_LEAK_WARN)
         fprintf(stderr, "nanobind: this is likely caused by a reference "
                         "counting issue in the binding code.\n");
+#endif
 
 #if NB_ABORT_ON_LEAK == 1
         abort(); // Extra-strict behavior for the CI server

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -325,51 +325,51 @@ static void internals_cleanup() {
     bool leak = false;
 
     if (!internals_p->inst_c2p.empty()) {
-#if !defined(NB_SUPPRESS_LEAK_WARN)
-        fprintf(stderr, "nanobind: leaked %zu instances!\n",
-                internals_p->inst_c2p.size());
-#endif
+        if (internals_p->print_leak_warnings) {
+            fprintf(stderr, "nanobind: leaked %zu instances!\n",
+                    internals_p->inst_c2p.size());
+        }
         leak = true;
     }
 
     if (!internals_p->keep_alive.empty()) {
-#if !defined(NB_SUPPRESS_LEAK_WARN)
-        fprintf(stderr, "nanobind: leaked %zu keep_alive records!\n",
-                internals_p->keep_alive.size());
-#endif
+        if (internals_p->print_leak_warnings) {
+            fprintf(stderr, "nanobind: leaked %zu keep_alive records!\n",
+                    internals_p->keep_alive.size());
+        }
         leak = true;
     }
 
     if (!internals_p->type_c2p.empty()) {
-#if !defined(NB_SUPPRESS_LEAK_WARN)
-        fprintf(stderr, "nanobind: leaked %zu types!\n",
-                internals_p->type_c2p.size());
-        int ctr = 0;
-        for (const auto &kv : internals_p->type_c2p) {
-            fprintf(stderr, " - leaked type \"%s\"\n", kv.second->name);
-            if (ctr++ == 10) {
-                fprintf(stderr, " - ... skipped remainder\n");
-                break;
+        if (internals_p->print_leak_warnings) {
+            fprintf(stderr, "nanobind: leaked %zu types!\n",
+                    internals_p->type_c2p.size());
+            int ctr = 0;
+            for (const auto &kv : internals_p->type_c2p) {
+                fprintf(stderr, " - leaked type \"%s\"\n", kv.second->name);
+                if (ctr++ == 10) {
+                    fprintf(stderr, " - ... skipped remainder\n");
+                    break;
+                }
             }
         }
-#endif
         leak = true;
     }
 
     if (!internals_p->funcs.empty()) {
-#if !defined(NB_SUPPRESS_LEAK_WARN)
-        fprintf(stderr, "nanobind: leaked %zu functions!\n",
-                internals_p->funcs.size());
-        int ctr = 0;
-        for (void *f : internals_p->funcs) {
-            fprintf(stderr, " - leaked function \"%s\"\n",
-                    nb_func_data(f)->name);
-            if (ctr++ == 10) {
-                fprintf(stderr, " - ... skipped remainder\n");
-                break;
+        if (internals_p->print_leak_warnings) {
+            fprintf(stderr, "nanobind: leaked %zu functions!\n",
+                    internals_p->funcs.size());
+            int ctr = 0;
+            for (void *f : internals_p->funcs) {
+                fprintf(stderr, " - leaked function \"%s\"\n",
+                        nb_func_data(f)->name);
+                if (ctr++ == 10) {
+                    fprintf(stderr, " - ... skipped remainder\n");
+                    break;
+                }
             }
         }
-#endif
         leak = true;
     }
 
@@ -377,10 +377,10 @@ static void internals_cleanup() {
         delete internals_p;
         internals_p = nullptr;
     } else {
-#if !defined(NB_SUPPRESS_LEAK_WARN)
-        fprintf(stderr, "nanobind: this is likely caused by a reference "
-                        "counting issue in the binding code.\n");
-#endif
+        if (internals_p->print_leak_warnings) {
+            fprintf(stderr, "nanobind: this is likely caused by a reference "
+                            "counting issue in the binding code.\n");
+        }
 
 #if NB_ABORT_ON_LEAK == 1
         abort(); // Extra-strict behavior for the CI server

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -200,6 +200,9 @@ struct nb_internals {
 
     /// Registered C++ -> Python exception translators
     std::vector<std::pair<exception_translator, void *>> exception_translators;
+
+    /// Boolean specifying whether to print leak warnings on exit
+    bool print_leak_warnings{true};
 };
 
 struct current_method {


### PR DESCRIPTION
The reasoning behind this is as follows:

In our project, we again ran into a reference-counting issue, which isn't caused by our own extension library, but most likely caused by the PyTorch extension library, see here: https://github.com/tingyu66/nanobind_example/commit/8629419b6ffa4416d4f3e5cb99f9a6731359cb32

We don't have the bandwidth/time to investigate all these issues in other libraries, and in general, we have no control over what other extension libraries our end users run the library with.
In order to avoid bothering users with leak reports, this PR adds a mechanism to suppress leak reports which would be used for builds distributed to end users.
Of course by default, we keep the leak reports on, in order to catch these during development, as well as in our own CI.