### PR TITLE
https://github.com/wjakob/nanobind/discussions/196

### DIFF
--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -78,9 +78,16 @@ struct tensorflow { };
 struct pytorch { };
 struct jax { };
 
+NAMESPACE_BEGIN(detail)
+
+template<typename T> constexpr bool is_ndarray_scalar_v =
+std::is_floating_point_v<T> || std::is_integral_v<T>;
+
+NAMESPACE_END(detail)
+
 template <typename T> constexpr dlpack::dtype dtype() {
     static_assert(
-        std::is_floating_point_v<T> || std::is_integral_v<T>,
+        detail::is_ndarray_scalar_v<T>,
         "nanobind::dtype<T>: T must be a floating point or integer variable!"
     );
 

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -7,19 +7,19 @@ using namespace nb::literals;
 
 NB_MODULE(test_eigen_ext, m) {
     m.def(
-        "addV3i_1",
+        "addV3i",
         [](const Eigen::Vector3i &a,
            const Eigen::Vector3i &b) -> Eigen::Vector3i { return a + b; },
         "a"_a, "b"_a.noconvert());
 
     m.def(
-        "addV3i_2",
+        "addR3i",
         [](const Eigen::RowVector3i &a,
            const Eigen::RowVector3i &b) -> Eigen::RowVector3i { return a + b; },
         "a"_a, "b"_a.noconvert());
 
     m.def(
-        "addV3i_3",
+        "addRefV3i",
         [](const Eigen::Ref<const Eigen::Vector3i> &a,
            const Eigen::Ref<const Eigen::Vector3i> &b) -> Eigen::Vector3i {
             return a + b;
@@ -27,13 +27,13 @@ NB_MODULE(test_eigen_ext, m) {
         "a"_a, "b"_a.noconvert());
 
     m.def(
-        "addV3i_4",
+        "addA3i",
         [](const Eigen::Array3i &a,
            const Eigen::Array3i &b) -> Eigen::Array3i { return a + b; },
         "a"_a, "b"_a.noconvert());
 
     m.def(
-        "addV3i_5",
+        "addA3i_retExpr",
         [](const Eigen::Array3i &a,
            const Eigen::Array3i &b) { return a + b; },
         "a"_a, "b"_a.noconvert());
@@ -47,62 +47,89 @@ NB_MODULE(test_eigen_ext, m) {
     using MatrixXuC = Eigen::Matrix<uint32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
     using MatrixXuR = Eigen::Matrix<uint32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
-    m.def("addM4u_1",
+    m.def("addM4uCC",
           [](const Matrix4uC &a,
              const Matrix4uC &b) -> Matrix4uC { return a + b; });
-    m.def("addMXu_1",
+    m.def("addMXuCC",
           [](const MatrixXuC &a,
              const MatrixXuC &b) -> MatrixXuC { return a + b; });
-    m.def("addMXu_1_nc",
+    m.def("addMXuCC_nc",
           [](const MatrixXuC &a,
              const MatrixXuC &b) -> MatrixXuC { return a + b; },
           "a"_a.noconvert(), "b"_a.noconvert());
 
 
-    m.def("addM4u_2",
+    m.def("addM4uRR",
           [](const Matrix4uR &a,
              const Matrix4uR &b) -> Matrix4uR { return a + b; });
-    m.def("addMXu_2",
+    m.def("addMXuRR",
           [](const MatrixXuR &a,
              const MatrixXuR &b) -> MatrixXuR { return a + b; });
-    m.def("addMXu_2_nc",
+    m.def("addMXuRR_nc",
           [](const MatrixXuR &a,
              const MatrixXuR &b) -> MatrixXuR { return a + b; },
           "a"_a.noconvert(), "b"_a.noconvert());
 
-    m.def("addM4u_3",
+    m.def("addM4uCR",
           [](const Matrix4uC &a,
              const Matrix4uR &b) -> Matrix4uC { return a + b; });
-    m.def("addMXu_3",
+    m.def("addMXuCR",
           [](const MatrixXuC &a,
              const MatrixXuR &b) -> MatrixXuC { return a + b; });
 
-    m.def("addM4u_4",
+    m.def("addM4uRC",
           [](const Matrix4uR &a,
              const Matrix4uC &b) -> Matrix4uR { return a + b; });
-    m.def("addMXu_4",
+    m.def("addMXuRC",
           [](const MatrixXuR &a,
              const MatrixXuC &b) -> MatrixXuR { return a + b; });
 
-    m.def("addMXu_5",
+    m.def("addMapMXuCC_nc",
+      [](const Eigen::Map<const MatrixXuC>& a,
+         const Eigen::Map<const MatrixXuC>& b) -> MatrixXuC { return a + b; },
+      "a"_a.noconvert(), "b"_a.noconvert());
+
+    m.def("addMapMXuRR_nc",
+      [](const Eigen::Map<const MatrixXuR>& a,
+         const Eigen::Map<const MatrixXuR>& b) -> MatrixXuC { return a + b; },
+      "a"_a.noconvert(), "b"_a.noconvert());
+
+    m.def("addRefMXuCC_nc",
+      [](const Eigen::Ref<const MatrixXuC>& a,
+         const Eigen::Ref<const MatrixXuC>& b) -> MatrixXuC { return a + b; },
+      "a"_a.noconvert(), "b"_a.noconvert());
+
+    m.def("addRefMXuRR_nc",
+      [](const Eigen::Ref<const MatrixXuR>& a,
+         const Eigen::Ref<const MatrixXuR>& b) -> MatrixXuC { return a + b; },
+      "a"_a.noconvert(), "b"_a.noconvert());
+
+    m.def("addDRefMXuCC_nc",
           [](const nb::DRef<const MatrixXuC> &a,
              const nb::DRef<const MatrixXuC> &b) -> MatrixXuC { return a + b; },
           "a"_a.noconvert(), "b"_a.noconvert());
 
-    m.def("mutate_MXu", [](nb::DRef<MatrixXuC> a) { a *= 2; }, nb::arg().noconvert());
+    m.def("addDRefMXuRR_nc",
+      [](const nb::DRef<const MatrixXuR>& a,
+         const nb::DRef<const MatrixXuR>& b) -> MatrixXuC { return a + b; },
+      "a"_a.noconvert(), "b"_a.noconvert());
 
-    m.def("updateV3i", [](Eigen::Ref<Eigen::Vector3i> a) { a[2] = 123; });
-    m.def("updateVXi", [](Eigen::Ref<Eigen::VectorXi> a) { a[2] = 123; });
+    m.def("mutate_DRefMXuC", [](nb::DRef<MatrixXuC> a) { a *= 2; }, nb::arg().noconvert());
+
+    m.def("updateRefV3i", [](Eigen::Ref<Eigen::Vector3i> a) { a[2] = 123; });
+    m.def("updateRefV3i_nc", [](Eigen::Ref<Eigen::Vector3i> a) { a[2] = 123; }, nb::arg().noconvert());
+    m.def("updateRefVXi", [](Eigen::Ref<Eigen::VectorXi> a) { a[2] = 123; });
+    m.def("updateRefVXi_nc", [](Eigen::Ref<Eigen::VectorXi> a) { a[2] = 123; }, nb::arg().noconvert());
 
     using SparseMatrixR = Eigen::SparseMatrix<float, Eigen::RowMajor>;
     using SparseMatrixC = Eigen::SparseMatrix<float>;
     Eigen::MatrixXf mat(5, 6);
     mat <<
-	 0, 3,  0, 0,  0, 11,
-	22, 0,  0, 0, 17, 11,
-	 7, 5,  0, 1,  0, 11,
-	 0, 0,  0, 0,  0, 11,
-	 0, 0, 14, 0,  8, 11;
+	     0, 3,  0, 0,  0, 11,
+	    22, 0,  0, 0, 17, 11,
+	     7, 5,  0, 1,  0, 11,
+	     0, 0,  0, 0,  0, 11,
+	     0, 0, 14, 0,  8, 11;
     m.def("sparse_r", [mat]() -> SparseMatrixR {
         return Eigen::SparseView<Eigen::MatrixXf>(mat);
     });
@@ -114,7 +141,8 @@ NB_MODULE(test_eigen_ext, m) {
     m.def("sparse_r_uncompressed", []() -> SparseMatrixR {
         SparseMatrixR m(2,2);
         m.coeffRef(0,0) = 1.0f;
-        return m;
+        assert(!m.isCompressed());
+        return m.markAsRValue();
     });
 
     /// issue #166
@@ -150,4 +178,13 @@ NB_MODULE(test_eigen_ext, m) {
     nb::class_<ClassWithEigenMember>(m, "ClassWithEigenMember")
         .def(nb::init<>())
         .def_rw("member", &ClassWithEigenMember::member);
+
+    m.def("castToMapVectorXi", [](nb::object obj) -> Eigen::Map<Eigen::VectorXi>
+      {
+        return nb::cast<Eigen::Map<Eigen::VectorXi>>(obj);
+      });
+    m.def("castToRefVectorXi", [](nb::object obj) -> Eigen::VectorXi
+      {
+        return nb::cast<Eigen::Ref<Eigen::VectorXi>>(obj);
+      });
 }


### PR DESCRIPTION
- new: `is_ndarray_scalar_v`, used to limit `type_caster<Eigen>` to those scalars that it can actually handle. This gives users the chance to add their own specializations for other scalars.
- de-bug: correct handling of Eigen/ndarray strides
- enhanced: fully support Eigen's dynamic strides; request contiguous memory from ndarray only if really needed.
- de-bug: prevent `nb::cast<Eigen::Map>` and `nb::cast<Eigen::Ref<mutable>>` from pointing to invalid memory due to conversions.
- enhanced: renamed a few test functions to better reflect their signature.

As discussed, `type_caster<Eigen::Map>` and `type_caster<Eigen::Ref<mutable>>` do not support conversions any longer, unless a cleanup_list is passed. This prevents `nb::cast` from returning Eigen types that point into destroyed memory.

Still, I suggest these 2 type casters to not support conversions at all, even if they handle bound function arguments. I believe that the intention of binding a function that expects an `Eigen::Map` is to modify the passed memory (`Map<mutable>`) or to avoid copies (`Map<const>`). Silent conversions may hide errors and show surprising behaviour instead, see e.g. https://github.com/WKarel/nanobind/blob/f339ec0df6ce0d2d185e82df03e4e1905c04a183/tests/test_eigen.py#L91 where the argument remains unmodified.