### PR TITLE
Validate our assumption that the base class is a primary (offset-zero) base

### DIFF
--- a/include/nanobind/nb_traits.h
+++ b/include/nanobind/nb_traits.h
@@ -132,6 +132,14 @@ struct detector<std::void_t<Op<Arg>>, Op, Arg>
    avoid redundancy when combined with nb::arg(...).none(). */
 template <typename T> struct remove_opt_mono { using type = T; };
 
+template <typename Base, typename Derived>
+struct is_accessible_static_base_of {
+    template <typename B = Base, typename D = Derived>
+    static decltype(static_cast<D*>(std::declval<B*>()), std::true_type()) check(B*);
+    static std::false_type check(...);
+    static constexpr bool value = decltype(check((Base*)nullptr))::value;
+};
+
 NAMESPACE_END(detail)
 
 template <typename... Args>

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -631,3 +631,10 @@ def test34_trampoline_optimization():
             assert t.go(d2) == 'Rufus says woof'
         finally:
             t.Dog.name = old
+
+
+def test35_non_primary():
+    with pytest.raises(RuntimeError, match="not support multiple inheritance"):
+        t.bind_newly_polymorphic_subclass()
+    with pytest.raises(RuntimeError, match="not support multiple inheritance"):
+        t.bind_subclass_with_non_primary_base()


### PR DESCRIPTION
This is easy to do at ~compile-time if the base is specified as a template argument. (It's not legal to `reinterpret_cast` in a constant expression, so the error is reported at runtime, but the test and error message are expected to be compiled out if the test doesn't fail, and I checked this on my system.)

Also detect and complain about accessible virtual bases at compile time. I'm not aware of a way to detect inaccessible virtual bases either at compile time or runtime, at least not without obtaining an instance pointer somehow.

It is sort of possible to validate these things at runtime if the base is specified as a Python object, but much more difficult (requires mucking around with implementation-defined subclasses of `std::type_info`). I can add an implementation of that for libstdc++ on Linux if desired, but it costs about 400 bytes in libnanobind and I don't know how to do it on other platforms. It didn't seem worth it to me.