### PR TITLE
Fix for ndarray_import when tensor imported is batch size 1.

### DIFF
--- a/tests/test_ndarray.cpp
+++ b/tests/test_ndarray.cpp
@@ -141,4 +141,13 @@ NB_MODULE(test_ndarray_ext, m) {
 
             return nb::ndarray<nb::numpy, float>(f, 0, shape, deleter);
     });
+
+    m.def(
+        "noop_3d_c_contig",
+        [](nb::ndarray<float, nb::shape<nb::any, nb::any, nb::any>, nb::c_contig>) { return; });
+
+    m.def(
+        "noop_2d_f_contig",
+        [](nb::ndarray<float, nb::shape<nb::any, nb::any>, nb::f_contig>) { return; });
+
 }

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -358,3 +358,52 @@ def test18_return_array_scalar():
     del x
     collect()
     assert t.destruct_count() - dc == 1
+
+# See PR #162
+@needs_torch
+def test19_single_and_empty_dimension_pytorch():
+    a = torch.ones((1,100,1025), dtype=torch.float32)
+    t.noop_3d_c_contig(a)
+    a = torch.ones((100,1,1025), dtype=torch.float32)
+    t.noop_3d_c_contig(a)
+    a = torch.ones((0,100,1025), dtype=torch.float32)
+    t.noop_3d_c_contig(a)
+    a = torch.ones((100,0,1025), dtype=torch.float32)
+    t.noop_3d_c_contig(a)
+    a = torch.ones((100,1025,0), dtype=torch.float32)
+    t.noop_3d_c_contig(a)
+    a = torch.ones((100,0,0), dtype=torch.float32)
+    t.noop_3d_c_contig(a)
+    a = torch.ones((0,0,0), dtype=torch.float32)
+    t.noop_3d_c_contig(a)
+
+# See PR #162
+@needs_numpy
+def test20_single_and_empty_dimension_numpy():
+    a = np.ones((1,100,1025), dtype=np.float32)
+    t.noop_3d_c_contig(a)
+    a = np.ones((100,1,1025), dtype=np.float32)
+    t.noop_3d_c_contig(a)
+    a = np.ones((0,100,1025), dtype=np.float32)
+    t.noop_3d_c_contig(a)
+    a = np.ones((100,0,1025), dtype=np.float32)
+    t.noop_3d_c_contig(a)
+    a = np.ones((100,1025,0), dtype=np.float32)
+    t.noop_3d_c_contig(a)
+    a = np.ones((100,0,0), dtype=np.float32)
+    t.noop_3d_c_contig(a)
+    a = np.ones((0,0,0), dtype=np.float32)
+    t.noop_3d_c_contig(a)
+
+# See PR #162
+@needs_torch
+def test21_single_and_empty_dimension_fortran_order_pytorch():
+    # This idiom creates a pytorch 2D tensor in column major (aka, 'F') ordering
+    a = torch.ones((0,100), dtype=torch.float32).t().contiguous().t()
+    t.noop_2d_f_contig(a)
+    a = torch.ones((100,0), dtype=torch.float32).t().contiguous().t()
+    t.noop_2d_f_contig(a)
+    a = torch.ones((1,100), dtype=torch.float32).t().contiguous().t()
+    t.noop_2d_f_contig(a)
+    a = torch.ones((100,1), dtype=torch.float32).t().contiguous().t()
+    t.noop_2d_f_contig(a)


### PR DESCRIPTION
Sorry for making a pullrequest instead of an issue, but it looks like pytorch does not always set the stride of its outermost dimension equal to 0 or the "expected stride" (i.e., the stride you would get if you increased the singleton dimension to a length greater than 1) when that dimension is singleton (i.e., that dimension's length is 1). Instead, it uses a stride of 1. `ndarray_import` assumes that singleton dimensions either have the "expected stride" or 0. If this isn't the case, you get an error about "incompatible function arguments".

I wrote a few reproducers for this issue, as well as a basic fix, though I admit it's a bit "ugly". However, since the only index that will ever be valid for a dimension of size 1 is 0, its stride will never be used anyway.

Edit: Upon further reflection, I don't believe this quick fix is entirely correct. What we want is to allow the slowest-changing dimension (So the first one in "C" ordering, or the last one in "F" ordering) to have any stride value when its length is equal to 1.