### PR TITLE
Add <exception> to headers included by nanobind.

### DIFF
--- a/include/nanobind/nanobind.h
+++ b/include/nanobind/nanobind.h
@@ -27,6 +27,7 @@
 
 // Core C++ headers that nanobind depends on
 #include <cstdint>
+#include <exception>
 #include <stdexcept>
 #include <type_traits>
 #include <typeinfo>


### PR DESCRIPTION
nanobind uses types from <exception> without including the header, e.g., std::exception. This will break in future versions of libc++, where not all such types are available via transitive includes.