### PR TITLE
Fix file name typos in include copyright headers

### DIFF
--- a/include/nanobind/nb_enums.h
+++ b/include/nanobind/nb_enums.h
@@ -1,5 +1,5 @@
 /*
-    nanobind/nb_enum.h: enumerations used in nanobind (just rv_policy atm.)
+    nanobind/nb_enums.h: enumerations used in nanobind (just rv_policy atm.)
 
     Copyright (c) 2022 Wenzel Jakob
 

--- a/include/nanobind/stl/detail/nb_dict.h
+++ b/include/nanobind/stl/detail/nb_dict.h
@@ -1,5 +1,5 @@
 /*
-    nanobind/stl/details/nb_dict.h: base class of dict casters
+    nanobind/stl/detail/nb_dict.h: base class of dict casters
 
     Copyright (c) 2022 Matej Ferencevic and Wenzel Jakob
 

--- a/include/nanobind/stl/detail/nb_list.h
+++ b/include/nanobind/stl/detail/nb_list.h
@@ -1,5 +1,5 @@
 /*
-    nanobind/stl/details/nb_list.h: base class of list casters
+    nanobind/stl/detail/nb_list.h: base class of list casters
 
     Copyright (c) 2022 Wenzel Jakob
 

--- a/include/nanobind/stl/detail/nb_set.h
+++ b/include/nanobind/stl/detail/nb_set.h
@@ -1,5 +1,5 @@
 /*
-    nanobind/stl/details/nb_set.h: base class of set casters
+    nanobind/stl/detail/nb_set.h: base class of set casters
 
     Copyright (c) 2022 Raymond Yun Fei and Wenzel Jakob
 

--- a/include/nanobind/stl/list.h
+++ b/include/nanobind/stl/list.h
@@ -1,5 +1,5 @@
 /*
-    nanobind/stl/function.h: type caster for std::list<...>
+    nanobind/stl/list.h: type caster for std::list<...>
 
     Copyright (c) 2022 Wenzel Jakob
 


### PR DESCRIPTION
Fixes wrong paths/file names in some of nanobind's include copyright headers.