### PR TITLE
Add filesystem support

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -97,6 +97,7 @@ function (nanobind_build_library TARGET_NAME)
     ${NB_DIR}/include/nanobind/stl/detail/nb_list.h
     ${NB_DIR}/include/nanobind/stl/detail/nb_set.h
     ${NB_DIR}/include/nanobind/stl/detail/traits.h
+    ${NB_DIR}/include/nanobind/stl/filesystem.h
     ${NB_DIR}/include/nanobind/stl/function.h
     ${NB_DIR}/include/nanobind/stl/list.h
     ${NB_DIR}/include/nanobind/stl/map.h

--- a/docs/exchanging.rst
+++ b/docs/exchanging.rst
@@ -98,6 +98,8 @@ The following table lists the currently available type casters:
     - Built-in (no include file needed)
   * - ``std::array<..>``
     - ``#include <nanobind/stl/array.h>``
+  * - ``std::filesystem``
+    - ``#include <nanobind/stl/filesystem.h>``
   * - ``std::function<..>``
     - ``#include <nanobind/stl/function.h>``
   * - ``std::list<..>``

--- a/docs/exchanging.rst
+++ b/docs/exchanging.rst
@@ -98,7 +98,7 @@ The following table lists the currently available type casters:
     - Built-in (no include file needed)
   * - ``std::array<..>``
     - ``#include <nanobind/stl/array.h>``
-  * - ``std::filesystem``
+  * - ``std::filesystem::path``
     - ``#include <nanobind/stl/filesystem.h>``
   * - ``std::function<..>``
     - ``#include <nanobind/stl/function.h>``

--- a/include/nanobind/stl/filesystem.h
+++ b/include/nanobind/stl/filesystem.h
@@ -1,7 +1,7 @@
 /*
     nanobind/stl/filesystem.h: type caster for std::string
 
-    Copyright (c) 2022 Qingnan Zhou and Wenzel Jakob
+    Copyright (c) 2023 Qingnan Zhou and Wenzel Jakob
 
     All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file.
@@ -9,68 +9,51 @@
 #pragma once
 
 #include <nanobind/nanobind.h>
-#include <string>
 
-#ifdef __has_include
-#if __has_include(<filesystem>)
 #include <filesystem>
-#define NB_HAS_FILESYSTEM 1
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-#define NB_HAS_EXPERIMENTAL_FILESYSTEM 1
-#endif
-#endif
+#include <string>
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
-template <typename T>
-struct path_caster {
+template <>
+struct type_caster<std::filesystem::path> {
 private:
-    static PyObject *unicode_from_fs_native(const std::string &w) {
-#if !defined(PYPY_VERSION)
-        return PyUnicode_DecodeFSDefaultAndSize(w.c_str(), Py_ssize_t(w.size()));
-#else
-        // PyPy mistakenly declares the first parameter as non-const.
-        return PyUnicode_DecodeFSDefaultAndSize(const_cast<char *>(w.c_str()),
+    static str unicode_from_fs_native(const std::string &w) {
+        PyObject* result = PyUnicode_DecodeFSDefaultAndSize(w.c_str(),
                                                 Py_ssize_t(w.size()));
-#endif
+        return steal<str>(result);
     }
 
-    static PyObject *unicode_from_fs_native(const std::wstring &w) {
-        return PyUnicode_FromWideChar(w.c_str(), Py_ssize_t(w.size()));
+    static str unicode_from_fs_native(const std::wstring &w) {
+        PyObject* result = PyUnicode_FromWideChar(w.c_str(), Py_ssize_t(w.size()));
+        return steal<str>(result);
     }
 
 public:
-    static handle from_cpp(const T &path, rv_policy, cleanup_list *) noexcept {
+    static handle from_cpp(const std::filesystem::path &path, rv_policy,
+                           cleanup_list *) noexcept {
         if (auto py_str = unicode_from_fs_native(path.native())) {
             return module_::import_("pathlib")
-                .attr("Path")(steal(py_str))
+                .attr("Path")(py_str)
                 .release();
         }
         return {};
     }
 
     bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
-        // PyUnicode_FSConverter and PyUnicode_FSDecoder normally take care of
-        // calling PyOS_FSPath themselves, but that's broken on PyPy (PyPy
-        // issue #3168) so we do it ourselves instead.
-        PyObject *buf = PyOS_FSPath(src.ptr());
-        if (!buf) {
-            PyErr_Clear();
-            return false;
-        }
         PyObject *native = nullptr;
-        if constexpr (std::is_same_v<typename T::value_type, char>) {
-            if (PyUnicode_FSConverter(buf, &native) != 0) {
+        if constexpr (std::is_same_v<typename std::filesystem::path::value_type,
+                                     char>) {
+            if (PyUnicode_FSConverter(src.ptr(), &native) != 0) {
                 if (auto *c_str = PyBytes_AsString(native)) {
                     // AsString returns a pointer to the internal buffer, which
                     // must not be free'd.
                     value = c_str;
                 }
             }
-        } else if constexpr (std::is_same_v<typename T::value_type, wchar_t>) {
-            if (PyUnicode_FSDecoder(buf, &native) != 0) {
+        } else {
+            if (PyUnicode_FSDecoder(src.ptr(), &native) != 0) {
                 if (auto *c_str = PyUnicode_AsWideCharString(native, nullptr)) {
                     // AsWideCharString returns a new string that must be
                     // free'd.
@@ -80,7 +63,6 @@ public:
             }
         }
         Py_XDECREF(native);
-        Py_DECREF(buf);
         if (PyErr_Occurred()) {
             PyErr_Clear();
             return false;
@@ -88,18 +70,8 @@ public:
         return true;
     }
 
-    NB_TYPE_CASTER(T, const_name("os.PathLike"));
+    NB_TYPE_CASTER(std::filesystem::path, const_name("os.PathLike"));
 };
-
-#if defined(NB_HAS_FILESYSTEM)
-template <>
-struct type_caster<std::filesystem::path>
-    : public path_caster<std::filesystem::path> {};
-#elif defined(NB_HAS_EXPERIMENTAL_FILESYSTEM)
-template <>
-struct type_caster<std::experimental::filesystem::path>
-    : public path_caster<std::experimental::filesystem::path> {};
-#endif
 
 NAMESPACE_END(detail)
 NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/filesystem.h
+++ b/include/nanobind/stl/filesystem.h
@@ -29,16 +29,16 @@ struct path_caster {
 private:
     static PyObject *unicode_from_fs_native(const std::string &w) {
 #if !defined(PYPY_VERSION)
-        return PyUnicode_DecodeFSDefaultAndSize(w.c_str(), ssize_t(w.size()));
+        return PyUnicode_DecodeFSDefaultAndSize(w.c_str(), Py_ssize_t(w.size()));
 #else
         // PyPy mistakenly declares the first parameter as non-const.
         return PyUnicode_DecodeFSDefaultAndSize(const_cast<char *>(w.c_str()),
-                                                ssize_t(w.size()));
+                                                Py_ssize_t(w.size()));
 #endif
     }
 
     static PyObject *unicode_from_fs_native(const std::wstring &w) {
-        return PyUnicode_FromWideChar(w.c_str(), ssize_t(w.size()));
+        return PyUnicode_FromWideChar(w.c_str(), Py_ssize_t(w.size()));
     }
 
 public:

--- a/include/nanobind/stl/filesystem.h
+++ b/include/nanobind/stl/filesystem.h
@@ -1,0 +1,105 @@
+/*
+    nanobind/stl/filesystem.h: type caster for std::string
+
+    Copyright (c) 2022 Qingnan Zhou and Wenzel Jakob
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+#pragma once
+
+#include <nanobind/nanobind.h>
+#include <string>
+
+#ifdef __has_include
+#if __has_include(<filesystem>)
+#include <filesystem>
+#define NB_HAS_FILESYSTEM 1
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+#define NB_HAS_EXPERIMENTAL_FILESYSTEM 1
+#endif
+#endif
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename T>
+struct path_caster {
+private:
+    static PyObject *unicode_from_fs_native(const std::string &w) {
+#if !defined(PYPY_VERSION)
+        return PyUnicode_DecodeFSDefaultAndSize(w.c_str(), ssize_t(w.size()));
+#else
+        // PyPy mistakenly declares the first parameter as non-const.
+        return PyUnicode_DecodeFSDefaultAndSize(const_cast<char *>(w.c_str()),
+                                                ssize_t(w.size()));
+#endif
+    }
+
+    static PyObject *unicode_from_fs_native(const std::wstring &w) {
+        return PyUnicode_FromWideChar(w.c_str(), ssize_t(w.size()));
+    }
+
+public:
+    static handle from_cpp(const T &path, rv_policy, cleanup_list *) noexcept {
+        if (auto py_str = unicode_from_fs_native(path.native())) {
+            return module_::import_("pathlib")
+                .attr("Path")(steal(py_str))
+                .release();
+        }
+        return {};
+    }
+
+    bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
+        // PyUnicode_FSConverter and PyUnicode_FSDecoder normally take care of
+        // calling PyOS_FSPath themselves, but that's broken on PyPy (PyPy
+        // issue #3168) so we do it ourselves instead.
+        PyObject *buf = PyOS_FSPath(src.ptr());
+        if (!buf) {
+            PyErr_Clear();
+            return false;
+        }
+        PyObject *native = nullptr;
+        if constexpr (std::is_same_v<typename T::value_type, char>) {
+            if (PyUnicode_FSConverter(buf, &native) != 0) {
+                if (auto *c_str = PyBytes_AsString(native)) {
+                    // AsString returns a pointer to the internal buffer, which
+                    // must not be free'd.
+                    value = c_str;
+                }
+            }
+        } else if constexpr (std::is_same_v<typename T::value_type, wchar_t>) {
+            if (PyUnicode_FSDecoder(buf, &native) != 0) {
+                if (auto *c_str = PyUnicode_AsWideCharString(native, nullptr)) {
+                    // AsWideCharString returns a new string that must be
+                    // free'd.
+                    value = c_str;  // Copies the string.
+                    PyMem_Free(c_str);
+                }
+            }
+        }
+        Py_XDECREF(native);
+        Py_DECREF(buf);
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+            return false;
+        }
+        return true;
+    }
+
+    NB_TYPE_CASTER(T, const_name("os.PathLike"));
+};
+
+#if defined(NB_HAS_FILESYSTEM)
+template <>
+struct type_caster<std::filesystem::path>
+    : public path_caster<std::filesystem::path> {};
+#elif defined(NB_HAS_EXPERIMENTAL_FILESYSTEM)
+template <>
+struct type_caster<std::experimental::filesystem::path>
+    : public path_caster<std::experimental::filesystem::path> {};
+#endif
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -11,6 +11,7 @@
 #include <nanobind/stl/array.h>
 #include <nanobind/stl/unordered_set.h>
 #include <nanobind/stl/set.h>
+#include <nanobind/stl/filesystem.h>
 
 NB_MAKE_OPAQUE(std::vector<float, std::allocator<float>>)
 
@@ -398,6 +399,17 @@ NB_MODULE(test_stl_ext, m) {
             }
         },
         nb::arg("x"));
+
+    // test66
+#if defined(NB_HAS_FILESYSTEM)
+    m.def("replace_extension", [](std::filesystem::path p, std::string ext) {
+        return p.replace_extension(ext);
+    });
+#elif defined(NB_HAS_EXPERIMENTAL_FILESYSTEM)
+    m.def("replace_extension", [](std::experimental::filesystem::path p, std::string ext) {
+        return p.replace_extension(ext);
+    });
+#endif
 
     struct ClassWithMovableField {
         std::vector<Movable> movable;

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -401,15 +401,10 @@ NB_MODULE(test_stl_ext, m) {
         nb::arg("x"));
 
     // test66
-#if defined(NB_HAS_FILESYSTEM)
     m.def("replace_extension", [](std::filesystem::path p, std::string ext) {
         return p.replace_extension(ext);
     });
-#elif defined(NB_HAS_EXPERIMENTAL_FILESYSTEM)
-    m.def("replace_extension", [](std::experimental::filesystem::path p, std::string ext) {
-        return p.replace_extension(ext);
-    });
-#endif
+    m.def("parent_path", [](const std::filesystem::path &p) { return p.parent_path(); });
 
     struct ClassWithMovableField {
         std::vector<Movable> movable;

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -2,7 +2,6 @@ import test_stl_ext as t
 import pytest
 import sys
 from common import collect, skip_on_pypy
-import pathlib
 
 
 @pytest.fixture
@@ -731,11 +730,25 @@ def test65_class_with_movable_field(clean):
     )
 
 def test66_replace_extension():
-    if not hasattr(t, "replace_extension"): return
+    from pathlib import Path
 
-    filename = pathlib.Path("test.txt")
+    filename = Path("test.txt")
     assert t.replace_extension(filename, ".obj") == filename.with_suffix(".obj")
 
-    filename = pathlib.Path("🍊.html")
+    filename = Path("🍊.html")
     assert t.replace_extension(filename, ".svg") == filename.with_suffix(".svg")
+
+    class PseudoStrPath:
+        def __fspath__(self):
+            return "foo/bar"
+
+    class PseudoBytesPath:
+        def __fspath__(self):
+            return b"foo/bar"
+
+    assert t.parent_path(Path("foo/bar")) == Path("foo")
+    assert t.parent_path("foo/bar") == Path("foo")
+    assert t.parent_path(b"foo/bar") == Path("foo")
+    assert t.parent_path(PseudoStrPath()) == Path("foo")
+    assert t.parent_path(PseudoBytesPath()) == Path("foo")
 

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -2,6 +2,7 @@ import test_stl_ext as t
 import pytest
 import sys
 from common import collect, skip_on_pypy
+import pathlib
 
 
 @pytest.fixture
@@ -728,3 +729,13 @@ def test65_class_with_movable_field(clean):
         move_constructed=2,
         destructed=4
     )
+
+def test66_replace_extension():
+    if not hasattr(t, "replace_extension"): return
+
+    filename = pathlib.Path("test.txt")
+    assert t.replace_extension(filename, ".obj") == filename.with_suffix(".obj")
+
+    filename = pathlib.Path("🍊.html")
+    assert t.replace_extension(filename, ".svg") == filename.with_suffix(".svg")
+


### PR DESCRIPTION
Summary:
* Add type caster for `std::filesystem::path` ~~or `std::experimental::filesystem::path`~~ to `pathlib.Path` based on [pybind11's counterpart](https://github.com/pybind/pybind11/blob/master/include/pybind11/stl/filesystem.h).
* Add unit test and update doc.