### PR TITLE
nb::handle: make bool conversion explicit to avoid ambiguity with integer conversions in derived types

### DIFF
--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -179,7 +179,7 @@ public:
         return *this;
     }
 
-    NB_INLINE operator bool() const { return m_ptr != nullptr; }
+    NB_INLINE explicit operator bool() const { return m_ptr != nullptr; }
     NB_INLINE PyObject *ptr() const { return m_ptr; }
     NB_INLINE static bool check_(handle) { return true; }
 


### PR DESCRIPTION
An `explicit operator bool()` can still be used in conditional tests without a cast (`if (h) { ... }`) and is a better match for the explicitness of, for example, `operator int()` in `nb::int_`. Without this change, if you write
```
void fn(nb::int_ ival) {
    int i = ival;
    printf("%d\n", i);
}
```
then `fn(nb::int_(42))` will print 1. (Only implicit conversions are allowed by the initialization style used, so the implicit `operator bool` in `nb::handle` is eligible while the explicit `operator int` in `nb::int_` is not.)