### PR TITLE
Use PEP-697 interface to access stashed data in type objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-2022', 'macos-latest']
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12.0-alpha.7', 'pypy3.9']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12.0-beta.1', 'pypy3.9']
         exclude:
           - os: 'macos-latest'
             python: 'pypy3.9'
           - os: 'windows-2022'
-            python: '3.12.0-alpha.7'
+            python: '3.12.0-beta.1'
 
     name: "Python ${{ matrix.python }} / ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -53,7 +53,7 @@ jobs:
         python -m pip install pytest pytest-github-actions-annotate-failures
 
     - name: Install NumPy
-      if: matrix.python != 'pypy3.9' && matrix.python != '3.12.0-alpha.7'
+      if: matrix.python != 'pypy3.9' && matrix.python != '3.12.0-beta.1'
       run: |
         python -m pip install numpy scipy
 

--- a/cmake/darwin-ld-cpython.sym
+++ b/cmake/darwin-ld-cpython.sym
@@ -494,6 +494,7 @@
 -U _PyObject_Dir
 -U _PyObject_Format
 -U _PyObject_Free
+-U _PyObject_GetTypeData
 -U _PyObject_GC_Del
 -U _PyObject_GC_IsFinalized
 -U _PyObject_GC_IsTracked

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -119,6 +119,12 @@ Version 1.3.0 (TBD)
   than ``some_obj.method()``.
   (PR `#216 <https://github.com/wjakob/nanobind/pull/216>`__).
 
+* Use the new `PEP-697 <https://peps.python.org/pep-0697/>`__ interface to
+  access data in type objects when compiling stable ABI3 wheels. This improves
+  forward compatibility (the Python team may at some point significantly
+  refactor the layout and internals of type objects). (PR `#211
+  <https://github.com/wjakob/nanobind/pull/211>`__):
+
 * ABI version 8.
 
 Version 1.2.0 (April 24, 2023)

--- a/docs/typeslots.rst
+++ b/docs/typeslots.rst
@@ -208,7 +208,7 @@ work without changes. The ``tp_clear`` slot requires small touch-ups:
 
    int wrapper_tp_clear(PyObject *self) {
        Wrapper *w = nb::inst_ptr<Wrapper>(self);
-       w->value = std::function<void(void)>();
+       w->value = nullptr;
        return 0;
    }
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -821,7 +821,7 @@ bool load_f32(PyObject *o, uint8_t flags, float *out) noexcept {
     return false;
 }
 
-#if PY_VERSION_HEX < 0x030c0000
+#if !defined(Py_LIMITED_API) && !defined(PYPY_VERSION) && PY_VERSION_HEX < 0x030c0000
 // Direct access for compact integers. These functions are
 // available as part of Python starting with version 3.12b1+
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -821,9 +821,40 @@ bool load_f32(PyObject *o, uint8_t flags, float *out) noexcept {
     return false;
 }
 
+#if PY_VERSION_HEX < 0x030c0000
+// Direct access for compact integers. These functions are
+// available as part of Python starting with version 3.12b1+
+
+NB_INLINE bool PyUnstable_Long_IsCompact(const PyLongObject *o) {
+    return abs(Py_SIZE(o)) <= 1;
+}
+
+NB_INLINE Py_ssize_t PyUnstable_Long_CompactValue(const PyLongObject *o) {
+    return Py_SIZE(o) * (Py_ssize_t) o->ob_digit[0];
+}
+#endif
+
 template <typename T, bool Recurse = true>
 NB_INLINE bool load_int(PyObject *o, uint32_t flags, T *out) noexcept {
     if (NB_LIKELY(PyLong_CheckExact(o))) {
+#if !defined(Py_LIMITED_API) && !defined(PYPY_VERSION)
+        PyLongObject *l = (PyLongObject *) o;
+
+        // Fast path for compact integers
+        if (NB_LIKELY(PyUnstable_Long_IsCompact(l))) {
+            Py_ssize_t value = PyUnstable_Long_CompactValue(l);
+            T value_t = (T) value;
+
+            if (NB_UNLIKELY((std::is_unsigned_v<T> && value < 0) ||
+                            (sizeof(T) != sizeof(Py_ssize_t) &&
+                             value != (Py_ssize_t) value_t)))
+                return false;
+
+            *out = value_t;
+            return true;
+        }
+#endif
+
         // Slow path
         using T0 = std::conditional_t<sizeof(T) <= sizeof(long), long, long long>;
         using Tp = std::conditional_t<std::is_signed_v<T>, T0, std::make_unsigned_t<T0>>;
@@ -852,14 +883,13 @@ NB_INLINE bool load_int(PyObject *o, uint32_t flags, T *out) noexcept {
     }
 
     if constexpr (Recurse) {
-        if ((flags & (uint8_t)cast_flags::convert) && !PyFloat_Check(o)) {
+        if ((flags & (uint8_t) cast_flags::convert) && !PyFloat_Check(o)) {
             PyObject* temp = PyNumber_Long(o);
             if (temp) {
                 bool result = load_int<T, false>(temp, 0, out);
                 Py_DECREF(temp);
                 return result;
-            }
-            else {
+            } else {
                 PyErr_Clear();
             }
         }

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -223,4 +223,6 @@ NB_MODULE(test_functions_ext, m) {
     m.def("test_cast_str", [](nb::handle h) {
         return nb::cast<const char *>(h);
     });
+
+    m.def("test_0", +[](int a, uint64_t b, int64_t c, uint32_t d, int32_t e, uint16_t f) { return a+b+c+d+e+f; });
 }


### PR DESCRIPTION
*This commit currently fails because the CI still builds against Python 3.12a7 that doesn't yet have PEP697. It will be merged once the GHA setup-python action has caught up with 3.12 beta*

PEP 697 introduced a new limited C API to extend opaque types. nanobind needs this feature because it stashes internal type data structures within Python ``type`` objects. Previously, we assumed a standard Python memory layout for such opaque types and did not do anything special besides adding an offset to get to the nanobind part.

However, such an approach is not acceptable when using nanobind to compile future-proof stable ABI wheels: the Python team may at some point significantly refactor the layout and internals of ``type`` objects, which would lead to undefined behavior in combination with our assumptions. This commit therefore switches to the recently introduced official interface that ensures long-term stability.