### PR TITLE
Add a convenience function for calling the builtin `hash`

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1918,6 +1918,10 @@ Miscellaneous
 
    Equivalent to ``iter(h)`` in Python.
 
+.. cpp:function:: Py_hash_t hash(handle h)
+
+   Equivalent to ``hash(h)`` in Python.
+
 .. cpp:function:: object none()
 
    Return an object representing the value ``None``.

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -161,6 +161,10 @@ NB_CORE size_t obj_len_hint(PyObject *o) noexcept;
 /// Obtain a string representation of a Python object
 NB_CORE PyObject* obj_repr(PyObject *o);
 
+/// Obtain a hash value of a Python object
+NB_CORE Py_hash_t obj_hash(PyObject *o);
+
+
 /// Perform a comparison between Python objects and handle errors
 NB_CORE bool obj_comp(PyObject *a, PyObject *b, int value);
 

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -164,7 +164,6 @@ NB_CORE PyObject* obj_repr(PyObject *o);
 /// Obtain a hash value of a Python object
 NB_CORE Py_hash_t obj_hash(PyObject *o);
 
-
 /// Perform a comparison between Python objects and handle errors
 NB_CORE bool obj_comp(PyObject *a, PyObject *b, int value);
 

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -496,6 +496,7 @@ NB_INLINE bool isinstance(handle h) noexcept {
 }
 
 NB_INLINE str repr(handle h) { return steal<str>(detail::obj_repr(h.ptr())); }
+NB_INLINE Py_hash_t hash(handle h) { return detail::obj_hash(h.ptr()); }
 NB_INLINE size_t len(handle h) { return detail::obj_len(h.ptr()); }
 NB_INLINE size_t len_hint(handle h) { return detail::obj_len_hint(h.ptr()); }
 NB_INLINE size_t len(const tuple &t) { return NB_TUPLE_GET_SIZE(t.ptr()); }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -219,6 +219,13 @@ size_t obj_len_hint(PyObject *o) noexcept {
 #endif
 }
 
+Py_hash_t obj_hash(PyObject *o) {
+    Py_hash_t res = PyObject_Hash(o);
+    if (res == -1)
+        raise_python_error();
+    return res;
+}
+
 PyObject *obj_repr(PyObject *o) {
     PyObject *res = PyObject_Repr(o);
     if (!res)

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -439,4 +439,13 @@ NB_MODULE(test_classes_ext, m) {
     m.def("is_int_1", [](nb::handle h) { return nb::isinstance<int>(h); });
     m.def("is_int_2", [](nb::handle h) { return nb::isinstance<nb::int_>(h); });
     m.def("is_struct", [](nb::handle h) { return nb::isinstance<Struct>(h); });
+
+    // test33_deference
+    struct Deferential {nb::object target; };
+    nb::class_<Deferential>(m, "Deferential")
+        .def(nb::init<nb::object>())
+        .def("__eq__", [](const Deferential &self, nb::object other){
+            return self.target.equal(other);
+        })
+        .def("__hash__", [](const Deferential &self){ return nb::hash(self.target); });
 }

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -440,12 +440,12 @@ NB_MODULE(test_classes_ext, m) {
     m.def("is_int_2", [](nb::handle h) { return nb::isinstance<nb::int_>(h); });
     m.def("is_struct", [](nb::handle h) { return nb::isinstance<Struct>(h); });
 
-    // test33_deference
-    struct Deferential {nb::object target; };
-    nb::class_<Deferential>(m, "Deferential")
+    // test33_indirect_hashing
+    struct Indirect { nb::object target; };
+    nb::class_<Indirect>(m, "Indirect")
         .def(nb::init<nb::object>())
-        .def("__eq__", [](const Deferential &self, nb::object other){
+        .def("__eq__", [](const Indirect &self, nb::object other) {
             return self.target.equal(other);
         })
-        .def("__hash__", [](const Deferential &self){ return nb::hash(self.target); });
+        .def("__hash__", [](const Indirect &self) { return nb::hash(self.target); });
 }

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -546,7 +546,6 @@ def test31_cycle():
     a.value = a
     del a
 
-
 def test32_type_checks():
     v1 = 5
     v2 = t.Struct()
@@ -554,3 +553,9 @@ def test32_type_checks():
     assert t.is_int_1(v1) and not t.is_int_1(v2)
     assert t.is_int_2(v1) and not t.is_int_2(v2)
     assert not t.is_struct(v1) and t.is_struct(v2)
+
+def test33_deference():
+    deferent = "my_val"
+    deferential = t.Deferential(deferent)
+    assert hash(deferential) == hash(deferent)
+    assert deferential == deferent

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -554,8 +554,8 @@ def test32_type_checks():
     assert t.is_int_2(v1) and not t.is_int_2(v2)
     assert not t.is_struct(v1) and t.is_struct(v2)
 
-def test33_deference():
-    deferent = "my_val"
-    deferential = t.Deferential(deferent)
-    assert hash(deferential) == hash(deferent)
-    assert deferential == deferent
+def test33_indirect_hashing():
+    direct = "my_val"
+    indirect = t.Indirect(direct)
+    assert hash(indirect) == hash(direct)
+    assert indirect == direct


### PR DESCRIPTION
pybind11 allows for calling `pybind11::hash(foo)` in C++ as an equivalent of `hash(foo)` in Python. This is handy when binding a type whose Python hash should match that of some other Python object (like a string, perhaps). Expose something similar for nanobind

Test included