### PR TITLE
Refactor type_data to save space

### DIFF
--- a/docs/benchmark.rst
+++ b/docs/benchmark.rst
@@ -20,8 +20,8 @@ The following experiments analyze the performance of a large function-heavy
 <https://github.com/pybind/pybind11/tree/smart_holder>`__ that addresses
 long-standing issues related to holder types in pybind11.
 
-Each experiment is shown twice: light gray `[debug]` columns provide data for
-a debug build, and `[opt]` shows a size-optimized build that is representative
+Each experiment is shown twice: light gray ``[debug]`` columns provide data for
+a debug build, and ``[opt]`` shows a size-optimized build that is representative
 of a deployment scenario. The former is included to show that nanobind
 performance is also good during a typical development workflow.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,8 +15,15 @@ case, both modules must use the same nanobind ABI version, or they will be
 isolated from each other. Releases that don't explicitly mention an ABI version
 below inherit that of the preceding release.
 
-Version 1.2.0 (April 24, 2023)
+Version 1.3.0 (TBD)
 -------------------
+
+* Reduced the size of nanobind type objects by 4 pointers.
+  (PR `#192 <https://github.com/wjakob/nanobind/pull/192>`__).
+* ABI version 9.
+
+Version 1.2.0 (April 24, 2023)
+------------------------------
 
 * Improvements to the internal C++ → Python instance map data structure to improve
   performance and address type confusion when returning previously registered instances.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,7 +19,7 @@ Version 1.3.0 (TBD)
 -------------------
 
 * Reduced the size of nanobind type objects by 4 pointers.
-  (PR `#192 <https://github.com/wjakob/nanobind/pull/192>`__).
+  (PR `#194 <https://github.com/wjakob/nanobind/pull/194>`__).
 * ABI version 9.
 
 Version 1.2.0 (April 24, 2023)

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -10,6 +10,7 @@
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
+/// Flags about a type that persist throughout its lifetime
 enum class type_flags : uint32_t {
     /// Does the type provide a C++ destructor?
     is_destructible          = (1 << 0),
@@ -20,78 +21,86 @@ enum class type_flags : uint32_t {
     /// Does the type provide a C++ move constructor?
     is_move_constructible    = (1 << 2),
 
-    /// Is this a python type that extends a bound C++ type?
-    is_python_type           = (1 << 4),
-
-    /// Is the 'scope' field of the type_data structure set?
-    has_scope                = (1 << 5),
-
-    /// Is the 'doc' field of the type_data structure set?
-    has_doc                  = (1 << 6),
-
-    /// Is the 'base' field of the type_data structure set?
-    has_base                 = (1 << 7),
-
-    /// Is the 'base_py' field of the type_data structure set?
-    has_base_py              = (1 << 8),
-
     /// Is the 'destruct' field of the type_data structure set?
-    has_destruct             = (1 << 9),
+    has_destruct             = (1 << 4),
 
     /// Is the 'copy' field of the type_data structure set?
-    has_copy                 = (1 << 10),
+    has_copy                 = (1 << 5),
 
     /// Is the 'move' field of the type_data structure set?
-    has_move                 = (1 << 11),
+    has_move                 = (1 << 6),
 
     /// Internal: does the type maintain a list of implicit conversions?
-    has_implicit_conversions = (1 << 12),
+    has_implicit_conversions = (1 << 7),
 
-    /// This type is a signed enumeration
-    is_signed_enum           = (1 << 13),
-
-    /// This type is an unsigned enumeration
-    is_unsigned_enum         = (1 << 14),
-
-    /// This type is an arithmetic enumeration
-    is_arithmetic            = (1 << 15),
-
-    /// This type provides extra PyType_Slot fields
-    has_type_slots           = (1 << 16),
+    /// Is this a python type that extends a bound C++ type?
+    is_python_type           = (1 << 8),
 
     /// This type does not permit subclassing from Python
-    is_final                 = (1 << 17),
+    is_final                 = (1 << 9),
 
-    /// This type does not permit subclassing from Python
-    has_supplement           = (1 << 18),
+    /// Is the 'supplement' field of the type_data structure set?
+    has_supplement           = (1 << 10),
 
     /// Instances of this type support dynamic attribute assignment
-    has_dynamic_attr         = (1 << 19),
+    has_dynamic_attr         = (1 << 11),
 
     /// The class uses an intrusive reference counting approach
-    intrusive_ptr            = (1 << 20),
+    intrusive_ptr            = (1 << 12),
 
     /// Is this a trampoline class meant to be overloaded in Python?
-    is_trampoline            = (1 << 21)
+    is_trampoline            = (1 << 13),
+
+    /// Is the 'scope' field of the type_data structure set?
+    has_scope                = (1 << 14),
+
+    /// This type is a signed enumeration
+    is_signed_enum           = (1 << 15),
+
+    /// This type is an unsigned enumeration
+    is_unsigned_enum         = (1 << 16),
+
+    /// This type is an arithmetic enumeration
+    is_arithmetic            = (1 << 17),
+
+    // Two more flag bits available (18 and 19) without needing
+    // a larger reorganization
 };
 
+/// Flags about a type that are only relevant when it is being created.
+/// These are currently stored in type_data::flags alongside the type_flags
+/// for more efficient memory layout, but could move elsewhere if we run
+/// out of flags.
+enum class type_init_flags : uint32_t {
+    /// Is the 'doc' field of the type_data_prelim structure set?
+    has_doc                  = (1 << 20),
+
+    /// Is the 'base' field of the type_data_prelim structure set?
+    has_base                 = (1 << 21),
+
+    /// Is the 'base_py' field of the type_data_prelim structure set?
+    has_base_py              = (1 << 22),
+
+    /// This type provides extra PyType_Slot fields
+    has_type_slots           = (1 << 23),
+
+    all_init_flags         = (0xf << 20)
+};
+
+/// Information about a type that persists throughout its lifetime
 struct type_data {
     uint32_t size;
     uint32_t align : 8;
     uint32_t flags : 24;
     const char *name;
-    const char *doc;
     PyObject *scope;
     const std::type_info *type;
-    const std::type_info *base;
     PyTypeObject *type_py;
-    PyTypeObject *base_py;
     void (*destruct)(void *);
     void (*copy)(void *, const void *);
     void (*move)(void *, void *) noexcept;
     const std::type_info **implicit;
     bool (**implicit_py)(PyTypeObject *, PyObject *, cleanup_list *) noexcept;
-    PyType_Slot *type_slots;
     void *supplement;
     void (*set_self_py)(void *, PyObject *) noexcept;
 #if defined(Py_LIMITED_API)
@@ -99,52 +108,62 @@ struct type_data {
 #endif
 };
 
-NB_INLINE void type_extra_apply(type_data &t, const handle &h) {
-    t.flags |= (uint32_t) type_flags::has_base_py;
+/// Information about a type that is only relevant when it is being created
+struct type_init_data : type_data {
+    const std::type_info *base;
+    PyTypeObject *base_py;
+    const char *doc;
+    const PyType_Slot *type_slots;
+};
+
+NB_INLINE void type_extra_apply(type_init_data &t, const handle &h) {
+    t.flags |= (uint32_t) type_init_flags::has_base_py;
     t.base_py = (PyTypeObject *) h.ptr();
 }
 
-NB_INLINE void type_extra_apply(type_data &t, const char *doc) {
-    t.flags |= (uint32_t) type_flags::has_doc;
+NB_INLINE void type_extra_apply(type_init_data &t, const char *doc) {
+    t.flags |= (uint32_t) type_init_flags::has_doc;
     t.doc = doc;
 }
 
-NB_INLINE void type_extra_apply(type_data &t, type_slots c) {
-    t.flags |= (uint32_t) type_flags::has_type_slots;
+NB_INLINE void type_extra_apply(type_init_data &t, type_slots c) {
+    t.flags |= (uint32_t) type_init_flags::has_type_slots;
     t.type_slots = c.value;
 }
 
 template <typename T>
-NB_INLINE void type_extra_apply(type_data &t, intrusive_ptr<T> ip) {
+NB_INLINE void type_extra_apply(type_init_data &t, intrusive_ptr<T> ip) {
     t.flags |= (uint32_t) type_flags::intrusive_ptr;
     t.set_self_py = (void (*)(void *, PyObject *) noexcept) ip.set_self_py;
 }
 
-NB_INLINE void type_extra_apply(type_data &t, is_enum e) {
+NB_INLINE void type_extra_apply(type_init_data &t, is_final) {
+    t.flags |= (uint32_t) type_flags::is_final;
+}
+
+NB_INLINE void type_extra_apply(type_init_data &t, dynamic_attr) {
+    t.flags |= (uint32_t) type_flags::has_dynamic_attr;
+}
+
+template <typename T>
+NB_INLINE void type_extra_apply(type_init_data &t, supplement<T>) {
+    static_assert(std::is_trivially_default_constructible_v<T>,
+                  "The supplement type must be a POD (plain old data) type");
+    t.flags |= (uint32_t) type_flags::has_supplement | (uint32_t) type_flags::is_final;
+    t.supplement = (void *) malloc(sizeof(T));
+}
+
+// Enum-specific annotations:
+
+NB_INLINE void type_extra_apply(type_init_data &t, is_enum e) {
     if (e.is_signed)
         t.flags |= (uint32_t) type_flags::is_signed_enum;
     else
         t.flags |= (uint32_t) type_flags::is_unsigned_enum;
 }
 
-NB_INLINE void type_extra_apply(type_data &t, is_final) {
-    t.flags |= (uint32_t) type_flags::is_final;
-}
-
-NB_INLINE void type_extra_apply(type_data &t, is_arithmetic) {
+NB_INLINE void type_extra_apply(type_init_data &t, is_arithmetic) {
     t.flags |= (uint32_t) type_flags::is_arithmetic;
-}
-
-NB_INLINE void type_extra_apply(type_data &t, dynamic_attr) {
-    t.flags |= (uint32_t) type_flags::has_dynamic_attr;
-}
-
-template <typename T>
-NB_INLINE void type_extra_apply(type_data &t, supplement<T>) {
-    static_assert(std::is_trivially_default_constructible_v<T>,
-                  "The supplement type must be a POD (plain old data) type");
-    t.flags |= (uint32_t) type_flags::has_supplement | (uint32_t) type_flags::is_final;
-    t.supplement = (void *) malloc(sizeof(T));
 }
 
 template <typename T> void wrap_copy(void *dst, const void *src) {
@@ -282,19 +301,19 @@ public:
 
     template <typename... Extra>
     NB_INLINE class_(handle scope, const char *name, const Extra &... extra) {
-        detail::type_data d;
+        detail::type_init_data d;
 
         d.flags = (uint32_t) detail::type_flags::has_scope;
         d.align = (uint8_t) alignof(Alias);
         d.size = (uint32_t) sizeof(Alias);
-        d.supplement = 0;
+        d.supplement = nullptr;
         d.name = name;
         d.scope = scope.ptr();
         d.type = &typeid(T);
 
         if constexpr (!std::is_same_v<Base, T>) {
             d.base = &typeid(Base);
-            d.flags |= (uint32_t) detail::type_flags::has_base;
+            d.flags |= (uint32_t) detail::type_init_flags::has_base;
         }
 
         if constexpr (!std::is_same_v<Alias, T>)

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -226,8 +226,8 @@ NB_CORE PyObject *nb_func_new(const void *data) noexcept;
 // ========================================================================
 
 /// Create a Python type object for the given type record
-struct type_data;
-NB_CORE PyObject *nb_type_new(const type_data *c) noexcept;
+struct type_init_data;
+NB_CORE PyObject *nb_type_new(const type_init_data *c) noexcept;
 
 /// Extract a pointer to a C++ type underlying a Python object, if possible
 NB_CORE bool nb_type_get(const std::type_info *t, PyObject *o, uint8_t flags,

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -17,7 +17,7 @@
 
 /// Tracks the ABI of nanobind
 #ifndef NB_INTERNALS_VERSION
-#  define NB_INTERNALS_VERSION 7
+#  define NB_INTERNALS_VERSION 9
 #endif
 
 /// On MSVC, debug and release builds are not ABI-compatible!


### PR DESCRIPTION
Split fields that are only needed during type object initialization (doc, base, base_py, type_slots) into a new `type_init_data` structure, so that the persistent `type_data` doesn't need to store them.//

Split off from #192 