### PR TITLE
Read-only array exchange via the buffer protocol

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -496,16 +496,16 @@ in a :ref:`separate section <ndarrays>`.
 
       Return the stride of dimension `i`.
 
-   .. cpp:function:: int64_t* shape_ptr() const
+   .. cpp:function:: const int64_t* shape_ptr() const
 
       Return a pointer to the shape array. Note that the return type is
-      ``int64_t*``, which may be unexpected as the scalar version
+      ``const int64_t*``, which may be unexpected as the scalar version
       :cpp:func:`shape()` casts its result to a ``size_t``.
 
       This is a consequence of the DLPack tensor representation that uses
       signed 64-bit integers for all of these fields.
 
-   .. cpp:function:: int64_t* stride_ptr() const
+   .. cpp:function:: const int64_t* stride_ptr() const
 
       Return pointer to the stride array.
 
@@ -526,11 +526,12 @@ in a :ref:`separate section <ndarrays>`.
 
    .. cpp:function:: const Scalar * data() const
 
-      Return a mutable pointer to the array data.
+      Return a const pointer to the array data.
 
    .. cpp:function:: Scalar * data()
 
-      Return a const pointer to the array data.
+      Return a mutable pointer to the array data. Only enabled when `Scalar` is
+      not itself ``const``.
 
    .. cpp:function:: template <typename... Ts> auto& operator()(Ts... indices)
 
@@ -603,6 +604,24 @@ Array annotations
 The :cpp:class:`ndarray\<..\> <ndarray>` class admits optional template
 parameters. They constrain the type of array arguments that may be passed to a
 function.
+
+The following are supported:
+
+Data type
++++++++++
+
+The data type of the underlying scalar element. The following are supported.
+
+- ``[u]int8_t`` up to ``[u]int64_t`` and other variations (``unsigned long long``, etc.)
+- ``float``, ``double``
+- ``bool``
+
+Annotate the data type with ``const`` to indicate a read-only array. Note that
+only the buffer protocol/NumPy interface considers ``const``-ness at the
+moment; data exchange with other array libraries will ignore this annotation.
+
+nanobind does not support non-standard types as documented in the section on
+:ref:`dtype limitations <dtype_restrictions>`.
 
 Shape
 +++++

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,9 @@ Version 1.3.0 (TBD)
 * Refined compiler and linker flags across platforms to ensure compact binaries
   especially in ``NB_STATIC`` builds. (commit `5ead9f
   <https://github.com/wjakob/nanobind/commit/5ead9ff348a2ef0df8231e6480607a5b0623a16b>`__)
+*  The :cpp:class:`nb::ndarray\<..\> <ndarray>` class can now use the buffer
+  protocol to receive and return arrays representing read-only memory. (PR
+  `#217 <https://github.com/wjakob/nanobind/pull/217>`__)t.
 * Reduced the number of exception-related exports to further crunch
   ``libnanobind``. (commit `763962
   <https://github.com/wjakob/nanobind/commit/763962b8ce76414148089ef6a68cff97d7cc66ce>`__).

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -389,8 +389,8 @@ NB_CORE ndarray_handle *ndarray_import(PyObject *o, const ndarray_req *req,
 NB_CORE ndarray_handle *ndarray_create(void *value, size_t ndim,
                                        const size_t *shape, PyObject *owner,
                                        const int64_t *strides,
-                                       dlpack::dtype *dtype, int32_t device,
-                                       int32_t device_id);
+                                       dlpack::dtype *dtype, bool ro,
+                                       int32_t device, int32_t device_id);
 
 /// Increase the reference count of the given ndarray object; returns a pointer
 /// to the underlying DLTensor

--- a/tests/test_ndarray.cpp
+++ b/tests/test_ndarray.cpp
@@ -8,6 +8,7 @@ namespace nb = nanobind;
 using namespace nb::literals;
 
 int destruct_count = 0;
+static const float f_const[] { 1, 2, 3, 4, 5, 6, 7, 8 };
 
 NB_MODULE(test_ndarray_ext, m) {
     m.def("get_shape", [](const nb::ndarray<> &t) {
@@ -148,6 +149,11 @@ NB_MODULE(test_ndarray_ext, m) {
                                                              deleter);
     });
 
+    m.def("ret_numpy_const", []() {
+        size_t shape[2] = { 2, 4 };
+        return nb::ndarray<nb::numpy, const float, nb::shape<2, 4>>(f_const, 2, shape);
+    });
+
     m.def("ret_pytorch", []() {
         float *f = new float[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
         size_t shape[2] = { 2, 4 };
@@ -173,12 +179,15 @@ NB_MODULE(test_ndarray_ext, m) {
             return nb::ndarray<nb::numpy, float>(f, 0, shape, deleter);
     });
 
-    m.def(
-        "noop_3d_c_contig",
-        [](nb::ndarray<float, nb::shape<nb::any, nb::any, nb::any>, nb::c_contig>) { return; });
+    m.def("noop_3d_c_contig",
+          [](nb::ndarray<float, nb::shape<nb::any, nb::any, nb::any>,
+                         nb::c_contig>) { return; });
 
-    m.def(
-        "noop_2d_f_contig",
-        [](nb::ndarray<float, nb::shape<nb::any, nb::any>, nb::f_contig>) { return; });
+    m.def("noop_2d_f_contig",
+          [](nb::ndarray<float, nb::shape<nb::any, nb::any>, nb::f_contig>) {
+              return;
+          });
 
+    m.def("accept_rw", [](nb::ndarray<float, nb::shape<2>> a) { return a(0); });
+    m.def("accept_ro", [](nb::ndarray<const float, nb::shape<2>> a) { return a(0); });
 }


### PR DESCRIPTION
This PR adapts nanobind so that it can both receive and return arrays representing read-only memory. This is communicated via the standard ``const`` type modifier, e.g. by replacing ``nb::ndarray<float, ...>`` with ``nb::ndarray<const float, ...>``.

The PR also adapts accessors (``data()``, ``operator()``) so that they only return constant references/pointers in that case.

The change is for now specific to the buffer protocol used to exchange nd-arrays with NumPy. The DLPack interface (used to exchange nd-arrays with PyTorch, Tensorflow, etc.) ignores the read-only annotation. This may change at some point in the future when an upcoming DLPack version with a read-only bit is more widely deployed.

This PR only targets the ``ndarray`` class. It will be nice to also propagate it into the Eigen type caster (@WKarel ?)