### PR TITLE
Support bool ndarray

### DIFF
--- a/tests/test_ndarray.cpp
+++ b/tests/test_ndarray.cpp
@@ -19,9 +19,13 @@ NB_MODULE(test_ndarray_ext, m) {
     m.def("check_float", [](const nb::ndarray<> &t) {
         return t.dtype() == nb::dtype<float>();
     });
+    m.def("check_bool", [](const nb::ndarray<> &t) {
+        return t.dtype() == nb::dtype<bool>();
+    });
 
     m.def("pass_float32", [](const nb::ndarray<float> &) { }, "array"_a.noconvert());
     m.def("pass_uint32", [](const nb::ndarray<uint32_t> &) { }, "array"_a.noconvert());
+    m.def("pass_bool", [](const nb::ndarray<bool> &) { }, "array"_a.noconvert());
     m.def("pass_float32_shaped",
           [](const nb::ndarray<float, nb::shape<3, nb::any, 4>> &) {}, "array"_a.noconvert());
 


### PR DESCRIPTION
This pull request adds support for bool ndarray. The bool type was introduced in DLPack [v0.8](https://github.com/dmlc/dlpack/issues/75).

The changes are ad follows:

* Add bool type to dtype code
* Add tests for NumPy, TensorFlow, and JAX.
  *  [PyTorch](https://github.com/pytorch/pytorch/blob/0c7ca2d97ba5980a2af7dcd6b8106dc915e591cd/aten/src/ATen/dlpack.h#L89) does not seem to support the bool type yet (?)

@wjakob Could you review this?