### PR TITLE
Fix surprising behavior in enum comparisons and arithmetic

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1510,9 +1510,11 @@ documented for :ref:`classes <class_binding_annotations>`.
    Indicate that the enumeration may be used with arithmetic
    operations.  This enables the binary operators ``+ - * // & | ^ <<
    >>`` and unary ``- ~ abs()``, with operands of either enumeration
-   or integer type; the result will be a regular integer. It is
-   unspecified whether operations on mixed enum types (such as
-   ``Shape.Circle + Color.Red``) are permissible.
+   or numeric type; the result will be as if the enumeration operands
+   were first converted to integers. (So ``Shape(2) + Shape(1) == 3`` and
+   ``Shape(2) * 1.5 == 3.0``.) It is unspecified whether operations on
+   mixed enum types (such as ``Shape.Circle + Color.Red``) are
+   permissible.
 
 Function binding
 ----------------


### PR DESCRIPTION
* Enum equality comparisons (``==`` and ``!=``) now can only be true if both operands have the same enum type, or if one is an enum and the other is an `int`. This resolves some confusing results and ensures that enumerators of different types have a distinct identity, which is important if they're being put into the same set or used as keys in the same dictionary. All of the following were previously true but will now evaluate as false:
  * ``FooEnum(1) == BarEnum(1)``
  * ``FooEnum(1) == 1.2``
  * ``FooEnum(1) == "1"``

* Enum ordering comparisons (``<``, ``<=``, ``>=``, ``>``) and arithmetic operations (when using the :cpp:struct:`is_arithmetic` annotation) now require that any non-enum operand be a Python number (an object that defines ``__int__``, ``__float__``, and/or ``__index__``) and will avoid truncating non-integer operands to integers. Note that unlike with equality comparisons, ordering and arithmetic operations *do* still permit two operands that are enums of different types. Some examples of changed behavior:
  * ``FooEnum(1) < 1.2`` is now true (used to be false)
  * ``FooEnum(2) * 1.5`` is now 3.0 (used to be 2)
  * ``FooEnum(3) - "2"`` now raises an exception (used to be 1)

* Enum comparisons and arithmetic operations with unsupported types now return `NotImplemented` rather than raising an exception. This means equality comparisons such as ``some_enum == None`` will return unequal rather than failing; order comparisons such as ``some_enum < None`` will still fail, but now with a more informative error.

Size impact: `nb_enum.cpp.o` text size decreases by 877 bytes while rodata increases by 32 bytes.