### PR TITLE
nanobind-config.cmake: Avoid top-level warnings in nanobind headers

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -139,7 +139,7 @@ function (nanobind_build_library TARGET_NAME)
   target_include_directories(${TARGET_NAME} PRIVATE
     ${NB_DIR}/ext/robin_map/include)
 
-  target_include_directories(${TARGET_NAME} PUBLIC
+  target_include_directories(${TARGET_NAME} SYSTEM PUBLIC
     ${Python_INCLUDE_DIRS}
     ${NB_DIR}/include)
 


### PR DESCRIPTION
If you're using nanobind_add_module within a project that has many warnings enabled, the compiler may warn you that nanobind doesn't comply with the current warning settings.

To prevent the warnings set by the top-level project from affecting nanobind, we can add the nanobind include directory with the SYSTEM flag. This will mark the directory as a system directory, which typically means the compiler will not issue warnings for files included from this directory.