### PR TITLE
Refactor type_data to save space and reduce nb_type/nb_enum entanglement

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1409,8 +1409,7 @@ Class binding annotations
 -------------------------
 
 The following annotations can be specified using the variable-length ``Extra``
-parameter of the constructor :cpp:func:`class_::class_` and
-:cpp:func:`enum_::enum_`.
+parameter of the constructor :cpp:func:`class_::class_`.
 
 .. cpp:struct:: is_final
 
@@ -1419,16 +1418,6 @@ parameter of the constructor :cpp:func:`class_::class_` and
 .. cpp:struct:: dynamic_attr
 
    Indicate that a type requires a Python dictionary to support the dynamic addition of attributes.
-
-.. cpp:struct:: is_enum
-
-   .. cpp:function:: is_enum(bool is_signed)
-
-      Mark the bound class as an enumeration backed by a signed or unsigned integer type.
-
-.. cpp:struct:: is_arithmetic
-
-   Indicate that the enumeration may be used as part of arithmetic operations.
 
 .. cpp:struct:: template <typename T> supplement
 
@@ -1455,6 +1444,27 @@ parameter of the constructor :cpp:func:`class_::class_` and
 
       Declares a callback that will be invoked when a C++ instance is first
       cast into a Python object.
+
+
+.. _enum_binding_annotations:
+
+Enum binding annotations
+------------------------
+
+The following annotations can be specified using the variable-length
+``Extra`` parameter of the constructor :cpp:func:`enum_::enum_`.
+Enums also support the :cpp:struct:`dynamic_attr`,
+:cpp:struct:`supplement`, and :cpp:struct:`type_slots` annotations
+documented for :ref:`classes <class_binding_annotations>`.
+
+.. cpp:struct:: is_arithmetic
+
+   Indicate that the enumeration may be used with arithmetic
+   operations.  This enables the binary operators ``+ - * // & | ^ <<
+   >>`` and unary ``- ~ abs()``, with operands of either enumeration
+   or integer type; the result will be a regular integer. It is
+   unspecified whether operations on mixed enum types (such as
+   ``Shape.Circle + Color.Red``) are permissible.
 
 Function binding
 ----------------
@@ -1831,8 +1841,8 @@ Class binding
 
       Bind the enumeration of type `T` to the identifier `name` within the
       scope `scope`. The variable length `extra` parameter can be used to pass
-      a docstring and other :ref:`class binding annotations
-      <class_binding_annotations>` such as :cpp:class:`is_arithmetic`.
+      a docstring and other :ref:`enum binding annotations
+      <enum_binding_annotations>` such as :cpp:class:`is_arithmetic`.
 
    .. cpp:function:: enum_ &value(const char * name, T value, const char * doc = nullptr)
 
@@ -1988,15 +1998,16 @@ Type objects
 
 .. cpp:function:: template <typename T> T &type_supplement(handle h)
 
-   Return a reference to supplemental data stashed in a type object. See
-   :cpp:class:`supplement`.
+   Return a reference to supplemental data stashed in a type object.
+   The type ``T`` must exactly match the type specified in the
+   :cpp:class:`nb::supplement\<T\> <supplement>` annotation used when
+   creating the type; no type check is performed, and accessing an
+   incorrect supplement type may crash the interpreter.
+   See :cpp:class:`supplement`.
 
 Instances
 ^^^^^^^^^
 
-
-Low-level instance access
--------------------------
 .. cpp:function:: bool inst_check(handle h)
 
    Returns ``true`` if `h` represents an instance of a type that was

--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -20,8 +20,8 @@ The following experiments analyze the performance of a large function-heavy
 <https://github.com/pybind/pybind11/tree/smart_holder>`__ that addresses
 long-standing issues related to holder types in pybind11.
 
-Each experiment is shown twice: light gray `[debug]` columns provide data for
-a debug build, and `[opt]` shows a size-optimized build that is representative
+Each experiment is shown twice: light gray ``[debug]`` columns provide data for
+a debug build, and ``[opt]`` shows a size-optimized build that is representative
 of a deployment scenario. The former is included to show that nanobind
 performance is also good during a typical development workflow.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,8 +15,26 @@ case, both modules must use the same nanobind ABI version, or they will be
 isolated from each other. Releases that don't explicitly mention an ABI version
 below inherit that of the preceding release.
 
-Version 1.2.0 (April 24, 2023)
+Version 1.3.0 (TBD)
 -------------------
+
+* Reduced the size of nanobind type objects by 4 pointers.
+  (PR `#192 <https://github.com/wjakob/nanobind/pull/192>`__).
+* Improved support for storing :ref:`supplemental data <supplement>`
+  that consists of a pointer to storage that is not managed by nanobind.
+  We now avoid an additional indirection in this case: the type object
+  stores the pointer directly instead of allocating the pointer on the
+  heap and then pointing to it.
+  (PR `#192 <https://github.com/wjakob/nanobind/pull/192>`__).
+* Updated the implementation of :cpp:class:`nb::enum_ <enum_>` so it does
+  not take advantage of any private nanobind type details. As a side effect,
+  the construct ``nb::class_<T>(..., nb::is_enum(...))`` is no longer permitted;
+  use ``nb::enum_<T>(...)`` instead.
+  (PR `#192 <https://github.com/wjakob/nanobind/pull/192>`__).
+* ABI version 9.
+
+Version 1.2.0 (April 24, 2023)
+------------------------------
 
 * Improvements to the internal C++ → Python instance map data structure to improve
   performance and address type confusion when returning previously registered instances.

--- a/docs/lowlevel.rst
+++ b/docs/lowlevel.rst
@@ -227,3 +227,20 @@ Here is what this might look like in an implementation:
 The :cpp:class:`nb::supplement\<T\>() <supplement>` annotation implicitly
 also passes :cpp:class:`nb::is_final() <is_final>` to ensure that type
 objects with supplemental data cannot be subclassed in Python.
+
+nanobind does not perform any initialization or destruction of the
+supplemental data, and therefore requires that the specified type
+``T`` be trivially default constructible. Note that the supplemental
+data will be **uninitialized** when the type is created, so you must
+either set all fields or use placement new to value-initialize the object.
+If you need to make your supplement own resources, you can use
+``nb::supplement<T*>()`` instead, and manage the lifetime of the ``T``
+object yourself.
+
+.. warning:: If your supplemental data owns Python object references,
+             you may wind up with reference leaks because the supplemental
+             data is not visible to Python's garbage collector. A recommended
+             alternative is to store the Python object references as
+             attributes of the type object (in its ``__dict__``), and
+             cache only non-owning references (:cpp:class:`nb::handle <handle>`)
+             inside the supplemental data.

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -53,7 +53,6 @@ struct is_implicit {};
 struct is_operator {};
 struct is_arithmetic {};
 struct is_final {};
-struct is_enum { bool is_signed; };
 
 template <size_t /* Nurse */, size_t /* Patient */> struct keep_alive {};
 template <typename T> struct supplement {};

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -226,8 +226,8 @@ NB_CORE PyObject *nb_func_new(const void *data) noexcept;
 // ========================================================================
 
 /// Create a Python type object for the given type record
-struct type_data;
-NB_CORE PyObject *nb_type_new(const type_data *c) noexcept;
+struct type_data_prelim;
+NB_CORE PyObject *nb_type_new(const type_data_prelim *c) noexcept;
 
 /// Extract a pointer to a C++ type underlying a Python object, if possible
 NB_CORE bool nb_type_get(const std::type_info *t, PyObject *o, uint8_t flags,
@@ -258,8 +258,11 @@ NB_CORE PyObject *nb_type_put_unique_p(const std::type_info *cpp_type,
 /// Try to reliquish ownership from Python object to a unique_ptr
 NB_CORE void nb_type_relinquish_ownership(PyObject *o, bool cpp_delete);
 
-/// Get a pointer to a user-defined 'extra' value associated with the nb_type t.
-NB_CORE void *nb_type_supplement(PyObject *t) noexcept;
+/// Return a pointer to the type_data::supplement field associated with
+/// the given nanobind type. This stores a piece of user-supplied
+/// data if small, or points to it otherwise; see use_inline_supplement
+/// in nb_class.h to disambiguate once you know the supplemental data type.
+NB_CORE void **nb_type_supplement(PyObject *t) noexcept;
 
 /// Check if the given python object represents a nanobind type
 NB_CORE bool nb_type_check(PyObject *t) noexcept;
@@ -348,6 +351,14 @@ NB_CORE void implicitly_convertible(bool (*predicate)(PyTypeObject *,
                                     const std::type_info *dst) noexcept;
 
 // ========================================================================
+
+struct enum_data_prelim;
+
+/// Extend ed.slots with type slots implementing enum functionality
+NB_CORE void nb_enum_prepare(enum_data_prelim *ed) noexcept;
+
+/// Extend ed.slots with the given user-provided type slots
+NB_CORE void nb_enum_extend_slots(enum_data_prelim *ed, const PyType_Slot *slots) noexcept;
 
 /// Add an entry to an enumeration
 NB_CORE void nb_enum_put(PyObject *type, const char *name, const void *value,

--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -13,11 +13,9 @@
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
-static PyObject *nb_enum_int(PyObject *o);
-
 /// Map to unique representative enum instance, returns a borrowed reference
 static PyObject *nb_enum_lookup(PyObject *self) {
-    PyObject *int_val = nb_enum_int(self),
+    PyObject *int_val = PyNumber_Index(self),
              *dict    = PyObject_GetAttrString((PyObject *) Py_TYPE(self), "__entries");
 
     PyObject *rec = nullptr;
@@ -69,36 +67,34 @@ static PyObject *nb_enum_get_doc(PyObject *self, void *) {
     return result;
 }
 
-static PyObject *nb_enum_int(PyObject *o) {
+static PyObject *nb_enum_int_signed(PyObject *o) {
     type_data *t = nb_type_data(Py_TYPE(o));
-
     const void *p = inst_ptr((nb_inst *) o);
-    if (t->flags & (uint32_t) type_flags::is_unsigned_enum) {
-        unsigned long long value;
-        switch (t->size) {
-            case 1: value = (unsigned long long) *(const uint8_t *)  p; break;
-            case 2: value = (unsigned long long) *(const uint16_t *) p; break;
-            case 4: value = (unsigned long long) *(const uint32_t *) p; break;
-            case 8: value = (unsigned long long) *(const uint64_t *) p; break;
-            default: PyErr_SetString(PyExc_TypeError, "nb_enum: invalid type size!");
-                     return nullptr;
-        }
-        return PyLong_FromUnsignedLongLong(value);
-    } else if (t->flags & (uint32_t) type_flags::is_signed_enum) {
-        long long value;
-        switch (t->size) {
-            case 1: value = (long long) *(const int8_t *)  p; break;
-            case 2: value = (long long) *(const int16_t *) p; break;
-            case 4: value = (long long) *(const int32_t *) p; break;
-            case 8: value = (long long) *(const int64_t *) p; break;
-            default: PyErr_SetString(PyExc_TypeError, "nb_enum: invalid type size!");
-                     return nullptr;
-        }
-        return PyLong_FromLongLong(value);
-    } else {
-        PyErr_SetString(PyExc_TypeError, "nb_enum: input is not an enumeration!");
-        return nullptr;
+    long long value;
+    switch (t->size) {
+        case 1: value = (long long) *(const int8_t *)  p; break;
+        case 2: value = (long long) *(const int16_t *) p; break;
+        case 4: value = (long long) *(const int32_t *) p; break;
+        case 8: value = (long long) *(const int64_t *) p; break;
+        default: PyErr_SetString(PyExc_TypeError, "nb_enum: invalid type size!");
+                 return nullptr;
     }
+    return PyLong_FromLongLong(value);
+}
+
+static PyObject *nb_enum_int_unsigned(PyObject *o) {
+    type_data *t = nb_type_data(Py_TYPE(o));
+    const void *p = inst_ptr((nb_inst *) o);
+    unsigned long long value;
+    switch (t->size) {
+        case 1: value = (unsigned long long) *(const uint8_t *)  p; break;
+        case 2: value = (unsigned long long) *(const uint16_t *) p; break;
+        case 4: value = (unsigned long long) *(const uint32_t *) p; break;
+        case 8: value = (unsigned long long) *(const uint64_t *) p; break;
+        default: PyErr_SetString(PyExc_TypeError, "nb_enum: invalid type size!");
+                 return nullptr;
+    }
+    return PyLong_FromUnsignedLongLong(value);
 }
 
 static PyObject *nb_enum_init(PyObject *, PyObject *, PyObject *) {
@@ -203,21 +199,15 @@ int nb_enum_traverse(PyObject *o, visitproc visit, void *arg) {
 Py_hash_t nb_enum_hash(PyObject *o) {
     Py_hash_t value = 0;
     type_data *t = nb_type_data(Py_TYPE(o));
-    if (t->flags & (uint32_t(type_flags::is_unsigned_enum) |
-                    uint32_t(type_flags::is_signed_enum))) {
-        const void *p = inst_ptr((nb_inst *) o);
-        switch (t->size) {
-            case 1: value = *(const int8_t *)  p; break;
-            case 2: value = *(const int16_t *) p; break;
-            case 4: value = *(const int32_t *) p; break;
-            case 8: value = *(const int64_t *) p; break;
-            default:
-                PyErr_SetString(PyExc_TypeError, "nb_enum: invalid type size!");
-                return -1;
-        }
-    } else {
-        PyErr_SetString(PyExc_TypeError, "nb_enum: input is not an enumeration!");
-        return -1;
+    const void *p = inst_ptr((nb_inst *) o);
+    switch (t->size) {
+        case 1: value = *(const int8_t *)  p; break;
+        case 2: value = *(const int16_t *) p; break;
+        case 4: value = *(const int32_t *) p; break;
+        case 8: value = *(const int64_t *) p; break;
+        default:
+            PyErr_SetString(PyExc_TypeError, "nb_enum: invalid type size!");
+            return -1;
     }
 
     // Hash functions should return -1 when an error occurred.
@@ -227,26 +217,32 @@ Py_hash_t nb_enum_hash(PyObject *o) {
     return value;
 }
 
-void nb_enum_prepare(PyType_Slot **s, bool is_arithmetic) {
-    PyType_Slot *t = *s;
+void nb_enum_prepare(enum_data_prelim *ed) noexcept {
+    /* 22 is the number of slot assignments below.
+       Careful: update it if you add more.
+       These built-in slots are added before any user-defined ones;
+       all together must fit in enum_data_prelim::slots_storage. */
+    static constexpr size_t max_builtin_enum_slots = 22;
+    static_assert(enum_data_prelim::max_slots > max_builtin_enum_slots);
 
-    /* Careful: update 'nb_enum_max_slots' field in nb_type.cpp
-       when adding further type slots */
+    auto int_fn = ed->is_signed ? nb_enum_int_signed : nb_enum_int_unsigned;
+
+    PyType_Slot *t = &ed->slots_storage[ed->next_slot];
     *t++ = { Py_tp_new, (void *) nb_enum_new };
     *t++ = { Py_tp_init, (void *) nb_enum_init };
     *t++ = { Py_tp_repr, (void *) nb_enum_repr };
     *t++ = { Py_tp_richcompare, (void *) nb_enum_richcompare };
-    *t++ = { Py_nb_int, (void *) nb_enum_int };
-    *t++ = { Py_nb_index, (void *) nb_enum_int };
+    *t++ = { Py_nb_int, (void *) int_fn };
+    *t++ = { Py_nb_index, (void *) int_fn };
     *t++ = { Py_tp_getset, (void *) nb_enum_getset };
     *t++ = { Py_tp_traverse, (void *) nb_enum_traverse };
     *t++ = { Py_tp_clear, (void *) nb_enum_clear };
     *t++ = { Py_tp_hash, (void *) nb_enum_hash };
 
-    if (is_arithmetic) {
+    if (ed->is_arithmetic) {
         *t++ = { Py_nb_add, (void *) nb_enum_add };
         *t++ = { Py_nb_subtract, (void *) nb_enum_sub };
-        *t++ = { Py_nb_multiply, (void *) nb_enum_sub };
+        *t++ = { Py_nb_multiply, (void *) nb_enum_mul };
         *t++ = { Py_nb_floor_divide, (void *) nb_enum_div };
         *t++ = { Py_nb_or, (void *) nb_enum_or };
         *t++ = { Py_nb_xor, (void *) nb_enum_xor };
@@ -258,7 +254,17 @@ void nb_enum_prepare(PyType_Slot **s, bool is_arithmetic) {
         *t++ = { Py_nb_absolute, (void *) nb_enum_abs };
     }
 
-    *s = t;
+    ed->next_slot = t - ed->slots_storage;
+}
+
+void nb_enum_extend_slots(enum_data_prelim *ed, const PyType_Slot *slots) noexcept {
+    size_t i = 0;
+    while (slots[i].slot) {
+        if (ed->next_slot + 1 == ed->max_slots)
+            fail("nanobind::detail::nb_enum_extend_slots(\"%s\"): ran out of "
+                 "type slots!", ed->name);
+        ed->slots_storage[ed->next_slot++] = slots[i++];
+    }
 }
 
 void nb_enum_put(PyObject *type, const char *name, const void *value,
@@ -291,7 +297,7 @@ void nb_enum_put(PyObject *type, const char *name, const void *value,
     if (PyObject_SetAttr(type, name_obj, (PyObject *) inst))
         goto error;
 
-    int_val = nb_enum_int((PyObject *) inst);
+    int_val = PyNumber_Index((PyObject *) inst);
     if (!int_val)
         goto error;
 
@@ -316,7 +322,8 @@ void nb_enum_put(PyObject *type, const char *name, const void *value,
     return;
 
 error:
-    fail("nanobind::detail::nb_enum_add(): could not create enum entry!");
+    python_error err;
+    fail("nanobind::detail::nb_enum_put(): could not create enum entry!");
 }
 
 void nb_enum_export(PyObject *tp) {

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -17,7 +17,7 @@
 
 /// Tracks the ABI of nanobind
 #ifndef NB_INTERNALS_VERSION
-#  define NB_INTERNALS_VERSION 7
+#  define NB_INTERNALS_VERSION 9
 #endif
 
 /// On MSVC, debug and release builds are not ABI-compatible!

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -225,7 +225,6 @@ extern char *type_name(const std::type_info *t);
 extern int nb_type_init(PyObject *, PyObject *, PyObject *);
 extern void nb_type_dealloc(PyObject *o);
 extern PyObject *inst_new_impl(PyTypeObject *tp, void *value);
-extern void nb_enum_prepare(PyType_Slot **s, bool is_arithmetic);
 extern int nb_static_property_set(PyObject *, PyObject *, PyObject *);
 
 /// Fetch the nanobind function record from a 'nb_func' instance

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -446,10 +446,20 @@ def test19_static_properties_doc():
     assert "Static property docstring" in pydoc.render_doc(t.StaticProperties2)
 
 
-def test20_supplement():
+def test20_supplement(capsys):
     c = t.ClassWithSupplement()
     assert t.check_supplement(c)
+    assert t.check_supplement(t.MyClass.ClassWithExternalSupplement())
     assert not t.check_supplement(t.Struct())
+    if sys.implementation.name == "pypy":
+        # pypy doesn't GC module contents:
+        # https://foss.heptapod.net/pypy/pypy/-/issues/3855
+        return
+    # test destruction of external supplement via keep_alive:
+    assert capsys.readouterr().out == ""
+    del t.MyClass.ClassWithExternalSupplement
+    collect()
+    assert capsys.readouterr().out == "Destroying external supplement\n"
 
 
 def test21_type_callback():

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -82,3 +82,12 @@ def test05_enum_property():
     w = t.EnumProperty()
     assert w.read_enum == t.Enum.A
     assert str(w.read_enum) == 'test_enum_ext.Enum.A'
+
+def test06_enum_with_custom_slots():
+    # Custom | operator returns an enum
+    assert t.Color.Red | t.Color.Green | t.Color.Blue is t.Color.White
+    assert t.Color.Black | t.Color.Black is t.Color.Black
+    # Other operators (via is_arithmetic) return ints
+    yellow = t.Color.Red + t.Color.Green
+    assert type(yellow) is int
+    assert yellow == t.Color.Yellow and yellow is not t.Color.Yellow


### PR DESCRIPTION
* Split fields that are only needed during type object initialization (doc, base, base_py, type_slots) into a new `type_data_prelim` structure, so that the persistent `type_data` doesn't need to store them.
* Allow `nb::supplement<T*>` to store the `T*` as `type_data::supplement` directly, rather than requiring another layer of indirection to access the pointer. This is useful when `T` does not meet the requirements of a supplement type on its own (e.g., has a non-trivial destructor).
* Remove all enum-specific logic from `type_data` and `nb_type.cpp`; instead, `nb::enum_` now implements all of its additional functionality through the same `type_slots` interface available to user code. This serves as a demonstration of how nanobind users can implement their own enum-like semantics, and frees up three flag bits for other uses.

(I made these changes together in order to put all the `type_data` ABI effects in one place, but they're separable if you like some of them and not others.)

Enums no longer explicitly save their signedness; instead they fill in the `Py_nb_int` and `Py_nb_index` with a different function depending on the signedness known at type creation time. This makes `int()` very marginally faster (no need to branch on the signedness) and `repr()` / `__name__` very marginally slower (need to indirect through the type slot instead of calling `nb_enum_int` directly).

On my laptop, `python3.9 -m timeit -s "from test_enum_ext import Enum"` with the following microbenchmarks had these results:
* `"int(Enum.C)"` went from (52.7, 54) ns per loop (two separate runs) to (50.5, 50.6) ns per loop
* `"repr(Enum.C)"` went from (353, 372) ns per loop to (347, 353) ns per loop
* `"Enum.C.__name__"` went from (114, 112) ns per loop to (128, 125) ns per loop

An alternative option would be to extend the inline-supplement support beyond single pointers, and use it to store the enum signedness and any other useful information (such as a borrowed reference to the `__entries` dict to avoid an attribute lookup, and/or the `type_data::scope` pointer since enums are the only user of it after the type has been created). However, this would potentially be a breaking change if user code is using enum supplements for other purposes already, unless we introduce a second type of supplement.