### PR TITLE
Reduce nb_type/nb_enum entanglement

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1463,6 +1463,24 @@ parameter of the constructor :cpp:func:`class_::class_`.
    zero-initialized ``PyType_Slot`` element. See :ref:`Customizing type creation
    <typeslots>` for more information about this feature.
 
+.. cpp:struct:: type_slots_callback
+
+   .. cpp:function:: type_slots_callback(void (*callback)(detail::type_init_data *, PyType_Slot *&slots, size_t max_slots) noexcept)
+
+   This is an alternative to `type_slots` that provides a callback
+   which will be invoked during type creation to populate the type's
+   list of slots. It is used by `enum_`. It can be used in addition to
+   the `type_slots` annotation; if both are provided,
+   `type_slots_callback` runs first (so `type_slots` can override its choices).
+
+   The callback should execute ``*slots++ = {Py_tp_foo, (void *) handle_foo};``
+   at most *max_slots* times.
+
+   Information about the type under construction is available via the first
+   parameter received by the callback, but be aware that this is an internal
+   type which is not subject to nanobind's usual semantic versioning guarantees.
+   See ``include/nanobind/nb_class.h`` for more details.
+
 .. cpp:struct:: template <typename T> intrusive_ptr
 
    nanobind provides a custom interface for intrusive reference-counted C++

--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1248,12 +1248,6 @@ The following annotations can be specified in both function and class bindings.
       :cpp:class:`type_object`) in which the function or class should be
       registered.
 
-.. cpp:struct:: name
-
-   .. cpp:function:: name(const char * value)
-
-      Captures the name of the function or class.
-
 .. _function_binding_annotations:
 
 Function binding annotations
@@ -1262,6 +1256,12 @@ Function binding annotations
 The following annotations can be specified using the variable-length ``Extra``
 parameter of :cpp:func:`module_::def`, :cpp:func:`class_::def`,
 :cpp:func:`cpp_function`, etc.
+
+.. cpp:struct:: name
+
+   .. cpp:function:: name(const char * value)
+
+      Captures the name of the function.
 
 .. cpp:struct:: arg
 
@@ -1436,8 +1436,7 @@ Class binding annotations
 -------------------------
 
 The following annotations can be specified using the variable-length ``Extra``
-parameter of the constructor :cpp:func:`class_::class_` and
-:cpp:func:`enum_::enum_`.
+parameter of the constructor :cpp:func:`class_::class_`.
 
 .. cpp:struct:: is_final
 
@@ -1445,21 +1444,13 @@ parameter of the constructor :cpp:func:`class_::class_` and
 
 .. cpp:struct:: dynamic_attr
 
-   Indicate that a type requires a Python dictionary to support the dynamic addition of attributes.
-
-.. cpp:struct:: is_enum
-
-   .. cpp:function:: is_enum(bool is_signed)
-
-      Mark the bound class as an enumeration backed by a signed or unsigned integer type.
-
-.. cpp:struct:: is_arithmetic
-
-   Indicate that the enumeration may be used as part of arithmetic operations.
+   Indicate that instances of a type require a Python dictionary to support the dynamic addition of attributes.
 
 .. cpp:struct:: template <typename T> supplement
 
-   Indicate that ``sizeof(T)`` bytes of memory should be set aside to store supplemental data in the type object.
+   Indicate that ``sizeof(T)`` bytes of memory should be set aside to
+   store supplemental data in the type object. See :ref:`Supplemental
+   type data <supplement>` for more information.
 
 .. cpp:struct:: type_slots
 
@@ -1469,7 +1460,8 @@ parameter of the constructor :cpp:func:`class_::class_` and
    types. In certain advanced use cases, it may be helpful to append additional
    type slots during type construction. This class binding annotation can be
    used to accomplish this. The provided list should be followed by a
-   zero-initialized ``PyType_Slot`` element.
+   zero-initialized ``PyType_Slot`` element. See :ref:`Customizing type creation
+   <typeslots>` for more information about this feature.
 
 .. cpp:struct:: template <typename T> intrusive_ptr
 
@@ -1482,6 +1474,27 @@ parameter of the constructor :cpp:func:`class_::class_` and
 
       Declares a callback that will be invoked when a C++ instance is first
       cast into a Python object.
+
+
+.. _enum_binding_annotations:
+
+Enum binding annotations
+------------------------
+
+The following annotations can be specified using the variable-length
+``Extra`` parameter of the constructor :cpp:func:`enum_::enum_`.
+Enums also support the :cpp:struct:`dynamic_attr` and
+:cpp:struct:`type_slots` annotations
+documented for :ref:`classes <class_binding_annotations>`.
+
+.. cpp:struct:: is_arithmetic
+
+   Indicate that the enumeration may be used with arithmetic
+   operations.  This enables the binary operators ``+ - * // & | ^ <<
+   >>`` and unary ``- ~ abs()``, with operands of either enumeration
+   or integer type; the result will be a regular integer. It is
+   unspecified whether operations on mixed enum types (such as
+   ``Shape.Circle + Color.Red``) are permissible.
 
 Function binding
 ----------------
@@ -1858,8 +1871,8 @@ Class binding
 
       Bind the enumeration of type `T` to the identifier `name` within the
       scope `scope`. The variable length `extra` parameter can be used to pass
-      a docstring and other :ref:`class binding annotations
-      <class_binding_annotations>` such as :cpp:class:`is_arithmetic`.
+      a docstring and other :ref:`enum binding annotations
+      <enum_binding_annotations>` such as :cpp:class:`is_arithmetic`.
 
    .. cpp:function:: enum_ &value(const char * name, T value, const char * doc = nullptr)
 
@@ -2015,15 +2028,16 @@ Type objects
 
 .. cpp:function:: template <typename T> T &type_supplement(handle h)
 
-   Return a reference to supplemental data stashed in a type object. See
-   :cpp:class:`supplement`.
+   Return a reference to supplemental data stashed in a type object.
+   The type ``T`` must exactly match the type specified in the
+   :cpp:class:`nb::supplement\<T\> <supplement>` annotation used when
+   creating the type; no type check is performed, and accessing an
+   incorrect supplement type may crash the interpreter.
+   See :cpp:class:`supplement`.
 
 Instances
 ^^^^^^^^^
 
-
-Low-level instance access
--------------------------
 .. cpp:function:: bool inst_check(handle h)
 
    Returns ``true`` if `h` represents an instance of a type that was

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,6 +63,17 @@ Version 1.3.0 (TBD)
   to improve the speed of object and name lookups. Note that this prevents
   use of ``nb::supplement<T>()`` with enums for other purposes.
   (PR `#195 <https://github.com/wjakob/nanobind/pull/195>`__).
+* Added the :cpp:class:`nb::type_slots_callback` class binding annotation,
+  similar to :cpp:class:`nb::type_slots` but allowing more dynamic choices.
+  (PR `#195 <https://github.com/wjakob/nanobind/pull/195>`__).
+* nanobind type objects now treat attributes specially whose names
+  begin with ``@``. These attributes can be set once, but not
+  rebound or deleted.  This safeguard allows a borrowed reference to
+  the attribute value to be safely stashed in the type supplement,
+  allowing arbitrary Python data associated with the type to be accessed
+  without a dictionary lookup while keeping this data visible to the
+  garbage collector.  (PR `#195 <https://github.com/wjakob/nanobind/pull/195>`__).
+* ABI version 9.
 
 Version 1.2.0 (April 24, 2023)
 ------------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,8 +34,9 @@ Version 1.3.0 (TBD)
 * Reduced the per-instance overhead of nanobind by 1 pointer and simplified the
   internal hash table types to crunch ``libnanobind``. (commit `de018d
   <https://github.com/wjakob/nanobind/commit/de018db2d17905564703f1ade4aa201a22f8551f>`__).
-* Reduced the size of nanobind type objects by 5 pointers. (PR `#194
-  <https://github.com/wjakob/nanobind/pull/194>`__ and commit `d82ca9
+* Reduced the size of nanobind type objects by 6 pointers. (PR `#194
+  <https://github.com/wjakob/nanobind/pull/194>`__, `#195
+  <https://github.com/wjakob/nanobind/pull/195>`__, and commit `d82ca9
   <https://github.com/wjakob/nanobind/commit/d82ca9c14191e74dd35dd5bf15fc90f5230319fb>`__).
 * Internal nanobind types (``nb_type``, ``nb_static_property``, ``nb_ndarray``)
   are now constructed on demand. This reduces the size of the ``libnanobind``
@@ -53,7 +54,15 @@ Version 1.3.0 (TBD)
   <python_error::discard_as_unraisable>` as a wrapper around
   ``PyErr_WriteUnraisable()``. (PR `#175
   <https://github.com/wjakob/nanobind/pull/175>`__).
-* ABI version 9.
+* Updated the implementation of :cpp:class:`nb::enum_ <enum_>` so it does
+  not take advantage of any private nanobind type details. As a side effect,
+  the construct ``nb::class_<T>(..., nb::is_enum(...))`` is no longer permitted;
+  use ``nb::enum_<T>(...)`` instead.
+  (PR `#195 <https://github.com/wjakob/nanobind/pull/195>`__).
+* nanobind enums now take advantage of :ref:`supplemental data <supplement>`
+  to improve the speed of object and name lookups. Note that this prevents
+  use of ``nb::supplement<T>()`` with enums for other purposes.
+  (PR `#195 <https://github.com/wjakob/nanobind/pull/195>`__).
 
 Version 1.2.0 (April 24, 2023)
 ------------------------------

--- a/docs/lowlevel.rst
+++ b/docs/lowlevel.rst
@@ -224,6 +224,12 @@ Here is what this might look like in an implementation:
   MyTensorMedadata &supplement = nb::type_supplement<MyTensorMedadata>(cls);
   supplement.stored_on_gpu = true;
 
-The :cpp:class:`nb::supplement\<T\>() <supplement>` annotation implicitly
-also passes :cpp:class:`nb::is_final() <is_final>` to ensure that type
-objects with supplemental data cannot be subclassed in Python.
+The :cpp:class:`nb::supplement\<T\>() <supplement>` annotation implicitly also
+passes :cpp:class:`nb::is_final() <is_final>` to ensure that type objects with
+supplemental data cannot be subclassed in Python.
+
+nanobind requires that the specified type ``T`` be trivially default
+constructible. It zero-initializes the supplement when the type is first
+created but does not perform any further custom initialization or destruction.
+You can fill the supplement with different contents following the type
+creation, e.g., using the placement new operator.

--- a/docs/lowlevel.rst
+++ b/docs/lowlevel.rst
@@ -233,3 +233,13 @@ constructible. It zero-initializes the supplement when the type is first
 created but does not perform any further custom initialization or destruction.
 You can fill the supplement with different contents following the type
 creation, e.g., using the placement new operator.
+
+The contents of the supplemental data are not directly visible to Python's
+cyclic garbage collector, which creates challenges if you want to reference
+Python objects. The recommended workaround is to store the Python objects
+as attributes of the type object (in its ``__dict__``) and store a borrowed
+``PyObject*`` reference in the supplemental data. If you use an attribute
+name that begins with the symbol ``@``, then nanobind will prevent Python
+code from rebinding or deleting the attribute after it has been set, making
+the borrowed reference reasonably safe. See the implementation of ``nb::enum_``
+for an example.

--- a/docs/typeslots.rst
+++ b/docs/typeslots.rst
@@ -19,9 +19,9 @@ annotation when creating the type.
    nb::class_<MyClass>(m, "MyClass", nb::type_slots(slots));
 
 Here, ``slots`` should refer to an array of function pointers that are tagged
-with a corresponding slot identifier. For example, here is a example
+with a corresponding slot identifier. For example, here is an example
 function that overrides the addition operator so that it behaves like a
-multiplication. 
+multiplication.
 
 .. code-block:: cpp
 

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -53,7 +53,6 @@ struct is_implicit {};
 struct is_operator {};
 struct is_arithmetic {};
 struct is_final {};
-struct is_enum { bool is_signed; };
 
 template <size_t /* Nurse */, size_t /* Patient */> struct keep_alive {};
 template <typename T> struct supplement {};
@@ -78,6 +77,20 @@ constexpr arg operator"" _a(const char *name, size_t) { return arg(name); }
 NAMESPACE_END(literals)
 
 NAMESPACE_BEGIN(detail)
+
+/// This is an alternative to 'nb::type_slots' that provides a
+/// callback which will be invoked during type creation to populate
+/// the type's list of slots.  It is used by nb::enum_. It can be used
+/// alongside the public nb::type_slots interface; if both are
+/// provided, type_slots_callback runs first (so type_slots can override).
+///
+/// The callback should execute ``*slots++ = {Py_tp_foo, (void *) handle_foo};``
+/// at most *max_slots* times.
+struct type_slots_callback {
+    using cb_t = void (*)(const type_init_data *t, PyType_Slot *&slots, size_t max_slots);
+    type_slots_callback(cb_t callback) : callback(callback) { }
+    cb_t callback;
+};
 
 enum class func_flags : uint32_t {
     /* Low 3 bits reserved for return value policy */

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -67,6 +67,13 @@ struct type_slots {
     PyType_Slot *value;
 };
 
+struct type_slots_callback {
+    using cb_t = void (*)(const detail::type_init_data *t,
+                          PyType_Slot *&slots, size_t max_slots) noexcept;
+    type_slots_callback(cb_t callback) : callback(callback) { }
+    cb_t callback;
+};
+
 struct raw_doc {
     const char *value;
     raw_doc(const char *doc) : value(doc) {}
@@ -77,20 +84,6 @@ constexpr arg operator"" _a(const char *name, size_t) { return arg(name); }
 NAMESPACE_END(literals)
 
 NAMESPACE_BEGIN(detail)
-
-/// This is an alternative to 'nb::type_slots' that provides a
-/// callback which will be invoked during type creation to populate
-/// the type's list of slots.  It is used by nb::enum_. It can be used
-/// alongside the public nb::type_slots interface; if both are
-/// provided, type_slots_callback runs first (so type_slots can override).
-///
-/// The callback should execute ``*slots++ = {Py_tp_foo, (void *) handle_foo};``
-/// at most *max_slots* times.
-struct type_slots_callback {
-    using cb_t = void (*)(const type_init_data *t, PyType_Slot *&slots, size_t max_slots);
-    type_slots_callback(cb_t callback) : callback(callback) { }
-    cb_t callback;
-};
 
 enum class func_flags : uint32_t {
     /* Low 3 bits reserved for return value policy */

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -355,6 +355,10 @@ NB_CORE void implicitly_convertible(bool (*predicate)(PyTypeObject *,
 
 // ========================================================================
 
+/// Fill in slots for an enum type being built
+NB_CORE void nb_enum_prepare(const type_init_data *t,
+                             PyType_Slot *&slots, size_t max_slots) noexcept;
+
 /// Add an entry to an enumeration
 NB_CORE void nb_enum_put(PyObject *type, const char *name, const void *value,
                          const char *doc) noexcept;

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -62,11 +62,6 @@ struct nb_inst { // usually: 24 bytes
 
 static_assert(sizeof(nb_inst) == sizeof(PyObject) + sizeof(void *));
 
-struct nb_enum_supplement {
-    PyObject *name;
-    const char *doc;
-};
-
 /// Python object representing a bound C++ function
 struct nb_func {
     PyObject_VAR_HEAD
@@ -258,7 +253,6 @@ extern char *type_name(const std::type_info *t);
 
 // Forward declarations
 extern PyObject *inst_new_impl(PyTypeObject *tp, void *value);
-extern void nb_enum_prepare(PyType_Slot **s, bool is_arithmetic);
 extern PyTypeObject *nb_static_property_tp() noexcept;
 
 /// Fetch the nanobind function record from a 'nb_func' instance

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -345,6 +345,21 @@ static int nb_type_setattro(PyObject* obj, PyObject* name, PyObject* value) {
             return rv;
         }
         Py_DECREF(cur);
+
+        const char *cname = PyUnicode_AsUTF8AndSize(name, nullptr);
+        if (!cname) {
+            PyErr_Clear(); // probably a non-string attribute name
+        } else if (cname[0] == '@') {
+            /* Prevent type attributes starting with an `@` sign from being
+               rebound or deleted. This is useful to safely stash owning
+               references. The ``nb::enum_<>`` class, e.g., uses this to ensure
+               indirect ownership of a borrowed reference in the supplemental
+               type data. */
+            PyErr_Format(PyExc_AttributeError,
+                         "internal nanobind attribute '%s' cannot be "
+                         "reassigned or deleted.", cname);
+            return -1;
+        }
     } else {
         PyErr_Clear();
     }
@@ -631,12 +646,7 @@ static PyTypeObject *nb_type_tp(nb_internals &internals,
 
 /// Called when a C++ type is bound via nb::class_<>
 PyObject *nb_type_new(const type_init_data *t) noexcept {
-    bool is_signed_enum    = t->flags & (uint32_t) type_flags::is_signed_enum,
-         is_unsigned_enum  = t->flags & (uint32_t) type_flags::is_unsigned_enum,
-         is_arithmetic     = t->flags & (uint32_t) type_flags::is_arithmetic,
-         is_enum           = is_signed_enum || is_unsigned_enum,
-         has_scope         = t->flags & (uint32_t) type_flags::has_scope,
-         has_doc           = t->flags & (uint32_t) type_init_flags::has_doc,
+    bool has_doc           = t->flags & (uint32_t) type_init_flags::has_doc,
          has_base          = t->flags & (uint32_t) type_init_flags::has_base,
          has_base_py       = t->flags & (uint32_t) type_init_flags::has_base_py,
          has_type_slots    = t->flags & (uint32_t) type_init_flags::has_type_slots,
@@ -649,21 +659,17 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
     object modname;
     PyObject *mod = nullptr;
 
-    if (has_scope) {
-        has_scope = t->scope != nullptr;
+    if (t->scope != nullptr) {
+        if (PyModule_Check(t->scope)) {
+            mod = t->scope;
+            modname = getattr(t->scope, "__name__", handle());
+        } else {
+            modname = getattr(t->scope, "__module__", handle());
 
-        if (has_scope) {
-            if (PyModule_Check(t->scope)) {
-                mod = t->scope;
-                modname = getattr(t->scope, "__name__", handle());
-            } else {
-                modname = getattr(t->scope, "__module__", handle());
-
-                object scope_qualname = getattr(t->scope, "__qualname__", handle());
-                if (scope_qualname.is_valid())
-                    qualname = steal<str>(
-                        PyUnicode_FromFormat("%U.%U", scope_qualname.ptr(), name.ptr()));
-            }
+            object scope_qualname = getattr(t->scope, "__qualname__", handle());
+            if (scope_qualname.is_valid())
+                qualname = steal<str>(
+                    PyUnicode_FromFormat("%U.%U", scope_qualname.ptr(), name.ptr()));
         }
     }
 
@@ -710,11 +716,9 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
     }
     char *name_copy = NB_STRDUP(name.c_str());
 
-    constexpr size_t nb_enum_max_slots = 22,
-                     nb_type_max_slots = 10,
+    constexpr size_t nb_type_max_slots = 10,
                      nb_extra_slots = 80,
                      nb_total_slots = nb_type_max_slots +
-                                      nb_enum_max_slots +
                                       nb_extra_slots + 1;
 
     PyMemberDef members[2] { };
@@ -738,17 +742,25 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
         *s++ = { Py_tp_doc, (void *) t->doc };
 
     if (has_type_slots) {
-        size_t i = 0;
-        while (t->type_slots[i].slot) {
-            if (i == nb_extra_slots)
-                fail("nanobind::detail::nb_type_new(\"%s\"): ran out of type "
-                     "slots!", t->name);
-            *s++ = t->type_slots[i++];
+        size_t num_avail = nb_extra_slots;
+        if (t->type_slots_callback) {
+            PyType_Slot* first_new = s;
+            t->type_slots_callback(t, s, num_avail);
+            if (first_new + num_avail < s)
+                fail("nanobind::detail::nb_type_new(\"%s\"): type_slots_callback "
+                     "overflowed the slots array!", t->name);
+            num_avail -= (s - first_new);
+        }
+        if (t->type_slots) {
+            size_t i = 0;
+            while (t->type_slots[i].slot) {
+                if (i == num_avail)
+                    fail("nanobind::detail::nb_type_new(\"%s\"): ran out of "
+                         "type slots!", t->name);
+                *s++ = t->type_slots[i++];
+            }
         }
     }
-
-    if (is_enum)
-        nb_enum_prepare(&s, is_arithmetic);
 
     bool has_traverse = false;
     for (PyType_Slot *ts = slots; ts != s; ++ts) {
@@ -791,18 +803,9 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
         fail("nanobind::detail::nb_type_new(\"%s\"): type construction failed: %s!", t->name, err.what());
     }
 
-// #if PY_VERSION_HEX < 0x03090000
-//     if (has_dynamic_attr)
-//         tp->tp_dictoffset = (Py_ssize_t) (basicsize - ptr_size);
-// #endif
-
-
     type_data *to = nb_type_data((PyTypeObject *) result);
     *to = *t; // note: slices off _init parts
     to->flags &= ~(uint32_t) type_init_flags::all_init_flags;
-
-    if (!has_scope)
-        to->flags &= ~(uint32_t) type_flags::has_scope;
 
     if (!intrusive_ptr && tb &&
         (tb->flags & (uint32_t) type_flags::intrusive_ptr)) {
@@ -820,7 +823,7 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
         #endif
     }
 
-    if (has_scope)
+    if (t->scope != nullptr)
         setattr(t->scope, t->name, result);
 
     setattr(result, "__qualname__", qualname.ptr());

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -650,7 +650,7 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
          has_base          = t->flags & (uint32_t) type_init_flags::has_base,
          has_base_py       = t->flags & (uint32_t) type_init_flags::has_base_py,
          has_type_slots    = t->flags & (uint32_t) type_init_flags::has_type_slots,
-         has_supplement    = t->flags & (uint32_t) type_flags::has_supplement,
+         has_supplement    = t->flags & (uint32_t) type_init_flags::has_supplement,
          has_dynamic_attr  = t->flags & (uint32_t) type_flags::has_dynamic_attr,
          intrusive_ptr     = t->flags & (uint32_t) type_flags::intrusive_ptr;
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -82,3 +82,20 @@ def test05_enum_property():
     w = t.EnumProperty()
     assert w.read_enum == t.Enum.A
     assert str(w.read_enum) == 'test_enum_ext.Enum.A'
+
+def test06_enum_with_custom_slots():
+    # Custom | operator returns an enum
+    assert t.Color.Red | t.Color.Green | t.Color.Blue is t.Color.White
+    assert t.Color.Black | t.Color.Black is t.Color.Black
+    # Other operators (via is_arithmetic) return ints
+    yellow = t.Color.Red + t.Color.Green
+    assert type(yellow) is int
+    assert yellow == t.Color.Yellow and yellow is not t.Color.Yellow
+
+
+def test07_enum_entries_dict_is_protected():
+    with pytest.raises(AttributeError, match="internal nanobind attribute"):
+        setattr(t.Color, "@entries", {})
+    with pytest.raises(AttributeError, match="internal nanobind attribute"):
+        delattr(t.Color, "@entries")
+    assert getattr(t.Color, "@entries")[3] == ("Yellow", None, t.Color.Yellow)


### PR DESCRIPTION
Remove all enum-specific logic from `type_data` and `nb_type.cpp`; instead, `nb::enum_` now implements all of its additional functionality through the same interface available to user code (using `type_slots` and `supplement`). This serves as a demonstration of how nanobind users can implement their own enum-like semantics, and frees up four flag bits for other uses.

Cache the enum's scope, `is_signed` flag, and entries dictionary in supplemental type data. Caching the scope allows it to move out of `type_data` (enums were the only entity using it after type initialization was complete). Caching the entries dictionary makes enum lookups by value (used in `__new__`, `__name__`, and `__repr__`) substantially faster.

On my laptop, `python3.9 -m timeit -s "from test_enum_ext import Enum"` with the following microbenchmarks had these results:
* `"int(Enum.C)"` went from (51.2, 50.4) ns per loop (two separate runs) to (50.3, 51.3) ns per loop
* `"Enum(0xffffffff)"` went from (98.2, 97) ns per loop to (41.5, 41.2) ns per loop
* `"repr(Enum.C)"` went from (348, 341) ns per loop to (306, 291) ns per loop
* `"Enum.C.__name__"` went from (105, 109) ns per loop to (50, 50) ns per loop

Size impacts:
* `nb_type.cpp.o` text size increases by 169 bytes (31032 -> 31201)
* `nb_enum.cpp.o` text size increases by 194 bytes (4921 -> 5115)
* `nb_enum.cpp.o` rodata size increases by 32 bytes (832 -> 864)
* `test_holders.cpp.o` (which contains one enum definition and is source-level unchanged across this PR) text size increases by 52 bytes

Additionally, `nb_type.cpp` no longer depends on `nb_enum.cpp`, so static-linking users that don't use `nb::enum_` will no longer pay for it in binary size.

Split off from #192.