### PR TITLE
nb_bound_method: add introspection attributes and fix surprising behavior around wrapper descriptors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -113,6 +113,11 @@ Version 1.3.0 (TBD)
   on object ownership <enable_shared_from_this>` for more details.
   (PR `#212 <https://github.com/wjakob/nanobind/pull/212>`__).
 
+* Added introspection attributes ``__self__`` and ``__func__`` to nanobind
+  bound methods, to make them more like regular Python bound methods.
+  Fixed a bug where ``some_obj.method.__call__()`` would behave differently
+  than ``some_obj.method()``.
+
 * ABI version 8.
 
 Version 1.2.0 (April 24, 2023)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -117,6 +117,7 @@ Version 1.3.0 (TBD)
   bound methods, to make them more like regular Python bound methods.
   Fixed a bug where ``some_obj.method.__call__()`` would behave differently
   than ``some_obj.method()``.
+  (PR `#216 <https://github.com/wjakob/nanobind/pull/216>`__).
 
 * ABI version 8.
 

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -163,6 +163,10 @@ static PyType_Spec nb_method_spec = {
 static PyMemberDef nb_bound_method_members[] = {
     { "__vectorcalloffset__", T_PYSSIZET,
       (Py_ssize_t) offsetof(nb_bound_method, vectorcall), READONLY, nullptr },
+    { "__func__", T_OBJECT_EX,
+      (Py_ssize_t) offsetof(nb_bound_method, func), READONLY, nullptr },
+    { "__self__", T_OBJECT_EX,
+      (Py_ssize_t) offsetof(nb_bound_method, self), READONLY, nullptr },
     { nullptr, 0, 0, 0, nullptr }
 };
 

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -607,6 +607,7 @@ def test33_polymorphic_downcast():
     assert isinstance(t.polymorphic_factory(), t.PolymorphicSubclass)
     assert isinstance(t.polymorphic_factory_2(), t.PolymorphicBase)
 
+
 def test34_trampoline_optimization():
     class Rufus(t.Dog):
         def __init__(self):
@@ -631,3 +632,19 @@ def test34_trampoline_optimization():
             assert t.go(d2) == 'Rufus says woof'
         finally:
             t.Dog.name = old
+
+
+def test35_method_introspection():
+    obj = t.Struct(5)
+    m = obj.value
+    assert m() == m.__call__() == 5
+    assert hash(m) == m.__hash__()
+    assert repr(m) == m.__repr__()
+    assert "bound_method" in repr(m)
+    assert m.__self__ is obj
+    assert m.__func__ is t.Struct.value
+    # attributes not defined by nb_bound_method are forwarded to nb_method:
+    assert m.__name__ == "value"
+    assert m.__qualname__ == "Struct.value"
+    assert m.__module__ == t.__name__
+    assert m.__doc__ == t.Struct.value.__doc__ == "value(self) -> int"


### PR DESCRIPTION
The introspection attributes `__self__` and `__func__` provide better interface compatibility with regular Python bound methods, and can be cheaply supported by adding new entries in the existing member list.

The previous wholesale forwarding of attribute accesses to the underlying `nb_func` produced surprising behavior when explicitly invoking dunder methods: `obj.method()` would work but `obj.method.__call__()` would not (it would need `obj.method.__call__(obj)`). Same thing for `__repr__`, `__hash__`, etc. Fix this by checking the 'normal' attribute path before delegating to the contained method, except for `__doc__` and `__module__` where we want `nb_func`'s version even though the attribute does exist in `nb_bound_method`'s class dict as well. This is necessary to support `__self__` and `__func__` but I think it's a good idea regardless.