### PR TITLE
eigen: support sparse matrix types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install NumPy
       if: matrix.python != 'pypy3.9' && matrix.python != '3.12.0-alpha.5'
       run: |
-        python -m pip install numpy
+        python -m pip install numpy scipy
 
     - name: Configure
       run: >

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -60,6 +60,9 @@ Version 0.2.0 (TBA)
 * Added casters for dense matrix/array types from the `Eigen library
   <https://eigen.tuxfamily.org/index.php?title=Main_Page>`__. (PR `#120
   <https://github.com/wjakob/nanobind/pull/120>`__).
+* Added casters for sparse matrix/array types from the `Eigen library
+  <https://eigen.tuxfamily.org/index.php?title=Main_Page>`__. (PR `#126
+  <https://github.com/wjakob/nanobind/pull/126>`_).
 * Implemented `nb::bind_vector\<T\>() <bind_vector>` analogous to similar
   functionality in pybind11. (commit `f2df8a
   <https://github.com/wjakob/nanobind/commit/f2df8a90fbfb06ee03a79b0dd85fa0e266efeaa9>`__).

--- a/docs/eigen.rst
+++ b/docs/eigen.rst
@@ -100,3 +100,16 @@ apply:
   .. code-block:: cpp
 
      void f4(nb::DRef<Eigen::MatrixXf> x) { x *= 2; }
+
+
+Sparse matrices
+---------------
+
+There is also support for Eigen's sparse matrices which are mapped to
+``scipy.sparse.csr_matrix``/``scipy.sparse.csc_matrix``. To use it the extra header
+:file:`nanobind/eigen/sparse.h` has to be included.
+
+.. note::
+
+    There is no support for Eigen sparse vectors because there exists no
+    equivalent type in ``scipy.sparse``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,7 @@ discourse:
    ownership_adv
    lowlevel
    typeslots
+   eigen
 
 .. toctree::
    :caption: API Reference

--- a/include/nanobind/eigen/dense.h
+++ b/include/nanobind/eigen/dense.h
@@ -172,7 +172,7 @@ template <typename T> struct type_caster<T, enable_if_t<is_eigen_xpr_v<T>>> {
 
 /// Caster for Eigen::Map<T>
 template <typename T, int Options, typename StrideType>
-struct type_caster<Eigen::Map<T, Options, StrideType>> {
+struct type_caster<Eigen::Map<T, Options, StrideType>, enable_if_t<is_eigen_plain_v<T>>> {
     using Map = Eigen::Map<T, Options, StrideType>;
     using NDArray = array_for_eigen_t<Map>;
     using NDArrayCaster = type_caster<NDArray>;
@@ -231,7 +231,7 @@ struct type_caster<Eigen::Map<T, Options, StrideType>> {
 
 /// Caster for Eigen::Ref<T>
 template <typename T, int Options, typename StrideType>
-struct type_caster<Eigen::Ref<T, Options, StrideType>> {
+struct type_caster<Eigen::Ref<T, Options, StrideType>, enable_if_t<is_eigen_plain_v<T>>> {
     using Ref = Eigen::Ref<T, Options, StrideType>;
     using Map = Eigen::Map<T, Options, StrideType>;
     using MapCaster = make_caster<Map>;

--- a/include/nanobind/eigen/dense.h
+++ b/include/nanobind/eigen/dense.h
@@ -13,8 +13,8 @@
 #include <nanobind/ndarray.h>
 #include <Eigen/Core>
 
-static_assert(EIGEN_VERSION_AT_LEAST(3, 2, 7),
-              "Eigen matrix support in pybind11 requires Eigen >= 3.2.7");
+static_assert(EIGEN_VERSION_AT_LEAST(3, 3, 0),
+              "Eigen matrix support in nanobind requires Eigen >= 3.3.0");
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
 
@@ -53,9 +53,13 @@ is_base_of_template_v<T, Eigen::EigenBase>;
 template <typename T> constexpr bool is_eigen_plain_v =
 is_base_of_template_v<T, Eigen::PlainObjectBase>;
 
+/// Detect Eigen::SparseMatrix
+template <typename T> constexpr bool is_eigen_sparse_v =
+is_base_of_template_v<T, Eigen::SparseMatrixBase>;
+
 /// Detects expression templates
 template <typename T> constexpr bool is_eigen_xpr_v =
-    is_eigen_v<T> && !is_eigen_plain_v<T> &&
+    is_eigen_v<T> && !is_eigen_plain_v<T> && !is_eigen_sparse_v<T> &&
     !std::is_base_of_v<Eigen::MapBase<T, Eigen::ReadOnlyAccessors>, T>;
 
 template <typename T> struct type_caster<T, enable_if_t<is_eigen_plain_v<T>>> {

--- a/include/nanobind/eigen/sparse.h
+++ b/include/nanobind/eigen/sparse.h
@@ -1,0 +1,132 @@
+/*
+    nanobind/eigen/sparse.h: type casters for sparse Eigen matrices
+
+    Copyright (c) 2023 Henri Menke and Wenzel Jakob
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include <nanobind/ndarray.h>
+#include <nanobind/eigen/dense.h>
+#include <Eigen/SparseCore>
+
+#include <type_traits>
+#include <utility>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+
+NAMESPACE_BEGIN(detail)
+
+/// Caster for Eigen::SparseMatrix
+template <typename T> struct type_caster<T, enable_if_t<is_eigen_sparse_v<T>>> {
+    using Scalar = typename T::Scalar;
+    using StorageIndex = typename T::StorageIndex;
+    using Index = typename T::Index;
+    using SparseMap = Eigen::Map<T>;
+
+    static_assert(std::is_same_v<T, Eigen::SparseMatrix<Scalar, T::Options, StorageIndex>>,
+                  "nanobind: Eigen sparse caster only implemented for matrices");
+
+    static constexpr bool row_major = T::IsRowMajor;
+
+    using ScalarNDArray = ndarray<numpy, Scalar, shape<any>>;
+    using StorageIndexNDArray = ndarray<numpy, StorageIndex, shape<any>>;
+
+    using ScalarCaster = make_caster<ScalarNDArray>;
+    using StorageIndexCaster = make_caster<StorageIndexNDArray>;
+
+    NB_TYPE_CASTER(T, const_name<row_major>("scipy.sparse.csr_matrix[",
+                                            "scipy.sparse.csc_matrix[")
+                   + make_caster<Scalar>::Name + const_name("]"));
+
+    ScalarCaster data_caster;
+    StorageIndexCaster indices_caster, indptr_caster;
+
+    bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+        object obj = borrow(src);
+        try {
+            object matrix_type = module_::import_("scipy.sparse").attr(row_major ? "csr_matrix" : "csc_matrix");
+            if (!obj.type().is(matrix_type))
+                obj = matrix_type(obj);
+        } catch (const python_error &) {
+            return false;
+        }
+
+        if (object data_o = obj.attr("data"); !data_caster.from_python(data_o, flags, cleanup))
+            return false;
+        ScalarNDArray& values = data_caster.value;
+
+        if (object indices_o = obj.attr("indices"); !indices_caster.from_python(indices_o, flags, cleanup))
+            return false;
+        StorageIndexNDArray& inner_indices = indices_caster.value;
+
+        if (object indptr_o = obj.attr("indptr"); !indptr_caster.from_python(indptr_o, flags, cleanup))
+            return false;
+        StorageIndexNDArray& outer_indices = indptr_caster.value;
+
+        object shape_o = obj.attr("shape"), nnz_o = obj.attr("nnz");
+        Index rows, cols, nnz;
+        try {
+            if (len(shape_o) != 2)
+                return false;
+            rows = cast<Index>(shape_o[0]);
+            cols = cast<Index>(shape_o[1]);
+            nnz = cast<Index>(nnz_o);
+        } catch (const python_error &) {
+            return false;
+        }
+
+        value = SparseMap(rows, cols, nnz, outer_indices.data(), inner_indices.data(), values.data());
+
+        return true;
+    }
+
+    static handle from_cpp(T &&v, rv_policy policy, cleanup_list *cleanup) noexcept {
+        if (policy == rv_policy::automatic ||
+            policy == rv_policy::automatic_reference)
+            policy = rv_policy::move;
+
+        return from_cpp((const T &) v, policy, cleanup);
+    }
+
+    static handle from_cpp(const T &v, rv_policy policy, cleanup_list *cleanup) noexcept {
+        if (!v.isCompressed()) {
+            PyErr_SetString(PyExc_ValueError,
+                            "nanobind: unable to return an Eigen sparse matrix that is not in a compressed format. "
+                            "Please call `.makeCompressed()` before returning the value on the C++ end.");
+            return handle();
+        }
+        T & src = const_cast<T &>(v);
+
+        object matrix_type;
+        try {
+            matrix_type = module_::import_("scipy.sparse").attr(row_major ? "csr_matrix" : "csc_matrix");
+        } catch (python_error &e) {
+            e.restore();
+            return handle();
+        }
+
+        const size_t data_shape[] = { (size_t)v.nonZeros() };
+        const size_t outer_indices_shape[] = { (size_t)((row_major ? v.rows() : v.cols()) + 1) };
+        ScalarNDArray data(src.valuePtr(), 1, data_shape);
+        StorageIndexNDArray outer_indices(src.outerIndexPtr(), 1, outer_indices_shape);
+        StorageIndexNDArray inner_indices(src.innerIndexPtr(), 1, data_shape);
+
+        try {
+            return matrix_type(make_tuple(
+                                   std::move(data), std::move(inner_indices), std::move(outer_indices)),
+                               make_tuple(v.rows(), v.cols()))
+                .release();
+        } catch (python_error &e) {
+            e.restore();
+            return handle();
+        }
+    }
+};
+
+NAMESPACE_END(detail)
+
+NAMESPACE_END(NB_NAMESPACE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ nanobind_add_module(test_intrusive_ext test_intrusive.cpp object.cpp object.h ${
 nanobind_add_module(test_exception_ext test_exception.cpp object.cpp object.h ${NB_EXTRA_ARGS})
 nanobind_add_module(test_make_iterator_ext test_make_iterator.cpp ${NB_EXTRA_ARGS})
 
-find_package (Eigen3 NO_MODULE)
+find_package (Eigen3 3.3.1 NO_MODULE)
 if (TARGET Eigen3::Eigen)
   nanobind_add_module(test_eigen_ext test_eigen.cpp ${NB_EXTRA_ARGS})
   target_link_libraries(test_eigen_ext PRIVATE Eigen3::Eigen)

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -106,10 +106,16 @@ NB_MODULE(test_eigen_ext, m) {
     m.def("sparse_r", [mat]() -> SparseMatrixR {
         return Eigen::SparseView<Eigen::MatrixXf>(mat);
     });
-    m.def("sparse_c",
-          [mat]() -> SparseMatrixC { return Eigen::SparseView<Eigen::MatrixXf>(mat); });
+    m.def("sparse_c", [mat]() -> SparseMatrixC {
+        return Eigen::SparseView<Eigen::MatrixXf>(mat);
+    });
     m.def("sparse_copy_r", [](const SparseMatrixR &m) -> SparseMatrixR { return m; });
     m.def("sparse_copy_c", [](const SparseMatrixC &m) -> SparseMatrixC { return m; });
+    m.def("sparse_r_uncompressed", []() -> SparseMatrixR {
+        SparseMatrixR m(2,2);
+        m.coeffRef(0,0) = 1.0f;
+        return m;
+    });
 
     struct Buffer {
         uint32_t x[30] { };

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -1,4 +1,5 @@
 #include <nanobind/eigen/dense.h>
+#include <nanobind/eigen/sparse.h>
 
 namespace nb = nanobind;
 
@@ -92,6 +93,23 @@ NB_MODULE(test_eigen_ext, m) {
 
     m.def("updateV3i", [](Eigen::Ref<Eigen::Vector3i> a) { a[2] = 123; });
     m.def("updateVXi", [](Eigen::Ref<Eigen::VectorXi> a) { a[2] = 123; });
+
+    using SparseMatrixR = Eigen::SparseMatrix<float, Eigen::RowMajor>;
+    using SparseMatrixC = Eigen::SparseMatrix<float>;
+    Eigen::MatrixXf mat(5, 6);
+    mat <<
+	 0, 3,  0, 0,  0, 11,
+	22, 0,  0, 0, 17, 11,
+	 7, 5,  0, 1,  0, 11,
+	 0, 0,  0, 0,  0, 11,
+	 0, 0, 14, 0,  8, 11;
+    m.def("sparse_r", [mat]() -> SparseMatrixR {
+        return Eigen::SparseView<Eigen::MatrixXf>(mat);
+    });
+    m.def("sparse_c",
+          [mat]() -> SparseMatrixC { return Eigen::SparseView<Eigen::MatrixXf>(mat); });
+    m.def("sparse_copy_r", [](const SparseMatrixR &m) -> SparseMatrixR { return m; });
+    m.def("sparse_copy_c", [](const SparseMatrixC &m) -> SparseMatrixC { return m; });
 
     struct Buffer {
         uint32_t x[30] { };

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -172,3 +172,28 @@ def test07_mutate_arg():
     A2 = A.copy()
     t.mutate_MXu(A)
     assert np.all(A == 2*A2)
+
+
+@needs_numpy_and_eigen
+def test_sparse():
+    pytest.importorskip("scipy")
+    ref = np.array(
+        [
+            [0.0, 3, 0, 0, 0, 11],
+            [22, 0, 0, 0, 17, 11],
+            [7, 5, 0, 1, 0, 11],
+            [0, 0, 0, 0, 0, 11],
+            [0, 0, 14, 0, 8, 11],
+        ]
+    )
+    def assert_equal_ref(mat):
+        nonlocal ref
+        np.testing.assert_array_equal(mat, ref)
+    def assert_sparse_equal_ref(sparse_mat):
+        assert_equal_ref(sparse_mat.toarray())
+    assert_sparse_equal_ref(t.sparse_r())
+    assert_sparse_equal_ref(t.sparse_c())
+    assert_sparse_equal_ref(t.sparse_copy_r(t.sparse_r()))
+    assert_sparse_equal_ref(t.sparse_copy_c(t.sparse_c()))
+    assert_sparse_equal_ref(t.sparse_copy_r(t.sparse_c()))
+    assert_sparse_equal_ref(t.sparse_copy_c(t.sparse_r()))


### PR DESCRIPTION
This is a first attempt at supporting sparse matrix types from Eigen. The code is mostly ported over from [pybind11](https://github.com/pybind/pybind11/blob/master/include/pybind11/eigen/matrix.h). It compiles but the test segfaults. This could have to with the fact that I have not really a good idea of what I'm doing. Help is very much appreciated.