### PR TITLE
Support enable_shared_from_this

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,7 +34,7 @@ Version 1.3.0 (TBD)
 * Reduced the per-instance overhead of nanobind by 1 pointer and simplified the
   internal hash table types to crunch ``libnanobind``. (commit `de018d
   <https://github.com/wjakob/nanobind/commit/de018db2d17905564703f1ade4aa201a22f8551f>`__).
-* Reduced the size of nanobind type objects by 6 pointers. (PR `#194
+* Reduced the size of nanobind type objects by 5 pointers. (PR `#194
   <https://github.com/wjakob/nanobind/pull/194>`__, `#195
   <https://github.com/wjakob/nanobind/pull/195>`__, and commit `d82ca9
   <https://github.com/wjakob/nanobind/commit/d82ca9c14191e74dd35dd5bf15fc90f5230319fb>`__).
@@ -107,6 +107,11 @@ Version 1.3.0 (TBD)
     return unequal rather than failing; order comparisons such as
     ``some_enum < None`` will still fail, but now with a more
     informative error.
+
+* nanobind now has limited support for binding types that inherit from
+  ``std::enable_shared_from_this<T>``. See the :ref:`advanced section
+  on object ownership <enable_shared_from_this>` for more details.
+  (PR `#212 <https://github.com/wjakob/nanobind/pull/212>`__).
 
 * ABI version 8.
 

--- a/docs/ownership_adv.rst
+++ b/docs/ownership_adv.rst
@@ -168,15 +168,17 @@ behaviors:
   identical to what would happen if the C++ code did ``return
   obj->shared_from_this();`` (returning an explicit
   ``std::shared_ptr<ST>`` to Python) rather than ``return obj;``.
-  The return value policy has no effect in this case; you will get
+  The return value policy has limited effect in this case; you will get
   shared ownership on the Python side regardless of whether you used
-  ``rv_policy::take_ownership`` or ``rv_policy::reference``.
+  `rv_policy::take_ownership` or `rv_policy::reference`.
+  (`rv_policy::copy` and `rv_policy::move` will still create a new
+  object that has no ongoing relationship to the returned pointer.)
 
   * Note that this behavior occurs only if such a ``std::shared_ptr<ST>``
     already exists! If not, then nanobind behaves as it would without
     ``enable_shared_from_this``: a raw pointer will transfer exclusive
     ownership to Python by default, or will create a non-owning reference
-    if you use ``rv_policy::reference``.
+    if you use `rv_policy::reference`.
 
 * If a Python object is passed to C++ as ``std::shared_ptr<ST> obj``,
   and there already exists an associated ``std::shared_ptr<ST>`` which
@@ -234,9 +236,10 @@ a problem for your application, you might get better results by using
 
 .. warning:: C++ code that receives a raw pointer ``T *obj`` *must not*
    assume that it has exclusive ownership of ``obj``, or even that
-   ``obj`` is allocated on the heap; ``obj`` might be a subobject of a
-   nanobind instance allocated from Python. This applies even if
-   ``T`` supports ``shared_from_this()`` and there is no associated
+   ``obj`` is allocated on the C++ heap (via ``operator new``);
+   ``obj`` might instead be a subobject of a nanobind instance
+   allocated from Python. This applies even if ``T`` supports
+   ``shared_from_this()`` and there is no associated
    ``std::shared_ptr``. Lack of a ``shared_ptr`` does *not* imply
    exclusive ownership; it just means there's no way to share ownership
    with whoever the current owner is.

--- a/docs/ownership_adv.rst
+++ b/docs/ownership_adv.rst
@@ -228,8 +228,9 @@ must produce type-specific code to implement the above behaviors.
 
 There is no way to enable ``shared_from_this`` immediately upon
 regular Python-side object construction (i.e., ``SomeType(*args)``
-rather than ``SomeType.some_fn(*args)``). If you need to support that,
-then use :ref:`intrusive reference counting <intrusive>` instead.
+rather than ``SomeType.some_fn(*args)``). If this limitation creates
+a problem for your application, you might get better results by using
+:ref:`intrusive reference counting <intrusive>` instead.
 
 .. warning:: C++ code that receives a raw pointer ``T *obj`` *must not*
    assume that it has exclusive ownership of ``obj``, or even that

--- a/docs/ownership_adv.rst
+++ b/docs/ownership_adv.rst
@@ -118,7 +118,7 @@ in the introductory section on object ownership and provides detail on how
 shared pointer conversion is *implemented* by nanobind.
 
 When the user calls a C++ function taking an argument of type
-``std::shared<T>`` from Python, ownership of that object must be
+``std::shared_ptr<T>`` from Python, ownership of that object must be
 shared between C++ to Python. nanobind does this by increasing the reference
 count of the ``PyObject`` and then creating a ``std::shared_ptr<T>`` with a new
 control block containing a custom deleter that will in turn reduce the Python
@@ -139,19 +139,106 @@ true global reference count.
 
 .. _enable_shared_from_this:
 
-Limitations
-^^^^^^^^^^^
+enable_shared_from_this
+^^^^^^^^^^^^^^^^^^^^^^^
 
-nanobind refuses conversion of classes that derive from
-``std::enable_shared_from_this<T>``. This is a fundamental limitation:
-nanobind instances do not create a base shared pointer that declares
-ownership of an object. Other parts of a C++ codebase might then incorrectly
-assume ownership and eventually try to ``delete`` a nanobind instance
-allocated using ``pymalloc`` (which is undefined behavior). A compile-time
-assertion catches this and warns about the problem.
+The C++ standard library class ``std::enable_shared_from_this<T>``
+allows an object that inherits from it to locate an existing
+``std::shared_ptr<T>`` that manages that object. nanobind supports
+types that inherit from ``enable_shared_from_this``, with some caveats
+described in this section.
 
-Replacing shared pointers with :ref:`intrusive reference counting
-<intrusive>` fixes this limitations.
+Background (not nanobind-specific): Suppose a type ``ST`` inherits
+from ``std::enable_shared_from_this<ST>``. When a raw pointer ``ST
+*obj`` or ``std::unique_ptr<ST> obj`` is wrapped in a shared pointer
+using a constructor of the form ``std::shared_ptr<ST>(obj, ...)``, a
+reference to the new ``shared_ptr``\'s control block is saved (as
+``std::weak_ptr<ST>``) inside the object. This allows new
+``shared_ptr``\s that share ownership with the existing one to be
+obtained for the same object using ``obj->shared_from_this()`` or
+``obj->weak_from_this()``.
+
+nanobind's support for ``std::enable_shared_from_this`` consists of three
+behaviors:
+
+* If a raw pointer ``ST *obj`` is returned from C++ to Python, and
+  there already exists an associated ``std::shared_ptr<ST>`` which
+  ``obj->shared_from_this()`` can locate, then nanobind will produce a
+  Python instance that shares ownership with it. The behavior is
+  identical to what would happen if the C++ code did ``return
+  obj->shared_from_this();`` (returning an explicit
+  ``std::shared_ptr<ST>`` to Python) rather than ``return obj;``.
+  The return value policy has no effect in this case; you will get
+  shared ownership on the Python side regardless of whether you used
+  ``rv_policy::take_ownership`` or ``rv_policy::reference``.
+
+  * Note that this behavior occurs only if such a ``std::shared_ptr<ST>``
+    already exists! If not, then nanobind behaves as it would without
+    ``enable_shared_from_this``: a raw pointer will transfer exclusive
+    ownership to Python by default, or will create a non-owning reference
+    if you use ``rv_policy::reference``.
+
+* If a Python object is passed to C++ as ``std::shared_ptr<ST> obj``,
+  and there already exists an associated ``std::shared_ptr<ST>`` which
+  ``obj->shared_from_this()`` can locate, then nanobind will produce a
+  ``std::shared_ptr<ST>`` that shares ownership with it: an additional
+  reference to the same control block, rather than a new control block
+  (as would occur without ``enable_shared_from_this``). This improves
+  performance and makes the result of ``shared_ptr::use_count()`` more
+  accurate.
+
+* If a Python object is passed to C++ as ``std::shared_ptr<ST> obj``, and
+  there is no associated ``std::shared_ptr<ST>`` that
+  ``obj->shared_from_this()`` can locate, then nanobind will produce
+  a ``std::shared_ptr<ST>`` as usual (with a new control block whose deleter
+  drops a Python object reference), *and* will do so in a way that enables
+  future calls to ``obj->shared_from_this()`` to find it as long
+  as any ``shared_ptr`` that shares this control block is still alive on
+  the C++ side.
+
+  (Once all of the ``std::shared_ptr<ST>``\s that share this control block
+  have been destroyed, the underlying PyObject reference being
+  managed by the ``shared_ptr`` deleter will be dropped,
+  and ``shared_from_this()`` will stop working. It can be reenabled by
+  passing the Python object back to C++ as ``std::shared_ptr<ST>`` once more,
+  which will create another control block.)
+
+Bindings for a class that supports ``enable_shared_from_this`` will be
+slightly larger than bindings for a class that doesn't, as nanobind
+must produce type-specific code to implement the above behaviors.
+
+.. warning:: The ``shared_from_this()`` method will only work when there
+   is actually a ``std::shared_ptr`` managing the object. A nanobind
+   instance constructed from Python will not have an associated
+   ``std::shared_ptr`` yet, so ``shared_from_this()`` will throw an
+   exception if you pass such an instance to C++ using a reference or
+   raw pointer. ``shared_from_this()`` will only work when there exists
+   a corresponding live ``std::shared_ptr`` on the C++ side.
+
+   The only situation where nanobind will create the first
+   ``std::shared_ptr`` for an object (thus enabling
+   ``shared_from_this()``), even with ``enable_shared_from_this``, is
+   when a Python instance is passed to C++ as the explicit type
+   ``std::shared_ptr<T>``. If you don't do this, or if no such
+   ``std::shared_ptr`` is still alive, then ``shared_from_this()`` will
+   throw an exception. It also works to create the ``std::shared_ptr``
+   on the C++ side, such as by using a factory function which always
+   uses ``std::make_shared<T>(...)`` to construct the object, and
+   returns the resulting ``std::shared_ptr<T>`` to Python.
+
+There is no way to enable ``shared_from_this`` immediately upon
+regular Python-side object construction (i.e., ``SomeType(*args)``
+rather than ``SomeType.some_fn(*args)``). If you need to support that,
+then use :ref:`intrusive reference counting <intrusive>` instead.
+
+.. warning:: C++ code that receives a raw pointer ``T *obj`` *must not*
+   assume that it has exclusive ownership of ``obj``, or even that
+   ``obj`` is allocated on the heap; ``obj`` might be a subobject of a
+   nanobind instance allocated from Python. This applies even if
+   ``T`` supports ``shared_from_this()`` and there is no associated
+   ``std::shared_ptr``. Lack of a ``shared_ptr`` does *not* imply
+   exclusive ownership; it just means there's no way to share ownership
+   with whoever the current owner is.
 
 .. _unique_ptr_adv:
 

--- a/docs/porting.rst
+++ b/docs/porting.rst
@@ -132,16 +132,22 @@ both of the following include directives to your code:
 .. code-block:: cpp
 
    #include <nanobind/stl/unique_ptr.h>
-   #include <nanobind/stl/unique_shared_ptr.h>
+   #include <nanobind/stl/shared_ptr.h>
 
 Binding functions that take ``std::unique_ptr<T>`` arguments involves some
 limitations that can be avoided by changing their signatures to
 ``std::unique_ptr<T, nb::deleter<T>>`` (:ref:`details <unique_ptr>`).
 
-Usage of ``std::enable_shared_from_this<T>`` is **prohibited** and will raise a
-compile-time assertion (:ref:`details <enable_shared_from_this>`) . This is
-consistent with the philosophy of this library: *the codebase has to adapt to
-the binding tool and not the other way around*.
+Use of ``std::enable_shared_from_this<T>`` is permitted, but since
+nanobind does not use holder types, an object
+constructed in Python will typically not have any associated
+``std::shared_ptr<T>`` until it is passed to a C++ function that
+accepts ``std::shared_ptr<T>``. That means a C++ function that accepts
+a raw ``T*`` and calls ``shared_from_this()`` on it might stop working
+when ported from pybind11 to nanobind. You can solve this problem
+by always passing such objects across the Python/C++ boundary as
+``std::shared_ptr<T>`` rather than as ``T*``. See the :ref:`advanced section
+on object ownership <enable_shared_from_this>` for more details.
 
 Custom constructors
 -------------------

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -394,6 +394,10 @@ public:
         if constexpr (detail::has_shared_from_this_v<T>) {
             d.flags |= (uint32_t) detail::type_flags::has_shared_from_this;
             d.keep_shared_from_this_alive = [](PyObject *self) noexcept {
+                // weak_from_this().lock() is equivalent to shared_from_this(),
+                // except that it returns an empty shared_ptr instead of
+                // throwing an exception if there is no active shared_ptr
+                // for this object. (Added in C++17.)
                 if (auto sp = inst_ptr<T>(self)->weak_from_this().lock()) {
                     detail::keep_alive(self, new auto(std::move(sp)),
                                        [](void *p) noexcept {

--- a/include/nanobind/nb_traits.h
+++ b/include/nanobind/nb_traits.h
@@ -132,6 +132,16 @@ struct detector<std::void_t<Op<Arg>>, Op, Arg>
    avoid redundancy when combined with nb::arg(...).none(). */
 template <typename T> struct remove_opt_mono { using type = T; };
 
+// Detect std::enable_shared_from_this without including <memory>
+template <typename T>
+auto has_shared_from_this_impl(T *ptr) ->
+    decltype(ptr->weak_from_this().lock().get(), std::true_type{});
+std::false_type has_shared_from_this_impl(...);
+
+template <typename T>
+constexpr bool has_shared_from_this_v =
+    decltype(has_shared_from_this_impl((T *) nullptr))::value;
+
 NAMESPACE_END(detail)
 
 template <typename... Args>

--- a/tests/test_holders.cpp
+++ b/tests/test_holders.cpp
@@ -27,6 +27,24 @@ struct SharedWrapper { std::shared_ptr<Example> value; };
 struct UniqueWrapper { std::unique_ptr<Example> value; };
 struct UniqueWrapper2 { std::unique_ptr<Example, nb::deleter<Example>> value; };
 
+struct ExampleST : std::enable_shared_from_this<ExampleST> {
+    int value;
+    ExampleST(int value) : value(value) { created++; }
+    ~ExampleST() { deleted++; }
+
+    static ExampleST *make(int value) { return new ExampleST(value); }
+    static std::shared_ptr<ExampleST> make_shared(int value) {
+        return std::make_shared<ExampleST>(value);
+    }
+};
+struct SharedWrapperST {
+    std::shared_ptr<ExampleST> value;
+    ExampleST* get() const { return value.get(); }
+};
+
+static_assert(nb::detail::has_shared_from_this_v<ExampleST>);
+static_assert(!nb::detail::has_shared_from_this_v<Example>);
+
 enum class PetKind { Cat, Dog };
 struct Pet { const PetKind kind; };
 struct Dog : Pet { Dog() : Pet{PetKind::Dog} { } };
@@ -67,6 +85,66 @@ NB_MODULE(test_holders_ext, m) {
           [](std::shared_ptr<Example> &shared) { return shared->value; });
     m.def("passthrough",
           [](std::shared_ptr<Example> shared) { return shared; });
+
+    // ------- enable_shared_from_this -------
+
+    nb::class_<ExampleST>(m, "ExampleST")
+        .def(nb::init<int>())
+        .def("has_shared_from_this", [](ExampleST& self) {
+            return !self.weak_from_this().expired();
+        })
+        .def("shared_from_this", [](ExampleST& self) {
+            return self.shared_from_this();
+        })
+        .def("use_count", [](ExampleST& self) {
+            return self.weak_from_this().use_count();
+        })
+        .def_rw("value", &ExampleST::value)
+        .def_static("make", &ExampleST::make)
+        .def_static("make_shared", &ExampleST::make_shared);
+
+    struct DerivedST : ExampleST {
+        using ExampleST::ExampleST;
+    };
+    static_assert(nb::detail::has_shared_from_this_v<DerivedST>);
+    nb::class_<DerivedST, ExampleST>(m, "DerivedST")
+        .def(nb::init<int>())
+        .def_static("make", [](int v) {
+            return static_cast<DerivedST*>(ExampleST::make(v));
+        })
+        .def_static("make_shared", [](int v) {
+            return std::static_pointer_cast<DerivedST>(ExampleST::make_shared(v));
+        });
+
+    nb::class_<SharedWrapperST>(m, "SharedWrapperST")
+        .def(nb::init<std::shared_ptr<ExampleST>>())
+        .def_static("from_existing", [](ExampleST *obj) {
+            return SharedWrapperST{obj->shared_from_this()};
+        })
+        .def_static("from_wrapper", [](SharedWrapperST& w) {
+            return SharedWrapperST{w.value};
+        })
+        .def("use_count", [](SharedWrapperST& self) {
+            return self.value.use_count();
+        })
+        .def("same_owner", [](SharedWrapperST& self, ExampleST& other) {
+            auto self_s = self.value;
+            auto other_s = other.shared_from_this();
+            return !self_s.owner_before(other_s) &&
+                   !other_s.owner_before(self_s);
+        })
+        .def("get_own", &SharedWrapperST::get)
+        .def("get_ref", &SharedWrapperST::get, nb::rv_policy::reference)
+        .def_rw("ptr", &SharedWrapperST::value)
+        .def_prop_rw("value",
+            [](SharedWrapperST &t) { return t.value->value; },
+            [](SharedWrapperST &t, int value) { t.value->value = value; });
+
+    m.def("owns_cpp", [](nb::handle h) { return nb::inst_state(h).second; });
+    m.def("same_owner", [](const SharedWrapperST& a,
+                           const SharedWrapperST& b) {
+        return !a.value.owner_before(b.value) && !b.value.owner_before(a.value);
+    });
 
     // ------- unique_ptr -------
 

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -301,6 +301,7 @@ def test12_shared_from_this_create_shared_in_cpp(clean):
     # The nanobind conversion to shared_ptr<ExampleST> should use the
     # existing shared_from_this shared_ptr
     w3 = t.SharedWrapperST(w.ptr)
+    collect()  # on pypy the w.ptr temporary can stay alive
     assert w3.use_count() == 3
     assert t.same_owner(w2, w3)
 


### PR DESCRIPTION
Per discussion in https://github.com/wjakob/nanobind/discussions/183, this is not actually dangerous, although it does have some caveats (which I think I've thoroughly documented).

This turned out better than I thought it would: it is unexpectedly possible to support the feature where returning a raw pointer whose `enable_shared_from_this` subobject knows about a shared_ptr creates a Python object that shares ownership with that shared_ptr, without requiring `#include <memory>` anywhere in nanobind that doesn't already have it.

Size impact: `nb_type.cpp.o` increases by 148 bytes. Use of `std::shared_ptr<T>` in non-`enable_shared_from_this` cases actually gets smaller; we were previously instantiating a deleter for `PyObject*` by mistake, and now we're not.