### PR TITLE
nb::typed<>: support use in return position

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -2130,11 +2130,12 @@ Miscellaneous
 
 .. cpp:struct:: template <typename T, typename D> typed
 
-    This helper class provides an an API for overriding the type annotation of
-    a function argument in generated docstrings. It is particularly helpful
-    when the type signature is not obvious and must be computed at compile time.
-    Otherwise, the :cpp:class:`raw_doc` attribute provides a simpler
-    alternative for taking full control of docstrings and type annotations.
+    This helper class provides an an API for overriding the type
+    annotation of a function argument or return value in generated
+    docstrings. It is particularly helpful when the type signature is
+    not obvious and must be computed at compile time.  Otherwise, the
+    :cpp:class:`raw_doc` attribute provides a simpler alternative for
+    taking full control of docstrings and type annotations.
 
     Consider the following binding that iterates over a Python list.
 

--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -220,7 +220,7 @@ template <typename T, typename X> struct type_caster<typed<T, X>> {
         return true;
     }
 
-    static handle from_cpp(const T &src, rv_policy policy,
+    static handle from_cpp(const T2 &src, rv_policy policy,
                            cleanup_list *cleanup) noexcept {
         return Caster::from_cpp(src.value, policy, cleanup);
     }


### PR DESCRIPTION
The uses are analogous to those in argument position; for example, you might want to return `nb::iterator` but indicate in the signature that it's an iterator over some specific type. It almost worked already, just had a typo in the `type_caster`.