### PR TITLE
Forward the arguments inside call_guard wrapper lambda

### DIFF
--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -22,7 +22,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
             [func = (forward_t<Func>) func](Args... args) NB_INLINE_LAMBDA {
                 typename Guard::type g;
                 (void) g;
-                return func(args...);
+                return func(std::forward<Args>(args)...);
             },
             (Return(*)(Args...)) nullptr, is, extra...);
     }

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -22,7 +22,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
             [func = (forward_t<Func>) func](Args... args) NB_INLINE_LAMBDA {
                 typename Guard::type g;
                 (void) g;
-                return func(std::forward<Args>(args)...);
+                return func((forward_t<Args>) args...);
             },
             (Return(*)(Args...)) nullptr, is, extra...);
     }

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -80,6 +80,9 @@ NB_MODULE(test_functions_ext, m) {
     });
 
     /// Test call_guard feature
+    m.def("test_call_guard_wrapper_rvalue_ref", [](int&& i) { return i; },
+          nb::call_guard<my_call_guard>());
+
     m.def("test_call_guard", []() {
         return call_guard_value;
     }, nb::call_guard<my_call_guard>());

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -137,6 +137,7 @@ def test13_call_guard():
     assert t.call_guard_value() == 0
     assert t.test_call_guard() == 1
     assert t.call_guard_value() == 2
+    assert t.test_call_guard_wrapper_rvalue_ref(1) == 1
     assert not t.test_release_gil()
 
 


### PR DESCRIPTION
Currently, binding a function that takes an rvalue reference (let's say `std::ranges::find`) only works if you don't pass a call guard. Otherwise it fails with `error: cannot bind rvalue reference of type ‘[$type]&&’ to lvalue of type ‘[$type]’`. Forwarding the arguments should fix this issue.