### PR TITLE
Add support for instance-level supplemental data

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1434,6 +1434,13 @@ parameter of the constructor :cpp:func:`class_::class_` and
 
    Indicate that ``sizeof(T)`` bytes of memory should be set aside to store supplemental data in the type object.
 
+.. cpp:struct:: instance_supplement
+
+   Indicate that ``sizeof(uintptr_t)`` bytes of memory should be set
+   aside to store supplemental data in each *instance* of this
+   type. See the discussion of :ref:`supplemental instance data
+   <instance_supplement>`.
+
 .. cpp:struct:: type_slots
 
    .. cpp:function:: type_slots(PyType_Slot * value)
@@ -2051,6 +2058,16 @@ Low-level instance access
 .. cpp:function:: void inst_move(handle dst, handle src)
 
    Copy-construct the contents of `src` into `dst` and mark `dst` as *ready*.
+
+.. cpp:function:: template <typename T> T &inst_supplement(handle h)
+
+   Return a reference to supplemental data stashed in a nanobind
+   instance.  The supplemental data type ``T`` must be trivially
+   copyable, no larger and no more aligned than a pointer; this will
+   be validated at compile time.  You must have passed
+   :cpp:class:`nb::instance_supplement() <instance_supplement>` when
+   constructing the corresponding class; this is *not* validated.
+   See :cpp:class:`instance_supplement`.
 
 
 Global flags

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,8 +15,14 @@ case, both modules must use the same nanobind ABI version, or they will be
 isolated from each other. Releases that don't explicitly mention an ABI version
 below inherit that of the preceding release.
 
-Version 1.2.0 (April 24, 2023)
+Version 1.3.0 (TBD)
 -------------------
+
+* Added support for :ref:`per-instance supplemental data <instance_supplement>`.
+  (PR `#193 <https://github.com/wjakob/nanobind/pull/193>`__).
+
+Version 1.2.0 (April 24, 2023)
+------------------------------
 
 * Improvements to the internal C++ → Python instance map data structure to improve
   performance and address type confusion when returning previously registered instances.

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -57,6 +57,7 @@ struct is_enum { bool is_signed; };
 
 template <size_t /* Nurse */, size_t /* Patient */> struct keep_alive {};
 template <typename T> struct supplement {};
+struct instance_supplement {};
 template <typename T> struct intrusive_ptr {
     intrusive_ptr(void (*set_self_py)(T *, PyObject *) noexcept)
         : set_self_py(set_self_py) { }

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -276,6 +276,10 @@ NB_CORE const std::type_info *nb_type_info(PyObject *t) noexcept;
 /// Get a pointer to the instance data of a nanobind instance (nb_inst)
 NB_CORE void *nb_inst_ptr(PyObject *o) noexcept;
 
+/// Get a pointer to storage for a user-defined 'extra' value
+/// associated with the nb_inst o.
+NB_CORE uintptr_t *nb_inst_supplement(PyObject *o) noexcept;
+
 /// Check if a Python type object wraps an instance of a specific C++ type
 NB_CORE bool nb_type_isinstance(PyObject *obj, const std::type_info *t) noexcept;
 

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -56,6 +56,19 @@ struct nb_inst { // usually: 24 bytes
 
     /// Does this instance hold reference to others? (via internals.keep_alive)
     bool clear_keep_alive : 1;
+
+    // Followed by some conditional fields:
+    //   uintptr_t instance_supplement;  // if has_instance_supplement type flag
+    //   union {
+    //       T internal_value;           // if this->internal
+    //       T* indirect_value;          // if !this->internal && !this->direct
+    //   };
+    //   PyObject *instance_dict;        // if has_dynamic_attr type flag
+    //
+    // Non-GCable instances are only as large as needed to accommodate the
+    // fields they need. GCable instances are a fixed size. Note that
+    // has_dynamic_attr turns on GC, so the instance_dict is always at a
+    // fixed offset if supported by the type.
 };
 
 static_assert(sizeof(nb_inst) == sizeof(PyObject) + sizeof(void *));


### PR DESCRIPTION
This is useful for caching hash values and similar things; there are a couple of motivating examples in the documentation. The data is limited to one pointer in size, trivially copyable, in order to minimize the performance impact.

Microbenchmark: ``python3.9 -m timeit -s "from test_classes_ext import Struct"`` ...
* ``"Struct(10)"`` (create instance from Python): goes from (61.5, 61.5) nsec/loop (two runs) to (63.1, 63.2) nsec/loop
* ``"Struct.create_reference()"`` (wrap a C++ pointer): goes from (69.2, 69.5) nsec/loop to (65, 64.3) nsec/loop

Size impact: ``size tests/CMakeFiles/nanobind-static.dir/__/src/nb_type.cpp.o``: text increases by 52 bytes on my system (30913 -> 30965)