### PR TITLE
Add `nb::bind_map`

### DIFF
--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -239,6 +239,9 @@ template <op_id id, op_type ot, typename L = undefined_t, typename R = undefined
 template <typename T, typename SFINAE = int>
 struct is_copy_constructible : std::is_copy_constructible<T> { };
 
+template <typename T>
+constexpr bool is_copy_constructible_v = is_copy_constructible<T>::value;
+
 NAMESPACE_END(detail)
 
 template <typename T, typename... Ts>
@@ -275,7 +278,7 @@ public:
         if constexpr (!std::is_same_v<Alias, T>)
             d.flags |= (uint32_t) detail::type_flags::is_trampoline;
 
-        if constexpr (detail::is_copy_constructible<T>::value) {
+        if constexpr (detail::is_copy_constructible_v<T>) {
             d.flags |= (uint32_t) detail::type_flags::is_copy_constructible;
 
             if constexpr (!std::is_trivially_copy_constructible_v<T>) {

--- a/include/nanobind/stl/bind_map.h
+++ b/include/nanobind/stl/bind_map.h
@@ -1,0 +1,301 @@
+/*
+    nanobind/stl/bind_map.h: nb::bind_map()
+
+    This implementation is a port from pybind11 with minimal adjustments.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+#include <nanobind/make_iterator.h>
+#include <nanobind/stl/unique_ptr.h> // TODO: Opt out of unique_ptr (used for returning key/value views)?
+#include <nanobind/stl/string.h>     // TODO: Opt out of string (used for constructing "(Keys|Values|Items)View[type]"-style names to bind to the module scope)
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+// only available since C++20
+using std::remove_cv_t;
+using std::remove_reference_t;
+
+template <class T>
+struct remove_cvref
+{
+    using type = remove_cv_t<remove_reference_t<T>>;
+};
+template <class T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
+template <typename, typename, typename... Args>
+void map_if_insertion_operator(const Args &...) {}
+template <typename, typename, typename... Args>
+void map_assignment(const Args &...) {}
+
+// Map assignment when copy-assignable: just copy the value
+template <typename Map, typename Class_>
+void map_assignment(
+    std::enable_if_t<std::is_copy_assignable<typename Map::mapped_type>::value, Class_> &cl)
+{
+    using KeyType = typename Map::key_type;
+    using MappedType = typename Map::mapped_type;
+
+    cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v)
+           {
+    auto it = m.find(k);
+    if (it != m.end()) {
+      it->second = v;
+    } else {
+      m.emplace(k, v);
+    } });
+}
+
+// Not copy-assignable, but still copy-constructible: we can update the value by
+// erasing and reinserting
+template <typename Map, typename Class_>
+void map_assignment(
+    std::enable_if_t<!std::is_copy_assignable<typename Map::mapped_type>::value &&
+                         std::is_copy_constructible<typename Map::mapped_type>::value,
+                     Class_> &cl)
+{
+    using KeyType = typename Map::key_type;
+    using MappedType = typename Map::mapped_type;
+
+    cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v)
+           {
+    // We can't use m[k] = v; because value type might not be default
+    // constructable
+    auto r = m.emplace(k, v);
+    if (!r.second) {
+      // value type is not copy assignable so the only way to insert it is to
+      // erase it first...
+      m.erase(r.first);
+      m.emplace(k, v);
+    } });
+}
+
+// template KeysView, ValuesView and ItemsView on their key type, so as
+// to bind different keys views for different key types
+template <typename KeyType>
+struct keys_view
+{
+    virtual size_t len() = 0;
+    virtual iterator iter() = 0;
+    virtual bool contains(const KeyType &k) = 0;
+    virtual bool contains(const object &k) = 0;
+    virtual ~keys_view() = default;
+};
+
+template <typename MappedType>
+struct values_view
+{
+    virtual size_t len() = 0;
+    virtual iterator iter() = 0;
+    virtual ~values_view() = default;
+};
+
+template <typename KeyType, typename MappedType>
+struct items_view
+{
+    virtual size_t len() = 0;
+    virtual iterator iter() = 0;
+    virtual ~items_view() = default;
+};
+
+template <typename Map, typename KeysView>
+struct KeysViewImpl : public KeysView
+{
+    explicit KeysViewImpl(Map &map) : map(map) {}
+    size_t len() override { return map.size(); }
+    // TODO: Does type<Map> at any point return nullptr (since Map is not bound yet)?
+    iterator iter() override { return make_key_iterator(type<Map>(), "make_key_iterator", map.begin(), map.end()); }
+    bool contains(const typename Map::key_type &k) override
+    {
+        return map.find(k) != map.end();
+    }
+    bool contains(const object &) override { return false; }
+    Map &map;
+};
+
+template <typename Map, typename ValuesView>
+struct ValuesViewImpl : public ValuesView
+{
+    explicit ValuesViewImpl(Map &map) : map(map) {}
+    size_t len() override { return map.size(); }
+    // TODO: Does type<Map> at any point return nullptr in this implementation (since Map is not bound yet)?
+    iterator iter() override
+    {
+        return make_value_iterator(type<Map>(), "make_value_iterator", map.begin(), map.end());
+    }
+    Map &map;
+};
+
+template <typename Map, typename ItemsView>
+struct ItemsViewImpl : public ItemsView
+{
+    explicit ItemsViewImpl(Map &map) : map(map) {}
+    size_t len() override { return map.size(); }
+    // TODO: Does type<Map> at any point return nullptr (since Map is not bound yet)?
+    iterator iter() override { return make_iterator(type<Map>(), "make_item_iterator", map.begin(), map.end()); }
+    Map &map;
+};
+
+NAMESPACE_END(detail)
+
+template <typename Map, typename... Args>
+class_<Map> bind_map(handle scope, const char *name, Args &&...args)
+{
+    using KeyType = typename Map::key_type;
+    using MappedType = typename Map::mapped_type;
+    // we do not want a different key type / mapped type between
+    // e.g. double and const double, or double and double& -> strip cv qualifier
+    using StrippedKeyType = detail::remove_cvref_t<KeyType>;
+    using StrippedMappedType = detail::remove_cvref_t<MappedType>;
+    using KeysView = detail::keys_view<StrippedKeyType>;
+    using ValuesView = detail::values_view<StrippedMappedType>;
+    using ItemsView = detail::items_view<StrippedKeyType, StrippedMappedType>;
+    using Class_ = class_<Map>;
+
+    Class_ cl(scope, name, std::forward<Args>(args)...);
+    static constexpr auto key_type_descr = detail::make_caster<KeyType>::Name;
+    static constexpr auto mapped_type_descr = detail::make_caster<MappedType>::Name;
+    std::string key_type_str(key_type_descr.text), mapped_type_str(mapped_type_descr.text);
+
+    // If key type isn't properly wrapped, fall back to C++ names
+    if (key_type_str == "%")
+    {
+        key_type_str = std::string(typeid(KeyType).name());
+    }
+    // Similarly for value type:
+    if (mapped_type_str == "%")
+    {
+        mapped_type_str = std::string(typeid(MappedType).name());
+    }
+
+    // Wrap KeysView[KeyType] if it wasn't already wrapped
+    if (!detail::nb_type_lookup(&typeid(KeysView)))
+    {
+        class_<KeysView> keys_view(scope, ("KeysView[" + key_type_str + "]").c_str());
+        keys_view.def("__len__", &KeysView::len);
+        keys_view.def("__iter__", &KeysView::iter,
+                      keep_alive<0, 1>() /* Essential: keep view alive while
+                                            iterator exists */
+        );
+        keys_view.def(
+            "__contains__",
+            static_cast<bool (KeysView::*)(const KeyType &)>(&KeysView::contains));
+        // Fallback for when the object is not of the key type
+        keys_view.def(
+            "__contains__",
+            static_cast<bool (KeysView::*)(const object &)>(&KeysView::contains));
+    }
+    // Similarly for ValuesView:
+    if (!detail::nb_type_lookup(&typeid(ValuesView)))
+    {
+        class_<ValuesView> values_view(scope, ("ValuesView[" + mapped_type_str + "]").c_str());
+        values_view.def("__len__", &ValuesView::len);
+        values_view.def("__iter__", &ValuesView::iter,
+                        keep_alive<0, 1>() /* Essential: keep view alive while
+                                              iterator exists */
+        );
+    }
+    // Similarly for ItemsView:
+    if (!detail::nb_type_lookup(&typeid(ItemsView)))
+    {
+        class_<ItemsView> items_view(
+            scope,
+            ("ItemsView[" + key_type_str + ", ").append(mapped_type_str + "]").c_str());
+        items_view.def("__len__", &ItemsView::len);
+        items_view.def("__iter__", &ItemsView::iter,
+                       keep_alive<0, 1>() /* Essential: keep view alive while
+                                             iterator exists */
+        );
+    }
+
+    cl.def(init<>());
+
+    cl.def(
+        "__bool__", [](const Map &m) -> bool
+        { return !m.empty(); },
+        "Check whether the map is nonempty");
+
+    cl.def(
+        "__iter__", [](Map &m)
+        { return make_key_iterator(type<Map>(), "make_key_iterator", m.begin(), m.end()); },
+        keep_alive<0, 1>() /* Essential: keep map alive while iterator exists */
+    );
+
+    cl.def(
+        "keys",
+        [](Map &m)
+        {
+            return std::unique_ptr<KeysView>(
+                new detail::KeysViewImpl<Map, KeysView>(m));
+        },
+        keep_alive<0, 1>() /* Essential: keep map alive while view exists */
+    );
+
+    cl.def(
+        "values",
+        [](Map &m)
+        {
+            return std::unique_ptr<ValuesView>(
+                new detail::ValuesViewImpl<Map, ValuesView>(m));
+        },
+        keep_alive<0, 1>() /* Essential: keep map alive while view exists */
+    );
+
+    cl.def(
+        "items",
+        [](Map &m)
+        {
+            return std::unique_ptr<ItemsView>(
+                new detail::ItemsViewImpl<Map, ItemsView>(m));
+        },
+        keep_alive<0, 1>() /* Essential: keep map alive while view exists */
+    );
+
+    cl.def(
+        "__getitem__",
+        [](Map &m, const KeyType &k) -> MappedType &
+        {
+            auto it = m.find(k);
+            if (it == m.end())
+            {
+                throw key_error();
+            }
+            return it->second;
+        },
+        rv_policy::reference_internal // ref + keepalive
+    );
+
+    cl.def("__contains__", [](Map &m, const KeyType &k) -> bool
+           {
+    auto it = m.find(k);
+    if (it == m.end()) {
+      return false;
+    }
+    return true; });
+    // Fallback for when the object is not of the key type
+    cl.def("__contains__", [](Map &, const object &) -> bool
+           { return false; });
+
+    // Assignment provided only if the type is copyable
+    detail::map_assignment<Map, Class_>(cl);
+
+    cl.def("__delitem__", [](Map &m, const KeyType &k)
+           {
+    auto it = m.find(k);
+    if (it == m.end()) {
+      throw key_error();
+    }
+    m.erase(it); });
+
+    cl.def("__len__", &Map::size);
+
+    return cl;
+}
+
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/bind_map.h
+++ b/include/nanobind/stl/bind_map.h
@@ -11,134 +11,73 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/make_iterator.h>
-#include <nanobind/stl/unique_ptr.h> // TODO: Opt out of unique_ptr (used for returning key/value views)?
-#include <nanobind/stl/string.h>     // TODO: Opt out of string (used for constructing "(Keys|Values|Items)View[type]"-style names to bind to the module scope)
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
-// only available since C++20
-using std::remove_cv_t;
-using std::remove_reference_t;
-
-template <class T>
-struct remove_cvref
-{
-    using type = remove_cv_t<remove_reference_t<T>>;
-};
-template <class T>
-using remove_cvref_t = typename remove_cvref<T>::type;
-
-template <typename, typename, typename... Args>
-void map_if_insertion_operator(const Args &...) {}
-template <typename, typename, typename... Args>
-void map_assignment(const Args &...) {}
-
-// Map assignment when copy-assignable: just copy the value
 template <typename Map, typename Class_>
-void map_assignment(
-    std::enable_if_t<std::is_copy_assignable<typename Map::mapped_type>::value, Class_> &cl)
+void map_assignment(Class_ &cl)
 {
     using KeyType = typename Map::key_type;
     using MappedType = typename Map::mapped_type;
-
-    cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v)
-           {
-    auto it = m.find(k);
-    if (it != m.end()) {
-      it->second = v;
-    } else {
-      m.emplace(k, v);
-    } });
-}
-
-// Not copy-assignable, but still copy-constructible: we can update the value by
-// erasing and reinserting
-template <typename Map, typename Class_>
-void map_assignment(
-    std::enable_if_t<!std::is_copy_assignable<typename Map::mapped_type>::value &&
-                         std::is_copy_constructible<typename Map::mapped_type>::value,
-                     Class_> &cl)
-{
-    using KeyType = typename Map::key_type;
-    using MappedType = typename Map::mapped_type;
-
-    cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v)
-           {
-    // We can't use m[k] = v; because value type might not be default
-    // constructable
-    auto r = m.emplace(k, v);
-    if (!r.second) {
-      // value type is not copy assignable so the only way to insert it is to
-      // erase it first...
-      m.erase(r.first);
-      m.emplace(k, v);
-    } });
-}
-
-// template KeysView, ValuesView and ItemsView on their key type, so as
-// to bind different keys views for different key types
-template <typename KeyType>
-struct keys_view
-{
-    virtual size_t len() = 0;
-    virtual iterator iter() = 0;
-    virtual bool contains(const KeyType &k) = 0;
-    virtual bool contains(const object &k) = 0;
-    virtual ~keys_view() = default;
-};
-
-template <typename MappedType>
-struct values_view
-{
-    virtual size_t len() = 0;
-    virtual iterator iter() = 0;
-    virtual ~values_view() = default;
-};
-
-template <typename KeyType, typename MappedType>
-struct items_view
-{
-    virtual size_t len() = 0;
-    virtual iterator iter() = 0;
-    virtual ~items_view() = default;
-};
-
-template <typename Map, typename KeysView>
-struct KeysViewImpl : public KeysView
-{
-    explicit KeysViewImpl(Map &map) : map(map) {}
-    size_t len() override { return map.size(); }
-    // TODO: Does type<Map> at any point return nullptr (since Map is not bound yet)?
-    iterator iter() override { return make_key_iterator(type<Map>(), "make_key_iterator", map.begin(), map.end()); }
-    bool contains(const typename Map::key_type &k) override
-    {
-        return map.find(k) != map.end();
+    // Map assignment when copy-assignable: just copy the value
+    if constexpr(std::is_copy_assignable_v<MappedType>){
+        cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v)
+        {
+            auto it = m.find(k);
+                if (it != m.end()) {
+                    it->second = v;
+                } else {
+                m.emplace(k, v);
+            }
+        });
     }
-    bool contains(const object &) override { return false; }
+    // Not copy-assignable, but still copy-constructible: we can update the value by erasing and
+    // reinserting
+    else if constexpr(!std::is_copy_assignable_v<MappedType> &&
+                      std::is_copy_constructible_v<MappedType>){
+        cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v)
+           {
+            // We can't use m[k] = v; because value type might not be default
+            // constructable
+            auto r = m.emplace(k, v);
+                if (!r.second) {
+                    // value type is not copy assignable so the only way to insert it is to
+                    // erase it first...
+                    m.erase(r.first);
+                    m.emplace(k, v);
+                } 
+            }
+        );
+    }
+}
+
+template <typename Map>
+struct KeysView
+{
+    explicit KeysView(Map &map) : map(map) {}
+    size_t len() { return map.size(); }
+    iterator iter() { return make_key_iterator(type<Map>(), "make_key_iterator", map.begin(), map.end()); }
+    bool contains(const typename Map::key_type &k) { return map.find(k) != map.end(); }
+    bool contains(const object &) { return false; }
     Map &map;
 };
 
-template <typename Map, typename ValuesView>
-struct ValuesViewImpl : public ValuesView
+template <typename Map>
+struct ValuesView
 {
-    explicit ValuesViewImpl(Map &map) : map(map) {}
-    size_t len() override { return map.size(); }
-    // TODO: Does type<Map> at any point return nullptr in this implementation (since Map is not bound yet)?
-    iterator iter() override
-    {
-        return make_value_iterator(type<Map>(), "make_value_iterator", map.begin(), map.end());
-    }
+    explicit ValuesView(Map &map) : map(map) {}
+    size_t len() { return map.size(); }
+    iterator iter() { return make_value_iterator(type<Map>(), "make_value_iterator", map.begin(), map.end()); }
     Map &map;
 };
 
-template <typename Map, typename ItemsView>
-struct ItemsViewImpl : public ItemsView
+template <typename Map>
+struct ItemsView
 {
-    explicit ItemsViewImpl(Map &map) : map(map) {}
-    size_t len() override { return map.size(); }
-    // TODO: Does type<Map> at any point return nullptr (since Map is not bound yet)?
-    iterator iter() override { return make_iterator(type<Map>(), "make_item_iterator", map.begin(), map.end()); }
+    explicit ItemsView(Map &map) : map(map) {}
+    size_t len() { return map.size(); }
+    iterator iter() { return make_iterator(type<Map>(), "make_item_iterator", map.begin(), map.end()); }
     Map &map;
 };
 
@@ -149,121 +88,78 @@ class_<Map> bind_map(handle scope, const char *name, Args &&...args)
 {
     using KeyType = typename Map::key_type;
     using MappedType = typename Map::mapped_type;
-    // we do not want a different key type / mapped type between
-    // e.g. double and const double, or double and double& -> strip cv qualifier
-    using StrippedKeyType = detail::remove_cvref_t<KeyType>;
-    using StrippedMappedType = detail::remove_cvref_t<MappedType>;
-    using KeysView = detail::keys_view<StrippedKeyType>;
-    using ValuesView = detail::values_view<StrippedMappedType>;
-    using ItemsView = detail::items_view<StrippedKeyType, StrippedMappedType>;
+    using KeysView = detail::KeysView<Map>;
+    using ValuesView = detail::ValuesView<Map>;
+    using ItemsView = detail::ItemsView<Map>;
     using Class_ = class_<Map>;
 
     Class_ cl(scope, name, std::forward<Args>(args)...);
-    static constexpr auto key_type_descr = detail::make_caster<KeyType>::Name;
-    static constexpr auto mapped_type_descr = detail::make_caster<MappedType>::Name;
-    std::string key_type_str(key_type_descr.text), mapped_type_str(mapped_type_descr.text);
 
-    // If key type isn't properly wrapped, fall back to C++ names
-    if (key_type_str == "%")
-    {
-        key_type_str = std::string(typeid(KeyType).name());
-    }
-    // Similarly for value type:
-    if (mapped_type_str == "%")
-    {
-        mapped_type_str = std::string(typeid(MappedType).name());
-    }
+    // install KeysView directly into the map class scope
+    class_<KeysView> keys_view(cl, "KeysView");
+    keys_view.def("__len__", &KeysView::len);
+    keys_view.def("__iter__", 
+                  &KeysView::iter,
+                  keep_alive<0, 1>() /* Essential: keep view alive while iterator exists */
+    );
+    keys_view.def("__contains__",
+                  static_cast<bool (KeysView::*)(const KeyType &)>(&KeysView::contains));
+    // Fallback for when the object is not of the key type
+    keys_view.def("__contains__",
+                  static_cast<bool (KeysView::*)(const object &)>(&KeysView::contains));
 
-    // Wrap KeysView[KeyType] if it wasn't already wrapped
-    if (!detail::nb_type_lookup(&typeid(KeysView)))
-    {
-        class_<KeysView> keys_view(scope, ("KeysView[" + key_type_str + "]").c_str());
-        keys_view.def("__len__", &KeysView::len);
-        keys_view.def("__iter__", &KeysView::iter,
-                      keep_alive<0, 1>() /* Essential: keep view alive while
-                                            iterator exists */
-        );
-        keys_view.def(
-            "__contains__",
-            static_cast<bool (KeysView::*)(const KeyType &)>(&KeysView::contains));
-        // Fallback for when the object is not of the key type
-        keys_view.def(
-            "__contains__",
-            static_cast<bool (KeysView::*)(const object &)>(&KeysView::contains));
-    }
-    // Similarly for ValuesView:
-    if (!detail::nb_type_lookup(&typeid(ValuesView)))
-    {
-        class_<ValuesView> values_view(scope, ("ValuesView[" + mapped_type_str + "]").c_str());
-        values_view.def("__len__", &ValuesView::len);
-        values_view.def("__iter__", &ValuesView::iter,
-                        keep_alive<0, 1>() /* Essential: keep view alive while
-                                              iterator exists */
-        );
-    }
-    // Similarly for ItemsView:
-    if (!detail::nb_type_lookup(&typeid(ItemsView)))
-    {
-        class_<ItemsView> items_view(
-            scope,
-            ("ItemsView[" + key_type_str + ", ").append(mapped_type_str + "]").c_str());
-        items_view.def("__len__", &ItemsView::len);
-        items_view.def("__iter__", &ItemsView::iter,
-                       keep_alive<0, 1>() /* Essential: keep view alive while
-                                             iterator exists */
-        );
-    }
+    // same in-place installation with ValuesView...
+    class_<ValuesView> values_view(cl, "ValuesView");
+    values_view.def("__len__", &ValuesView::len);
+    values_view.def("__iter__",
+                    &ValuesView::iter,
+                    keep_alive<0, 1>() /* Essential: keep view alive while iterator exists */
+    );
+
+    // and with ItemsView, too.
+    class_<ItemsView> items_view(scope, "ItemsView");
+    items_view.def("__len__", &ItemsView::len);
+    items_view.def("__iter__",
+                   &ItemsView::iter,
+                   keep_alive<0, 1>() /* Essential: keep view alive while iterator exists */
+    );
 
     cl.def(init<>());
 
     cl.def(
-        "__bool__", [](const Map &m) -> bool
-        { return !m.empty(); },
+        "__bool__", 
+        [](const Map &m) -> bool { return !m.empty(); },
         "Check whether the map is nonempty");
 
     cl.def(
-        "__iter__", [](Map &m)
-        { return make_key_iterator(type<Map>(), "make_key_iterator", m.begin(), m.end()); },
+        "__iter__",
+        [](Map &m) { return make_key_iterator(type<Map>(), "make_key_iterator", m.begin(), m.end()); },
         keep_alive<0, 1>() /* Essential: keep map alive while iterator exists */
     );
 
     cl.def(
         "keys",
-        [](Map &m)
-        {
-            return std::unique_ptr<KeysView>(
-                new detail::KeysViewImpl<Map, KeysView>(m));
-        },
+        [](Map &m){ return new detail::KeysView<Map>(m); },
         keep_alive<0, 1>() /* Essential: keep map alive while view exists */
     );
 
     cl.def(
         "values",
-        [](Map &m)
-        {
-            return std::unique_ptr<ValuesView>(
-                new detail::ValuesViewImpl<Map, ValuesView>(m));
-        },
+        [](Map &m) { return new detail::ValuesView<Map>(m); },
         keep_alive<0, 1>() /* Essential: keep map alive while view exists */
     );
 
     cl.def(
         "items",
-        [](Map &m)
-        {
-            return std::unique_ptr<ItemsView>(
-                new detail::ItemsViewImpl<Map, ItemsView>(m));
-        },
+        [](Map &m) { return new detail::ItemsView<Map>(m); },
         keep_alive<0, 1>() /* Essential: keep map alive while view exists */
     );
 
     cl.def(
         "__getitem__",
-        [](Map &m, const KeyType &k) -> MappedType &
-        {
+        [](Map &m, const KeyType &k) -> MappedType & {
             auto it = m.find(k);
-            if (it == m.end())
-            {
+            if (it == m.end()) {
                 throw key_error();
             }
             return it->second;
@@ -271,27 +167,26 @@ class_<Map> bind_map(handle scope, const char *name, Args &&...args)
         rv_policy::reference_internal // ref + keepalive
     );
 
-    cl.def("__contains__", [](Map &m, const KeyType &k) -> bool
-           {
-    auto it = m.find(k);
-    if (it == m.end()) {
-      return false;
-    }
-    return true; });
+    cl.def("__contains__", [](Map &m, const KeyType &k) -> bool {
+        auto it = m.find(k);
+        if (it == m.end()) {
+            return false;
+        }
+        return true; 
+    });
     // Fallback for when the object is not of the key type
-    cl.def("__contains__", [](Map &, const object &) -> bool
-           { return false; });
+    cl.def("__contains__", [](Map &, const object &) -> bool { return false; });
 
     // Assignment provided only if the type is copyable
     detail::map_assignment<Map, Class_>(cl);
 
-    cl.def("__delitem__", [](Map &m, const KeyType &k)
-           {
-    auto it = m.find(k);
-    if (it == m.end()) {
-      throw key_error();
-    }
-    m.erase(it); });
+    cl.def("__delitem__", [](Map &m, const KeyType &k) {
+        auto it = m.find(k);
+        if (it == m.end()) {
+            throw key_error();
+        }
+        m.erase(it); 
+    });
 
     cl.def("__len__", &Map::size);
 

--- a/include/nanobind/stl/bind_map.h
+++ b/include/nanobind/stl/bind_map.h
@@ -9,6 +9,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/make_iterator.h>
+#include <nanobind/stl/detail/traits.h>
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
@@ -139,10 +140,10 @@ class_<Map> bind_map(handle scope, const char *name, Args &&...args)
     cl.def("__contains__", [](const Map &, handle) -> bool { return false; });
 
     // Assignment provided only if the type is copyable
-    if constexpr(std::is_copy_assignable_v<MappedType> ||
-                 std::is_copy_constructible_v<MappedType>){
+    if constexpr(detail::is_copy_assignable_v<MappedType> ||
+                 detail::is_copy_constructible_v<MappedType>){
         // Map assignment when copy-assignable: just copy the value
-        if constexpr(std::is_copy_assignable_v<MappedType>){
+        if constexpr(detail::is_copy_assignable_v<MappedType>){
             cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v)
             {
                 auto it = m.find(k);

--- a/include/nanobind/stl/bind_map.h
+++ b/include/nanobind/stl/bind_map.h
@@ -12,176 +12,107 @@
 #include <nanobind/stl/detail/traits.h>
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
-NAMESPACE_BEGIN(detail)
-
-template <typename Map>
-struct KeysView
-{
-    explicit KeysView(Map &map) : map(map) {}
-    size_t len() { return map.size(); }
-    iterator iter() { return make_key_iterator(type<Map>(), "make_key_iterator", map.begin(), map.end()); }
-    bool contains(const typename Map::key_type &k) { return map.find(k) != map.end(); }
-    bool contains(const object &) { return false; }
-    Map &map;
-};
-
-template <typename Map>
-struct ValuesView
-{
-    explicit ValuesView(Map &map) : map(map) {}
-    size_t len() { return map.size(); }
-    iterator iter() { return make_value_iterator(type<Map>(), "make_value_iterator", map.begin(), map.end()); }
-    Map &map;
-};
-
-template <typename Map>
-struct ItemsView
-{
-    explicit ItemsView(Map &map) : map(map) {}
-    size_t len() { return map.size(); }
-    iterator iter() { return make_iterator(type<Map>(), "make_item_iterator", map.begin(), map.end()); }
-    Map &map;
-};
-
-NAMESPACE_END(detail)
 
 template <typename Map, typename... Args>
-class_<Map> bind_map(handle scope, const char *name, Args &&...args)
-{
-    using KeyType = typename Map::key_type;
-    using MappedType = typename Map::mapped_type;
-    using KeysView = detail::KeysView<Map>;
-    using ValuesView = detail::ValuesView<Map>;
-    using ItemsView = detail::ItemsView<Map>;
-    using Class_ = class_<Map>;
+class_<Map> bind_map(handle scope, const char *name, Args &&...args) {
+    using Key = typename Map::key_type;
+    using Value = typename Map::mapped_type;
 
-    Class_ cl(scope, name, std::forward<Args>(args)...);
+    auto cl = class_<Map>(scope, name, std::forward<Args>(args)...)
+        .def(init<>())
 
-    // install KeysView directly into the map class scope
-    class_<KeysView> keys_view(cl, "KeysView");
-    keys_view.def("__len__", &KeysView::len);
-    keys_view.def("__iter__", 
-                  &KeysView::iter,
-                  keep_alive<0, 1>()
-    );
-    keys_view.def("__contains__",
-                  static_cast<bool (KeysView::*)(const KeyType &)>(&KeysView::contains));
-    // Fallback for when the object is not of the key type
-    keys_view.def("__contains__",
-                  static_cast<bool (KeysView::*)(const object &)>(&KeysView::contains));
+        .def("__len__", &Map::size)
 
-    // same in-place installation with ValuesView...
-    class_<ValuesView> values_view(cl, "ValuesView");
-    values_view.def("__len__", &ValuesView::len);
-    values_view.def("__iter__",
-                    &ValuesView::iter,
-                    keep_alive<0, 1>()
-    );
+        .def("__bool__",
+             [](const Map &m) { return !m.empty(); },
+             "Check whether the map is nonempty")
 
-    // and with ItemsView, too.
-    class_<ItemsView> items_view(scope, "ItemsView");
-    items_view.def("__len__", &ItemsView::len);
-    items_view.def("__iter__",
-                   &ItemsView::iter,
-                   keep_alive<0, 1>()
-    );
+        .def("__contains__",
+             [](const Map &m, const Key &k) { return m.find(k) != m.end(); })
 
-    cl.def(init<>());
+        .def("__contains__", // fallback for incompatible types
+             [](const Map &, handle) { return false; })
 
-    cl.def(
-        "__bool__", 
-        [](const Map &m) -> bool { return !m.empty(); },
-        "Check whether the map is nonempty");
+        .def("__iter__",
+             [](Map &m) {
+                 return make_key_iterator(type<Map>(), "KeyIterator",
+                                          m.begin(), m.end());
+             },
+             keep_alive<0, 1>())
 
-    cl.def(
-        "__iter__",
-        [](Map &m) { return make_key_iterator(type<Map>(), "make_key_iterator", m.begin(), m.end()); },
-        keep_alive<0, 1>() /* Essential: keep map alive while iterator exists */
-    );
+        .def("__getitem__",
+             [](Map &m, const Key &k) -> Value & {
+                 auto it = m.find(k);
+                 if (it == m.end())
+                     throw key_error();
+                 return it->second;
+             },
+             rv_policy::reference_internal
+        )
 
-    cl.def(
-        "keys",
-        [](Map &m){ return new detail::KeysView<Map>(m); },
-        keep_alive<0, 1>()
-    );
-
-    cl.def(
-        "values",
-        [](Map &m) { return new detail::ValuesView<Map>(m); },
-        keep_alive<0, 1>()
-    );
-
-    cl.def(
-        "items",
-        [](Map &m) { return new detail::ItemsView<Map>(m); },
-        keep_alive<0, 1>()
-    );
-
-    cl.def(
-        "__getitem__",
-        [](Map &m, const KeyType &k) -> MappedType & {
-            auto it = m.find(k);
-            if (it == m.end()) {
-                throw key_error();
-            }
-            return it->second;
-        },
-        rv_policy::reference_internal // ref + keepalive
-    );
-
-    cl.def("__contains__", [](const Map &m, const KeyType &k) -> bool {
-        auto it = m.find(k);
-        if (it == m.end()) {
-            return false;
-        }
-        return true; 
-    });
-    // Fallback for when the object is not of the key type
-    cl.def("__contains__", [](const Map &, handle) -> bool { return false; });
-
-    // Assignment provided only if the type is copyable
-    if constexpr(detail::is_copy_assignable_v<MappedType> ||
-                 detail::is_copy_constructible_v<MappedType>){
-        // Map assignment when copy-assignable: just copy the value
-        if constexpr(detail::is_copy_assignable_v<MappedType>){
-            cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v)
-            {
+        .def("__delitem__",
+            [](Map &m, const Key &k) {
                 auto it = m.find(k);
-                    if (it != m.end()) {
-                        it->second = v;
-                    } else {
+                if (it == m.end())
+                    throw key_error();
+                m.erase(it);
+            }
+        );
+
+    // Assignment operator for copy-assignable/copy-constructible types
+    if constexpr (detail::is_copy_assignable_v<Value> ||
+                  detail::is_copy_constructible_v<Value>) {
+        cl.def("__setitem__", [](Map &m, const Key &k, const Value &v) {
+            if constexpr (detail::is_copy_assignable_v<Value>) {
+                m[k] = v;
+            } else {
+                auto r = m.emplace(k, v);
+                if (!r.second) {
+                    // Value is not copy-assignable. Erase and retry
+                    m.erase(r.first);
                     m.emplace(k, v);
                 }
-            });
-        }
-        // Not copy-assignable, but still copy-constructible: we can update the value by erasing and
-        // reinserting
-        else{
-            cl.def("__setitem__", [](Map &m, const KeyType &k, const MappedType &v)
-            {
-                // We can't use m[k] = v; because value type might not be default
-                // constructible
-                auto r = m.emplace(k, v);
-                    if (!r.second) {
-                        // value type is not copy assignable so the only way to insert it is to
-                        // erase it first.
-                        m.erase(r.first);
-                        m.emplace(k, v);
-                    } 
-                }
-            );
-        }
+            }
+        });
     }
 
-    cl.def("__delitem__", [](Map &m, const KeyType &k) {
-        auto it = m.find(k);
-        if (it == m.end()) {
-            throw key_error();
-        }
-        m.erase(it); 
-    });
+    // Item, value, and key views
+    struct KeyView   { Map &map; };
+    struct ValueView { Map &map; };
+    struct ItemView  { Map &map; };
 
-    cl.def("__len__", &Map::size);
+    class_<ItemView>(cl, "ItemView")
+        .def("__len__", [](ItemView &v) { return v.map.size(); })
+        .def("__iter__",
+             [](ItemView &v) {
+                 return make_iterator(type<Map>(), "ItemIterator",
+                                      v.map.begin(), v.map.end());
+             },
+             keep_alive<0, 1>());
+
+    class_<KeyView>(cl, "KeyView")
+        .def("__contains__", [](KeyView &v, const Key &k) { return v.map.find(k) != v.map.end(); })
+        .def("__contains__", [](KeyView &, handle) { return false; })
+        .def("__len__", [](KeyView &v) { return v.map.size(); })
+        .def("__iter__",
+             [](KeyView &v) {
+                 return make_key_iterator(type<Map>(), "KeyIterator",
+                                          v.map.begin(), v.map.end());
+             },
+             keep_alive<0, 1>());
+
+    class_<ValueView>(cl, "ValueView")
+        .def("__len__", [](ValueView &v) { return v.map.size(); })
+        .def("__iter__",
+             [](ValueView &v) {
+                 return make_value_iterator(type<Map>(), "ValueIterator",
+                                            v.map.begin(), v.map.end());
+             },
+             keep_alive<0, 1>());
+
+    cl.def("keys", [](Map &m)   { return new KeyView{m}; }, keep_alive<0, 1>());
+    cl.def("values", [](Map &m) { return new ValueView{m}; }, keep_alive<0, 1>());
+    cl.def("items", [](Map &m)  { return new ItemView{m}; }, keep_alive<0, 1>());
 
     return cl;
 }

--- a/include/nanobind/stl/detail/traits.h
+++ b/include/nanobind/stl/detail/traits.h
@@ -31,12 +31,33 @@ struct is_copy_constructible<
         is_copy_constructible<typename T::value_type>::value;
 };
 
+// std::pair is copy-constructible <=> both constituents are copy-constructible
 template <typename T1, typename T2>
 struct is_copy_constructible<std::pair<T1, T2>> {
     static constexpr bool value =
-        is_copy_constructible<T1>::value ||
+        is_copy_constructible<T1>::value &&
         is_copy_constructible<T2>::value;
 };
+
+// The header file include/nanobind/stl/detail/traits.h extends this type trait
+template <typename T, typename SFINAE = int>
+struct is_copy_assignable : std::is_copy_assignable<T> { };
+
+template <typename T>
+struct is_copy_assignable<T,
+                          enable_if_t<std::is_copy_assignable_v<T> &&
+                                      std::is_same_v<typename T::value_type &,
+                                                     typename T::reference>>> {
+    static constexpr bool value = is_copy_assignable<typename T::value_type>::value;
+};
+
+template <typename T1, typename T2>
+struct is_copy_assignable<std::pair<T1, T2>> {
+    static constexpr bool value = is_copy_assignable<T1>::value && is_copy_assignable<T2>::value;
+};
+
+template <typename T>
+constexpr bool is_copy_assignable_v = is_copy_assignable<T>::value;
 
 NAMESPACE_END(detail)
 NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/detail/traits.h
+++ b/include/nanobind/stl/detail/traits.h
@@ -39,7 +39,7 @@ struct is_copy_constructible<std::pair<T1, T2>> {
         is_copy_constructible<T2>::value;
 };
 
-// The header file include/nanobind/stl/detail/traits.h extends this type trait
+// Analogous template for checking copy-assignability
 template <typename T, typename SFINAE = int>
 struct is_copy_assignable : std::is_copy_assignable<T> { };
 
@@ -53,7 +53,9 @@ struct is_copy_assignable<T,
 
 template <typename T1, typename T2>
 struct is_copy_assignable<std::pair<T1, T2>> {
-    static constexpr bool value = is_copy_assignable<T1>::value && is_copy_assignable<T2>::value;
+    static constexpr bool value =
+            is_copy_assignable<T1>::value &&
+            is_copy_assignable<T2>::value;
 };
 
 template <typename T>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ nanobind_add_module(test_functions_ext test_functions.cpp ${NB_EXTRA_ARGS})
 nanobind_add_module(test_classes_ext test_classes.cpp ${NB_EXTRA_ARGS})
 nanobind_add_module(test_holders_ext test_holders.cpp ${NB_EXTRA_ARGS})
 nanobind_add_module(test_stl_ext test_stl.cpp ${NB_EXTRA_ARGS})
+nanobind_add_module(test_bind_map_ext test_stl_bind_map.cpp ${NB_EXTRA_ARGS})
 nanobind_add_module(test_enum_ext test_enum.cpp ${NB_EXTRA_ARGS})
 nanobind_add_module(test_tensor_ext test_tensor.cpp ${NB_EXTRA_ARGS})
 nanobind_add_module(test_intrusive_ext test_intrusive.cpp object.cpp object.h ${NB_EXTRA_ARGS})
@@ -40,6 +41,7 @@ set(TEST_FILES
   test_classes.py
   test_holders.py
   test_stl.py
+  test_stl_bind_map.py
   test_enum.py
   test_tensor.py
   test_intrusive.py

--- a/tests/test_stl_bind_map.cpp
+++ b/tests/test_stl_bind_map.cpp
@@ -1,14 +1,10 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/bind_map.h>
+#include <nanobind/stl/string.h>
 #include <nanobind/stl/map.h>
 #include <nanobind/stl/unordered_map.h>
 
 namespace nb = nanobind;
-
-NB_MAKE_OPAQUE(std::map<std::string, double>);
-NB_MAKE_OPAQUE(std::unordered_map<std::string, double>);
-NB_MAKE_OPAQUE(std::map<std::string, double const>);
-NB_MAKE_OPAQUE(std::unordered_map<std::string, double const>);
 
 NB_MODULE(test_bind_map_ext, m) {
     // test_map_string_double

--- a/tests/test_stl_bind_map.cpp
+++ b/tests/test_stl_bind_map.cpp
@@ -1,7 +1,42 @@
 #include <nanobind/stl/bind_map.h>
 #include <nanobind/stl/string.h>
+#include <map>
+#include <unordered_map>
+#include <vector>
 
 namespace nb = nanobind;
+
+// testing for insertion of non-copyable class
+class E_nc {
+public:
+    explicit E_nc(int i) : value{i} {}
+    E_nc(const E_nc &) = delete;
+    E_nc &operator=(const E_nc &) = delete;
+    E_nc(E_nc &&) = default;
+    E_nc &operator=(E_nc &&) = default;
+
+    int value;
+};
+
+template <class Map>
+Map *times_ten(int n) {
+    auto *m = new Map();
+    for (int i = 1; i <= n; i++) {
+        m->emplace(int(i), E_nc(10 * i));
+    }
+    return m;
+}
+
+template <class NestMap>
+NestMap *times_hundred(int n) {
+    auto *m = new NestMap();
+    for (int i = 1; i <= n; i++) {
+        for (int j = 1; j <= n; j++) {
+            (*m)[i].emplace(int(j * 10), E_nc(100 * j));
+        }
+    }
+    return m;
+}
 
 NB_MODULE(test_bind_map_ext, m) {
     // test_map_string_double
@@ -11,4 +46,28 @@ NB_MODULE(test_bind_map_ext, m) {
     nb::bind_map<std::map<std::string, double const>>(m, "MapStringDoubleConst");
     nb::bind_map<std::unordered_map<std::string, double const>>(m,
                                                                 "UnorderedMapStringDoubleConst");
+
+    nb::class_<E_nc>(m, "ENC").def(nb::init_implicit<int>()).def_readwrite("value", &E_nc::value);
+
+    nb::bind_map<std::map<int, E_nc>>(m, "MapENC");
+    m.def("get_mnc", &times_ten<std::map<int, E_nc>>);
+    nb::bind_map<std::unordered_map<int, E_nc>>(m, "UmapENC");
+    m.def("get_umnc", &times_ten<std::unordered_map<int, E_nc>>);
+    // Issue #1885: binding nested std::map<X, Container<E>> with E non-copyable
+    nb::bind_map<std::map<int, std::vector<E_nc>>>(m, "MapVecENC");
+    m.def("get_nvnc", [](int n) {
+        auto *m = new std::map<int, std::vector<E_nc>>();
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= n; j++) {
+                (*m)[i].emplace_back(j);
+            }
+        }
+        return m;
+    });
+
+    nb::bind_map<std::map<int, std::map<int, E_nc>>>(m, "MapMapENC");
+    m.def("get_nmnc", &times_hundred<std::map<int, std::map<int, E_nc>>>);
+    nb::bind_map<std::unordered_map<int, std::unordered_map<int, E_nc>>>(m, "UmapUmapENC");
+    m.def("get_numnc", &times_hundred<std::unordered_map<int, std::unordered_map<int, E_nc>>>);
+
 }

--- a/tests/test_stl_bind_map.cpp
+++ b/tests/test_stl_bind_map.cpp
@@ -1,8 +1,9 @@
-#include <nanobind/stl/bind_map.h>
-#include <nanobind/stl/string.h>
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <vector>
+
+#include <nanobind/stl/bind_map.h>
 
 namespace nb = nanobind;
 
@@ -47,7 +48,7 @@ NB_MODULE(test_bind_map_ext, m) {
     nb::bind_map<std::unordered_map<std::string, double const>>(m,
                                                                 "UnorderedMapStringDoubleConst");
 
-    nb::class_<E_nc>(m, "ENC").def(nb::init_implicit<int>()).def_readwrite("value", &E_nc::value);
+    nb::class_<E_nc>(m, "ENC").def(nb::init<int>()).def_readwrite("value", &E_nc::value);
 
     nb::bind_map<std::map<int, E_nc>>(m, "MapENC");
     m.def("get_mnc", &times_ten<std::map<int, E_nc>>);

--- a/tests/test_stl_bind_map.cpp
+++ b/tests/test_stl_bind_map.cpp
@@ -4,6 +4,8 @@
 #include <vector>
 
 #include <nanobind/stl/bind_map.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 
 namespace nb = nanobind;
 

--- a/tests/test_stl_bind_map.cpp
+++ b/tests/test_stl_bind_map.cpp
@@ -1,8 +1,5 @@
-#include <nanobind/nanobind.h>
 #include <nanobind/stl/bind_map.h>
 #include <nanobind/stl/string.h>
-#include <nanobind/stl/map.h>
-#include <nanobind/stl/unordered_map.h>
 
 namespace nb = nanobind;
 

--- a/tests/test_stl_bind_map.cpp
+++ b/tests/test_stl_bind_map.cpp
@@ -1,0 +1,21 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/bind_map.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/unordered_map.h>
+
+namespace nb = nanobind;
+
+NB_MAKE_OPAQUE(std::map<std::string, double>);
+NB_MAKE_OPAQUE(std::unordered_map<std::string, double>);
+NB_MAKE_OPAQUE(std::map<std::string, double const>);
+NB_MAKE_OPAQUE(std::unordered_map<std::string, double const>);
+
+NB_MODULE(test_bind_map_ext, m) {
+    // test_map_string_double
+    nb::bind_map<std::map<std::string, double>>(m, "MapStringDouble");
+    nb::bind_map<std::unordered_map<std::string, double>>(m, "UnorderedMapStringDouble");
+    // test_map_string_double_const
+    nb::bind_map<std::map<std::string, double const>>(m, "MapStringDoubleConst");
+    nb::bind_map<std::unordered_map<std::string, double const>>(m,
+                                                                "UnorderedMapStringDoubleConst");
+}

--- a/tests/test_stl_bind_map.py
+++ b/tests/test_stl_bind_map.py
@@ -1,0 +1,49 @@
+import pytest
+
+import test_bind_map_ext as t
+
+def test_map_delitem():
+    mm = t.MapStringDouble()
+    mm["a"] = 1
+    mm["b"] = 2.5
+
+    assert list(mm) == ["a", "b"]
+    assert list(mm.items()) == [("a", 1), ("b", 2.5)]
+    del mm["a"]
+    assert list(mm) == ["b"]
+    assert list(mm.items()) == [("b", 2.5)]
+
+    um = t.UnorderedMapStringDouble()
+    um["ua"] = 1.1
+    um["ub"] = 2.6
+
+    assert sorted(list(um)) == ["ua", "ub"]
+    assert sorted(list(um.items())) == [("ua", 1.1), ("ub", 2.6)]
+    del um["ua"]
+    assert sorted(list(um)) == ["ub"]
+    assert sorted(list(um.items())) == [("ub", 2.6)]
+
+def test_map_view_types():
+    map_string_double = t.MapStringDouble()
+    unordered_map_string_double = t.UnorderedMapStringDouble()
+    map_string_double_const = t.MapStringDoubleConst()
+    unordered_map_string_double_const = t.UnorderedMapStringDoubleConst()
+
+    assert map_string_double.keys().__class__.__name__ == "KeysView[str]"
+    assert map_string_double.values().__class__.__name__ == "ValuesView[float]"
+    assert map_string_double.items().__class__.__name__ == "ItemsView[str, float]"
+
+    keys_type = type(map_string_double.keys())
+    assert type(unordered_map_string_double.keys()) is keys_type
+    assert type(map_string_double_const.keys()) is keys_type
+    assert type(unordered_map_string_double_const.keys()) is keys_type
+
+    values_type = type(map_string_double.values())
+    assert type(unordered_map_string_double.values()) is values_type
+    assert type(map_string_double_const.values()) is values_type
+    assert type(unordered_map_string_double_const.values()) is values_type
+
+    items_type = type(map_string_double.items())
+    assert type(unordered_map_string_double.items()) is items_type
+    assert type(map_string_double_const.items()) is items_type
+    assert type(unordered_map_string_double_const.items()) is items_type

--- a/tests/test_stl_bind_map.py
+++ b/tests/test_stl_bind_map.py
@@ -2,6 +2,129 @@ import pytest
 
 import test_bind_map_ext as t
 
+
+def test_map_string_double():
+    mm = m.MapStringDouble()
+    mm["a"] = 1
+    mm["b"] = 2.5
+
+    assert list(mm) == ["a", "b"]
+    assert "b" in mm
+    assert "c" not in mm
+    assert 123 not in mm
+
+    # Check that keys, values, items are views, not merely iterable
+    keys = mm.keys()
+    values = mm.values()
+    items = mm.items()
+    assert list(keys) == ["a", "b"]
+    assert len(keys) == 2
+    assert "a" in keys
+    assert "c" not in keys
+    assert 123 not in keys
+    assert list(items) == [("a", 1), ("b", 2.5)]
+    assert len(items) == 2
+    assert ("b", 2.5) in items
+    assert "hello" not in items
+    assert ("b", 2.5, None) not in items
+    assert list(values) == [1, 2.5]
+    assert len(values) == 2
+    assert 1 in values
+    assert 2 not in values
+    # Check that views update when the map is updated
+    mm["c"] = -1
+    assert list(keys) == ["a", "b", "c"]
+    assert list(values) == [1, 2.5, -1]
+    assert list(items) == [("a", 1), ("b", 2.5), ("c", -1)]
+
+    um = m.UnorderedMapStringDouble()
+    um["ua"] = 1.1
+    um["ub"] = 2.6
+
+    assert sorted(list(um)) == ["ua", "ub"]
+    assert list(um.keys()) == list(um)
+    assert sorted(list(um.items())) == [("ua", 1.1), ("ub", 2.6)]
+    assert list(zip(um.keys(), um.values())) == list(um.items())
+    assert "UnorderedMapStringDouble" in str(um)
+
+
+def test_map_string_double_const():
+    mc = m.MapStringDoubleConst()
+    mc["a"] = 10
+    mc["b"] = 20.5
+
+    umc = m.UnorderedMapStringDoubleConst()
+    umc["a"] = 11
+    umc["b"] = 21.5
+
+    str(umc)
+
+
+def test_maps_with_noncopyable_values():
+    # std::map
+    mnc = m.get_mnc(5)
+    for i in range(1, 6):
+        assert mnc[i].value == 10 * i
+
+    vsum = 0
+    for k, v in mnc.items():
+        assert v.value == 10 * k
+        vsum += v.value
+
+    assert vsum == 150
+
+    # std::unordered_map
+    mnc = m.get_umnc(5)
+    for i in range(1, 6):
+        assert mnc[i].value == 10 * i
+
+    vsum = 0
+    for k, v in mnc.items():
+        assert v.value == 10 * k
+        vsum += v.value
+
+    assert vsum == 150
+
+    # nested std::map<std::vector>
+    nvnc = m.get_nvnc(5)
+    for i in range(1, 6):
+        for j in range(0, 5):
+            assert nvnc[i][j].value == j + 1
+
+    # Note: maps do not have .values()
+    for _, v in nvnc.items():
+        for i, j in enumerate(v, start=1):
+            assert j.value == i
+
+    # nested std::map<std::map>
+    nmnc = m.get_nmnc(5)
+    for i in range(1, 6):
+        for j in range(10, 60, 10):
+            assert nmnc[i][j].value == 10 * j
+
+    vsum = 0
+    for _, v_o in nmnc.items():
+        for k_i, v_i in v_o.items():
+            assert v_i.value == 10 * k_i
+            vsum += v_i.value
+
+    assert vsum == 7500
+
+    # nested std::unordered_map<std::unordered_map>
+    numnc = m.get_numnc(5)
+    for i in range(1, 6):
+        for j in range(10, 60, 10):
+            assert numnc[i][j].value == 10 * j
+
+    vsum = 0
+    for _, v_o in numnc.items():
+        for k_i, v_i in v_o.items():
+            assert v_i.value == 10 * k_i
+            vsum += v_i.value
+
+    assert vsum == 7500
+
+
 def test_map_delitem():
     mm = t.MapStringDouble()
     mm["a"] = 1
@@ -23,15 +146,12 @@ def test_map_delitem():
     assert sorted(list(um)) == ["ub"]
     assert sorted(list(um.items())) == [("ub", 2.6)]
 
+
 def test_map_view_types():
     map_string_double = t.MapStringDouble()
     unordered_map_string_double = t.UnorderedMapStringDouble()
     map_string_double_const = t.MapStringDoubleConst()
     unordered_map_string_double_const = t.UnorderedMapStringDoubleConst()
-
-    assert map_string_double.keys().__class__.__name__ == "KeysView[str]"
-    assert map_string_double.values().__class__.__name__ == "ValuesView[float]"
-    assert map_string_double.items().__class__.__name__ == "ItemsView[str, float]"
 
     keys_type = type(map_string_double.keys())
     assert type(unordered_map_string_double.keys()) is keys_type
@@ -47,3 +167,7 @@ def test_map_view_types():
     assert type(unordered_map_string_double.items()) is items_type
     assert type(map_string_double_const.items()) is items_type
     assert type(unordered_map_string_double_const.items()) is items_type
+
+    assert map_string_double.keys().__class__.__name__ == "KeysView[str]"
+    assert map_string_double.values().__class__.__name__ == "ValuesView[float]"
+    assert map_string_double.items().__class__.__name__ == "ItemsView[str, float]"

--- a/tests/test_stl_bind_map.py
+++ b/tests/test_stl_bind_map.py
@@ -4,7 +4,7 @@ import test_bind_map_ext as t
 
 
 def test_map_string_double():
-    mm = m.MapStringDouble()
+    mm = t.MapStringDouble()
     mm["a"] = 1
     mm["b"] = 2.5
 
@@ -37,7 +37,7 @@ def test_map_string_double():
     assert list(values) == [1, 2.5, -1]
     assert list(items) == [("a", 1), ("b", 2.5), ("c", -1)]
 
-    um = m.UnorderedMapStringDouble()
+    um = t.UnorderedMapStringDouble()
     um["ua"] = 1.1
     um["ub"] = 2.6
 
@@ -47,13 +47,17 @@ def test_map_string_double():
     assert list(zip(um.keys(), um.values())) == list(um.items())
     assert "UnorderedMapStringDouble" in str(um)
 
+    assert type(keys).__qualname__ == 'MapStringDouble.KeyView'
+    assert type(values).__qualname__ == 'MapStringDouble.ValueView'
+    assert type(items).__qualname__ == 'MapStringDouble.ItemView'
+
 
 def test_map_string_double_const():
-    mc = m.MapStringDoubleConst()
+    mc = t.MapStringDoubleConst()
     mc["a"] = 10
     mc["b"] = 20.5
 
-    umc = m.UnorderedMapStringDoubleConst()
+    umc = t.UnorderedMapStringDoubleConst()
     umc["a"] = 11
     umc["b"] = 21.5
 
@@ -62,7 +66,7 @@ def test_map_string_double_const():
 
 def test_maps_with_noncopyable_values():
     # std::map
-    mnc = m.get_mnc(5)
+    mnc = t.get_mnc(5)
     for i in range(1, 6):
         assert mnc[i].value == 10 * i
 
@@ -74,7 +78,7 @@ def test_maps_with_noncopyable_values():
     assert vsum == 150
 
     # std::unordered_map
-    mnc = m.get_umnc(5)
+    mnc = t.get_umnc(5)
     for i in range(1, 6):
         assert mnc[i].value == 10 * i
 
@@ -86,7 +90,7 @@ def test_maps_with_noncopyable_values():
     assert vsum == 150
 
     # nested std::map<std::vector>
-    nvnc = m.get_nvnc(5)
+    nvnc = t.get_nvnc(5)
     for i in range(1, 6):
         for j in range(0, 5):
             assert nvnc[i][j].value == j + 1
@@ -97,7 +101,7 @@ def test_maps_with_noncopyable_values():
             assert j.value == i
 
     # nested std::map<std::map>
-    nmnc = m.get_nmnc(5)
+    nmnc = t.get_nmnc(5)
     for i in range(1, 6):
         for j in range(10, 60, 10):
             assert nmnc[i][j].value == 10 * j
@@ -111,7 +115,7 @@ def test_maps_with_noncopyable_values():
     assert vsum == 7500
 
     # nested std::unordered_map<std::unordered_map>
-    numnc = m.get_numnc(5)
+    numnc = t.get_numnc(5)
     for i in range(1, 6):
         for j in range(10, 60, 10):
             assert numnc[i][j].value == 10 * j
@@ -145,29 +149,3 @@ def test_map_delitem():
     del um["ua"]
     assert sorted(list(um)) == ["ub"]
     assert sorted(list(um.items())) == [("ub", 2.6)]
-
-
-def test_map_view_types():
-    map_string_double = t.MapStringDouble()
-    unordered_map_string_double = t.UnorderedMapStringDouble()
-    map_string_double_const = t.MapStringDoubleConst()
-    unordered_map_string_double_const = t.UnorderedMapStringDoubleConst()
-
-    keys_type = type(map_string_double.keys())
-    assert type(unordered_map_string_double.keys()) is keys_type
-    assert type(map_string_double_const.keys()) is keys_type
-    assert type(unordered_map_string_double_const.keys()) is keys_type
-
-    values_type = type(map_string_double.values())
-    assert type(unordered_map_string_double.values()) is values_type
-    assert type(map_string_double_const.values()) is values_type
-    assert type(unordered_map_string_double_const.values()) is values_type
-
-    items_type = type(map_string_double.items())
-    assert type(unordered_map_string_double.items()) is items_type
-    assert type(map_string_double_const.items()) is items_type
-    assert type(unordered_map_string_double_const.items()) is items_type
-
-    assert map_string_double.keys().__class__.__name__ == "KeysView[str]"
-    assert map_string_double.values().__class__.__name__ == "ValuesView[float]"
-    assert map_string_double.items().__class__.__name__ == "ItemsView[str, float]"


### PR DESCRIPTION
Adds a port of pybind11's `bind_map` to nanobind, including tests.

For now, all additions have been made inline in the new header file, nanobind/stl/bind_map.h. This file opts the user into the standard library headers `<string>` (due to its use of string concatenation for constructing dynamic keys/values view names) and `<memory>` (for dynamically allocating keys/values/items views.)

--------------------------------------------------------------------------

This is my best effort of porting over `py::bind_map`, so far. Since I am not writing C++ that often, please be relentless so that I can learn and do better :)

The use of `<string>` and `<memory>` are only necessary because I ported over https://github.com/pybind/pybind11/pull/4353, which pulls them in for dynamically constructing string reprentations for keys/value/items views. Please give guidance on whether this is ok, or whether that makes `bind_map` incompatible with nanobind's design goals.

I would like guidance on the following questions that came up over the course of developing (I also left some TODOs which are essentially questions that I asked myself while implementing):

- How should I structure the added `using` defs (I assume they are detail-namespace-wide)?
- Is the polymorphism in `KeysViewImpl` et al. compatible with nanobind? (this ties into the above)
- I was confused at having to use `NB_MAKE_OPAQUE` in the tests (they are essentially ported verbatim from `pybind`), to avoid a static assertion about a missing type caster, where pybind does apparently not. What am I doing wrong there?

Thanks in advance for guidance and comments.