### PR TITLE
Introduce the ALIAS target nanobind::nanobind

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -120,6 +120,7 @@ function (nanobind_build_library TARGET_NAME)
     ${NB_DIR}/src/trampoline.cpp
     ${NB_DIR}/src/implicit.cpp
   )
+  add_library(nanobind::nanobind ALIAS ${TARGET_NAME})
 
   if (TARGET_TYPE STREQUAL "SHARED")
     nanobind_link_options(${TARGET_NAME})


### PR DESCRIPTION
Quote from the documentation of target_link_libraries:

> Items containing ::, such as Foo::Bar, are assumed to be IMPORTED or
> ALIAS library target names and will cause an error if no such target
> exists. See policy CMP0028.

https://cmake.org/cmake/help/latest/command/target_link_libraries.html

Using such target names prevents users from accidentally making a typo or related error and silently getting a library link flag.