### PR TITLE
Implement nb_func.__{name,qualname,module}__ without properties

### DIFF
--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -74,13 +74,10 @@
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
-extern PyObject *nb_func_get_doc(PyObject *, void *);
-extern PyObject *nb_func_get_name(PyObject *, void *);
-extern PyObject *nb_func_get_qualname(PyObject *, void *);
-extern PyObject *nb_func_get_module(PyObject *, void *);
-#if PY_VERSION_HEX < 0x03090000
 extern PyObject *nb_func_getattro(PyObject *, PyObject *);
-#endif
+extern PyObject *nb_func_get_doc(PyObject *, void *);
+extern PyObject *nb_bound_method_getattro(PyObject *, PyObject *);
+extern PyObject *nb_func_get_getset(PyObject *, PyObject *);
 extern int nb_func_traverse(PyObject *, visitproc, void *);
 extern int nb_func_clear(PyObject *);
 extern void nb_func_dealloc(PyObject *);
@@ -109,18 +106,13 @@ static PyMemberDef nb_func_members[] = {
 
 static PyGetSetDef nb_func_getset[] = {
     { "__doc__", nb_func_get_doc, nullptr, nullptr, nullptr },
-    { "__name__", nb_func_get_name, nullptr, nullptr, nullptr },
-    { "__qualname__", nb_func_get_qualname, nullptr, nullptr, nullptr },
-    { "__module__", nb_func_get_module, nullptr, nullptr, nullptr },
     { nullptr, nullptr, nullptr, nullptr, nullptr }
 };
 
 static PyType_Slot nb_func_slots[] = {
     { Py_tp_members, (void *) nb_func_members },
     { Py_tp_getset, (void *) nb_func_getset },
-#if PY_VERSION_HEX < 0x03090000
     { Py_tp_getattro, (void *) nb_func_getattro },
-#endif
     { Py_tp_traverse, (void *) nb_func_traverse },
     { Py_tp_clear, (void *) nb_func_clear },
     { Py_tp_dealloc, (void *) nb_func_dealloc },
@@ -142,9 +134,7 @@ static PyType_Spec nb_func_spec = {
 static PyType_Slot nb_method_slots[] = {
     { Py_tp_members, (void *) nb_func_members },
     { Py_tp_getset, (void *) nb_func_getset },
-#if PY_VERSION_HEX < 0x03090000
     { Py_tp_getattro, (void *) nb_func_getattro },
-#endif
     { Py_tp_traverse, (void *) nb_func_traverse },
     { Py_tp_clear, (void *) nb_func_clear },
     { Py_tp_dealloc, (void *) nb_func_dealloc },
@@ -172,6 +162,7 @@ static PyMemberDef nb_bound_method_members[] = {
 
 static PyType_Slot nb_bound_method_slots[] = {
     { Py_tp_members, (void *) nb_bound_method_members },
+    { Py_tp_getattro, (void *) nb_bound_method_getattro },
     { Py_tp_traverse, (void *) nb_bound_method_traverse },
     { Py_tp_clear, (void *) nb_bound_method_clear },
     { Py_tp_dealloc, (void *) nb_bound_method_dealloc },

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -309,6 +309,7 @@ NB_MODULE(test_classes_ext, m) {
     struct MyClass { struct NestedClass { }; };
     nb::class_<MyClass> mcls(m, "MyClass");
     nb::class_<MyClass::NestedClass> ncls(mcls, "NestedClass");
+    mcls.def(nb::init<>());
     mcls.def("f", []{});
     ncls.def("f", []{});
 

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -31,6 +31,7 @@ def test01_signature():
     assert t.Struct.value.__doc__ == "value(self) -> int"
     assert t.Struct.create_move.__doc__ == "create_move() -> test_classes_ext.Struct"
     assert t.Struct.set_value.__doc__ == "set_value(self, value: int) -> None"
+    assert t.Struct().set_value.__doc__ == "set_value(self, value: int) -> None"
     assert t.Struct.__doc__ == 'Some documentation'
     assert t.Struct.static_test.__doc__ == (
         "static_test(arg: int, /) -> int\n"
@@ -376,6 +377,9 @@ def test17_name_qualname_module():
     assert MyClass.f.__name__ == 'f'
     assert MyClass.f.__qualname__ == 'MyClass.f'
     assert MyClass.f.__module__ == 'test_classes'
+    assert MyClass().f.__name__ == 'f'
+    assert MyClass().f.__qualname__ == 'MyClass.f'
+    assert MyClass().f.__module__ == 'test_classes'
     assert MyClass.NestedClass.__name__ == 'NestedClass'
     assert MyClass.NestedClass.__qualname__ == 'MyClass.NestedClass'
     assert MyClass.NestedClass.__module__ == 'test_classes'
@@ -387,12 +391,21 @@ def test17_name_qualname_module():
     assert t.f.__module__ == 'test_classes_ext'
     assert t.f.__name__ == 'f'
     assert t.f.__qualname__ == 'f'
+    assert type(t.f).__module__ == 'nanobind'
+    assert type(t.f).__name__ == 'nb_func'
+    assert type(t.f).__qualname__ == 'nb_func'
     assert t.MyClass.__name__ == 'MyClass'
     assert t.MyClass.__qualname__ == 'MyClass'
     assert t.MyClass.__module__ == 'test_classes_ext'
     assert t.MyClass.f.__name__ == 'f'
     assert t.MyClass.f.__qualname__ == 'MyClass.f'
     assert t.MyClass.f.__module__ == 'test_classes_ext'
+    assert t.MyClass().f.__name__ == 'f'
+    assert t.MyClass().f.__qualname__ == 'MyClass.f'
+    assert t.MyClass().f.__module__ == 'test_classes_ext'
+    assert type(t.MyClass.f).__module__ == 'nanobind'
+    assert type(t.MyClass.f).__name__ == 'nb_method'
+    assert type(t.MyClass.f).__qualname__ == 'nb_method'
     assert t.MyClass.NestedClass.__name__ == 'NestedClass'
     assert t.MyClass.NestedClass.__qualname__ == 'MyClass.NestedClass'
     assert t.MyClass.NestedClass.__module__ == 'test_classes_ext'


### PR DESCRIPTION
A subtle side effect of how
``nb_func``/``nb_method``/``nb_bound_method`` attribute getters were implemented caused problems in combination with IPython (see issue #148). This commit explores an alternative approach.