### PR TITLE
Add an enum annotation that permits unenumerated values to be constructed

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1516,6 +1516,16 @@ documented for :ref:`classes <class_binding_annotations>`.
    mixed enum types (such as ``Shape.Circle + Color.Red``) are
    permissible.
 
+.. cpp:struct:: allow_unenumerated
+
+   Indicate that the enumeration may have unenumerated values constructed
+   from Python; for example, ``SomeEnum(4)`` when only 0 through 3 are
+   defined. Without this annotation, such attempts will raise an
+   exception (although returning the unenumerated value from C++ will
+   still work for performance reasons). This supports binding
+   enumerations that are used on the C++ side as strongly typed
+   integers, with or without a few named values.
+
 Function binding
 ----------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -108,6 +108,10 @@ Version 1.3.0 (TBD)
     ``some_enum < None`` will still fail, but now with a more
     informative error.
 
+* Added an `enum_` annotation, `allow_unenumerated`, which permits
+  unenumerated values to be constructed from Python. By default these
+  are forbidden, but some C++ code relies on them.
+
 * ABI version 8.
 
 Version 1.2.0 (April 24, 2023)

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -51,8 +51,9 @@ struct dynamic_attr {};
 struct is_method {};
 struct is_implicit {};
 struct is_operator {};
-struct is_arithmetic {};
 struct is_final {};
+struct is_arithmetic {};
+struct allow_unenumerated {};
 
 template <size_t /* Nurse */, size_t /* Patient */> struct keep_alive {};
 template <typename T> struct supplement {};

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -566,14 +566,17 @@ public:
 
         (detail::type_extra_apply(d, extra), ...);
 
+        // Save this so the compiler can tell it's not changed by nb_type_new:
+        const bool allow_unenumerated = d.allow_unenumerated;
+
         Base::m_ptr = detail::nb_type_new(&d);
 
         detail::enum_supplement &supp = type_supplement<detail::enum_supplement>(*this);
         supp.is_signed = d.is_signed;
-        supp.allow_unenumerated = d.allow_unenumerated;
+        supp.allow_unenumerated = allow_unenumerated;
         supp.scope = d.scope;
 
-        if (supp.allow_unenumerated) {
+        if (allow_unenumerated) {
             this->def("__setstate__",
                       [](T *self, std::underlying_type_t<T> value) {
                           *self = static_cast<T>(value);

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -572,6 +572,13 @@ public:
         supp.is_signed = d.is_signed;
         supp.allow_unenumerated = d.allow_unenumerated;
         supp.scope = d.scope;
+
+        if (supp.allow_unenumerated) {
+            this->def("__setstate__",
+                      [](T *self, std::underlying_type_t<T> value) {
+                          *self = static_cast<T>(value);
+                      });
+        }
     }
 
     NB_INLINE enum_ &value(const char *name, T value, const char *doc = nullptr) {

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -159,6 +159,7 @@ NB_INLINE void type_extra_apply(type_init_data &t, supplement<T>) {
 /// Information about an enum, stored as its type_data::supplement
 struct enum_supplement {
     bool is_signed = false;
+    bool allow_unenumerated = false;
     PyObject* entries = nullptr;
     PyObject* scope = nullptr;
 };
@@ -167,10 +168,14 @@ struct enum_supplement {
 struct enum_init_data : type_init_data {
     bool is_signed = false;
     bool is_arithmetic = false;
+    bool allow_unenumerated = false;
 };
 
 NB_INLINE void type_extra_apply(enum_init_data &ed, is_arithmetic) {
     ed.is_arithmetic = true;
+}
+NB_INLINE void type_extra_apply(enum_init_data &ed, allow_unenumerated) {
+    ed.allow_unenumerated = true;
 }
 
 // Enums can't have base classes or supplements or be intrusive, and
@@ -565,6 +570,7 @@ public:
 
         detail::enum_supplement &supp = type_supplement<detail::enum_supplement>(*this);
         supp.is_signed = d.is_signed;
+        supp.allow_unenumerated = d.allow_unenumerated;
         supp.scope = d.scope;
     }
 

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -221,7 +221,8 @@ PyObject *nb_func_new(const void *in_) noexcept {
             PyErr_Clear();
         }
 
-        is_constructor = strcmp(f->name, "__init__") == 0;
+        is_constructor = (strcmp(f->name, "__init__") == 0 ||
+                          strcmp(f->name, "__setstate__") == 0);
 
         // Don't use implicit conversions in copy constructors (causes infinite recursion)
         if (is_constructor && f->nargs == 2 && f->descr_types[0] &&

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -4,6 +4,8 @@ namespace nb = nanobind;
 
 enum class Enum  : uint32_t { A, B, C = (uint32_t) -1 };
 enum class SEnum : int32_t { A, B, C = (int32_t) -1 };
+enum class StrongInt : int16_t { Invalid = -1 };
+enum class StrongUInt : uint16_t {};
 enum ClassicEnum { Item1, Item2 };
 
 struct EnumProperty { Enum get_enum() { return Enum::A; } };
@@ -66,6 +68,10 @@ NB_MODULE(test_enum_ext, m) {
         .value("Yellow", Color::Yellow)
         .value("Magenta", Color::Magenta)
         .value("White", Color::White);
+
+    nb::enum_<StrongUInt>(m, "StrongUInt", nb::allow_unenumerated());
+    nb::enum_<StrongInt>(m, "StrongInt", nb::allow_unenumerated())
+        .value("Invalid", StrongInt::Invalid);
 
     m.def("from_enum", [](Enum value) { return (uint32_t) value; });
     m.def("to_enum", [](uint32_t value) { return (Enum) value; });

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,3 +1,4 @@
+import sys
 import test_enum_ext as t
 import pytest
 
@@ -159,17 +160,23 @@ def test09_enum_unenumerated():
     assert repr(t.StrongInt(-1)) == "test_enum_ext.StrongInt.Invalid"
     assert repr(t.StrongUInt(0)) == "test_enum_ext.StrongUInt(0)"
 
+    outside_longlong_range = (
+        "integer too large"
+        if sys.implementation.name == "pypy"
+        else "too big to convert"
+    )
+
     with pytest.raises(OverflowError, match="too large"):
         t.StrongUInt(65536)
-    with pytest.raises(OverflowError, match="too big to convert"):
+    with pytest.raises(OverflowError, match=outside_longlong_range):
         t.StrongUInt(2 ** 64)
-    with pytest.raises(OverflowError, match="negative int to unsigned"):
+    with pytest.raises(OverflowError, match="negative int.* to unsigned"):
         t.StrongUInt(-1)
     with pytest.raises(OverflowError, match="too negative"):
         t.StrongInt(-32769)
     with pytest.raises(OverflowError, match="too positive"):
         t.StrongInt(32768)
-    with pytest.raises(OverflowError, match="too big to convert"):
+    with pytest.raises(OverflowError, match=outside_longlong_range):
         t.StrongInt(2 ** 63)
-    with pytest.raises(OverflowError, match="too big to convert"):
+    with pytest.raises(OverflowError, match=outside_longlong_range):
         t.StrongInt(-(2 ** 63) - 1)

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -147,3 +147,29 @@ def test08_enum_comparisons():
     assert t.SEnum.B > t.Enum.A
     assert t.Enum.A <= t.SEnum.A and t.Enum.A >= t.SEnum.A
     assert t.Enum.A != t.SEnum.A
+
+
+def test09_enum_unenumerated():
+    assert t.StrongInt.Invalid == -1
+    assert t.StrongInt(42) == 42
+    assert t.StrongInt(-32768) == -32768
+    assert t.StrongUInt(1) == 1
+    assert t.StrongUInt(65535) == 65535
+    assert repr(t.StrongInt(42)) == "test_enum_ext.StrongInt(42)"
+    assert repr(t.StrongInt(-1)) == "test_enum_ext.StrongInt.Invalid"
+    assert repr(t.StrongUInt(0)) == "test_enum_ext.StrongUInt(0)"
+
+    with pytest.raises(OverflowError, match="too large"):
+        t.StrongUInt(65536)
+    with pytest.raises(OverflowError, match="too big to convert"):
+        t.StrongUInt(2 ** 64)
+    with pytest.raises(OverflowError, match="negative int to unsigned"):
+        t.StrongUInt(-1)
+    with pytest.raises(OverflowError, match="too negative"):
+        t.StrongInt(-32769)
+    with pytest.raises(OverflowError, match="too positive"):
+        t.StrongInt(32768)
+    with pytest.raises(OverflowError, match="too big to convert"):
+        t.StrongInt(2 ** 63)
+    with pytest.raises(OverflowError, match="too big to convert"):
+        t.StrongInt(-(2 ** 63) - 1)

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,4 +1,3 @@
-import sys
 import test_enum_ext as t
 import pytest
 
@@ -160,23 +159,17 @@ def test09_enum_unenumerated():
     assert repr(t.StrongInt(-1)) == "test_enum_ext.StrongInt.Invalid"
     assert repr(t.StrongUInt(0)) == "test_enum_ext.StrongUInt(0)"
 
-    outside_longlong_range = (
-        "integer too large"
-        if sys.implementation.name == "pypy"
-        else "too big to convert"
-    )
-
-    with pytest.raises(OverflowError, match="too large"):
+    with pytest.raises(RuntimeError):
         t.StrongUInt(65536)
-    with pytest.raises(OverflowError, match=outside_longlong_range):
+    with pytest.raises(RuntimeError):
         t.StrongUInt(2 ** 64)
-    with pytest.raises(OverflowError, match="negative int.* to unsigned"):
+    with pytest.raises(RuntimeError):
         t.StrongUInt(-1)
-    with pytest.raises(OverflowError, match="too negative"):
+    with pytest.raises(RuntimeError):
         t.StrongInt(-32769)
-    with pytest.raises(OverflowError, match="too positive"):
+    with pytest.raises(RuntimeError):
         t.StrongInt(32768)
-    with pytest.raises(OverflowError, match=outside_longlong_range):
+    with pytest.raises(RuntimeError):
         t.StrongInt(2 ** 63)
-    with pytest.raises(OverflowError, match=outside_longlong_range):
+    with pytest.raises(RuntimeError):
         t.StrongInt(-(2 ** 63) - 1)


### PR DESCRIPTION
Enums in C++ are sometimes used for their type-safety, even when the values are not enumerated. See for example https://embeddedartistry.com/blog/2020/09/28/strongly-typed-integers-and-registers-in-c/. This PR adds support to nanobind for binding enums that are used in this way.

Text size cost: 619 bytes