### PR TITLE
Remove '<anonymous>' from docstring

### DIFF
--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -256,7 +256,7 @@ PyObject *nb_func_new(const void *in_) noexcept {
         fc->flags |= (uint32_t) func_flags::has_args;
 
     if (!has_name)
-        fc->name = "<anonymous>";
+        fc->name = "";
 
     if (is_implicit) {
         if (!(fc->flags & (uint32_t) func_flags::is_constructor))


### PR DESCRIPTION
Remove '<anonymous>' from docstring.  It's left in the error message for convenience.

Related to https://github.com/wjakob/nanobind/discussions/171 .