### PR TITLE
Add missing IsClass to std::pair type_caster

### DIFF
--- a/include/nanobind/stl/optional.h
+++ b/include/nanobind/stl/optional.h
@@ -23,7 +23,7 @@ struct type_caster<std::optional<T>> {
     using Ti = detail::intrinsic_t<T>;
     using Caster = make_caster<Ti>;
 
-    static constexpr auto Name = const_name("Optional[") + concat(Caster::Name) + const_name("]");;
+    static constexpr auto Name = const_name("Optional[") + concat(Caster::Name) + const_name("]");
     static constexpr bool IsClass = false;
 
     template <typename T_>

--- a/include/nanobind/stl/pair.h
+++ b/include/nanobind/stl/pair.h
@@ -43,6 +43,7 @@ template <typename T1, typename T2> struct type_caster<std::pair<T1, T2>> {
     // Value name for docstring generation
     static constexpr auto Name =
         const_name(NB_TYPING_TUPLE "[") + concat(Caster1::Name, Caster2::Name) + const_name("]");
+    static constexpr bool IsClass = false;
 
     /// Python -> C++ caster, populates `caster1` and `caster2` upon success
     bool from_python(handle src, uint8_t flags,


### PR DESCRIPTION
The std::pair type_caster is missing an `bool IsClass = false;`.
Without that an error is triggered when building and using `def_rw` together with an std::pair.
The problem is not covered by the tests. 