### PR TITLE
Wrap `PyInit_##name` in macro to allow macros as module names

### DIFF
--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -131,12 +131,15 @@
 #    error "nanobind requires a newer PyPy version (>= 7.3.10)"
 #endif
 
-#define NB_MODULE(name, variable)                                              \
+#define NB_MODULE_IMPL(name)                                                   \
     extern "C" [[maybe_unused]] NB_EXPORT PyObject *PyInit_##name();           \
+    extern "C" NB_EXPORT PyObject *PyInit_##name()
+
+#define NB_MODULE(name, variable)                                              \
     static PyModuleDef NB_CONCAT(nanobind_module_def_, name);                  \
     [[maybe_unused]] static void NB_CONCAT(nanobind_init_,                     \
                                            name)(::nanobind::module_ &);       \
-    extern "C" NB_EXPORT PyObject *PyInit_##name() {                           \
+    NB_MODULE_IMPL(name) {                                                     \
         nanobind::module_ m =                                                  \
             nanobind::steal<nanobind::module_>(nanobind::detail::module_new(   \
                 NB_TOSTRING(name), &NB_CONCAT(nanobind_module_def_, name)));   \


### PR DESCRIPTION
This is similar to what pybind11 does:

https://github.com/pybind/pybind11/blob/4ce05175d51a4685232452bdc1e9cbb13a240a65/include/pybind11/detail/common.h#LL372-L374

Pasting the macro argument directly does not work, as demonstrated by: https://godbolt.org/z/Kv9EEfEsY