### PR TITLE
Discussion - All nanobind types should have a tp_traverse?

### DIFF
--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -191,15 +191,6 @@ NB_ENUM_UNOP(neg, PyNumber_Negative)
 NB_ENUM_UNOP(inv, PyNumber_Invert)
 NB_ENUM_UNOP(abs, PyNumber_Absolute)
 
-int nb_enum_clear(PyObject *) {
-    return 0;
-}
-
-int nb_enum_traverse(PyObject *o, visitproc visit, void *arg) {
-    Py_VISIT(Py_TYPE(o));
-    return 0;
-}
-
 Py_hash_t nb_enum_hash(PyObject *o) {
     Py_hash_t value = 0;
     type_data *t = nb_type_data(Py_TYPE(o));
@@ -239,8 +230,6 @@ void nb_enum_prepare(PyType_Slot **s, bool is_arithmetic) {
     *t++ = { Py_nb_int, (void *) nb_enum_int };
     *t++ = { Py_nb_index, (void *) nb_enum_int };
     *t++ = { Py_tp_getset, (void *) nb_enum_getset };
-    *t++ = { Py_tp_traverse, (void *) nb_enum_traverse };
-    *t++ = { Py_tp_clear, (void *) nb_enum_clear };
     *t++ = { Py_tp_hash, (void *) nb_enum_hash };
 
     if (is_arithmetic) {

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -94,6 +94,10 @@ int wrapper_tp_traverse(PyObject *self, visitproc visit, void *arg) {
     // Inform the Python GC about it
     Py_VISIT(value.ptr());
 
+    // And inform Python GC about our type (bpo-40217)
+    #if PY_VERSION_HEX >= 0x03090000
+        Py_VISIT(Py_TYPE(self));
+    #endif
     return 0;
 }
 

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -546,7 +546,6 @@ def test31_cycle():
     a.value = a
     del a
 
-
 def test32_type_checks():
     v1 = 5
     v2 = t.Struct()
@@ -554,3 +553,6 @@ def test32_type_checks():
     assert t.is_int_1(v1) and not t.is_int_1(v2)
     assert t.is_int_2(v1) and not t.is_int_2(v2)
     assert not t.is_struct(v1) and t.is_struct(v2)
+
+def test33_cycle_with_type():
+    t.Struct.foo = t.Struct()


### PR DESCRIPTION
Hello again! I wasn't _totally_ sure what the best area of the repo was the best to bring this up in. Please forgive me if I picked incorrectly

While cleaning up some leak warnings in our extension module, I was looking into how `nanobind::enum_` handles the cycles that are created between the type -> enumeration members that are instances, stored as attributes on the type ->  the type. Our extension module has a few cases of this pattern: we have our own version of enums (with all the instances being stored as attributes of the type). We also sometimes expose "special" instances of a non-enumeration class as an attribute on the type object itself. That could be done in Python (as my example code shows here) or in C++.

I think the original issue is in [bpo-40217](https://bugs.python.org/issue40217). In 3.8, it looks like CPython tried to handle this automatically (by adding a `tp_traverse` slot; https://github.com/python/cpython/pull/19414). However, it was reverted (I think? https://github.com/python/cpython/pull/20264/), and it seems that it's now incumbent on heap types to define a `tp_traverse` that calls `Py_VISIT` on the type object. This is exactly what `nanobind::enum_` [does](https://github.com/wjakob/nanobind/blob/50e761af3f7cdc2a3986f01bcbd75bf5de2123b6/src/nb_enum.cpp#L242), and `nanobind::class_` [will do it](https://github.com/wjakob/nanobind/blob/50e761af3f7cdc2a3986f01bcbd75bf5de2123b6/src/nb_type.cpp#L432) if the objects have an instance dict. It seems, though, that nanobind should do this for _all_ created types. Otherwise they leak at shutdown.

There's almost certainly some nuance from this issue that I'm missing, so I figured I'd bring this up for discussion (showing the issue) before proposing any specific fix. Thanks for your consideration.