### PR TITLE
Propagate includes as SYSTEM

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -156,9 +156,11 @@ function (nanobind_build_library TARGET_NAME)
   endif()
 
   target_include_directories(${TARGET_NAME} PRIVATE
-    ${NB_DIR}/ext/robin_map/include)
+    ${NB_DIR}/ext/robin_map/include
+    ${Python_INCLUDE_DIRS}
+    ${NB_DIR}/include)
 
-  target_include_directories(${TARGET_NAME} PUBLIC
+  target_include_directories(${TARGET_NAME} SYSTEM INTERFACE
     ${Python_INCLUDE_DIRS}
     ${NB_DIR}/include)
 


### PR DESCRIPTION
This prevents users from getting warnings in their code from 3rd party includes when the toolchain supports system headers.

This makes code like this unnecessary:

    get_property(
        nanobind_includes TARGET nanobind-static
        PROPERTY INTERFACE_INCLUDE_DIRECTORIES
    )
    set_target_properties(
        nanobind-static PROPERTIES
        FOLDER nanobind-static
        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${nanobind_includes}"
    )

The above code marks usage requirements (i.e. headers in this case) as system, so they are included using the appropriate -isystem or /external:I flags.