### PR TITLE
Support `Eigen::Block` API

### DIFF
--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -192,12 +192,16 @@ NB_MODULE(test_eigen_ext, m) {
 
 
     struct ClassWithEigenMember {
-        Eigen::MatrixXd member = Eigen::Matrix2d::Ones();
+        Eigen::MatrixXd member = Eigen::Matrix3d::Ones();
     };
 
     nb::class_<ClassWithEigenMember>(m, "ClassWithEigenMember")
         .def(nb::init<>())
-        .def_rw("member", &ClassWithEigenMember::member);
+        .def_rw("member", &ClassWithEigenMember::member)
+        .def("get_view", [](ClassWithEigenMember& c){ return c.member(Eigen::seq(0, 2, 2), Eigen::seq(0, 1)); })
+        .def("get_block", [](ClassWithEigenMember& c){ return c.member(Eigen::seq(0, 1), Eigen::seq(0, 1)); })
+        .def("get_xpr_block", [](ClassWithEigenMember& c){ return (c.member * 1.)(Eigen::seq(0, 1), Eigen::seq(0, 1)); })
+        .def("get_index", [](ClassWithEigenMember& c){ return c.member(0, 0); });
 
     m.def("castToMapVXi", [](nb::object obj) -> Eigen::Map<Eigen::VectorXi> {
         return nb::cast<Eigen::Map<Eigen::VectorXi>>(obj);
@@ -214,5 +218,4 @@ NB_MODULE(test_eigen_ext, m) {
     m.def("castToRef03CnstVXi", [](nb::object obj) -> Eigen::VectorXi {
         return nb::cast<Eigen::Ref<const Eigen::VectorXi, Eigen::Unaligned, Eigen::InnerStride<3>>>(obj);
     });
-
 }

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -308,7 +308,7 @@ def test10_eigen_scalar_default():
 def test11_prop():
     for j in range(3):
         c = t.ClassWithEigenMember()
-        ref = np.ones((2, 2))
+        ref = np.ones((3, 3))
         if j == 0:
             c.member = ref
 
@@ -349,3 +349,35 @@ def test12_cast():
     for v in vec, vec2, vecf:
         with pytest.raises(RuntimeError, match='bad[_ ]cast'):
             t.castToRef03CnstVXi(v)
+
+@needs_numpy_and_eigen
+def test13_view():
+    c = t.ClassWithEigenMember()
+    view = c.get_view()
+    ref = np.ones((2, 2))
+    assert view.size == 4
+    assert view.shape == (2, 2)
+    assert np.all(view == ref)
+
+    view[0, 0] = 10.
+    # a view is an expression, evaluated when returned
+    assert c.member[0, 0] == 1.
+
+@needs_numpy_and_eigen
+def test14_block():
+    c = t.ClassWithEigenMember()
+    block = c.get_block()
+    ref = np.ones((2, 2))
+    assert block.size == 4
+    assert block.shape == (2, 2)
+    assert np.all(block == ref)
+
+    block[0, 0] = 10.
+    assert c.member[0, 0] == 10.
+
+@needs_numpy_and_eigen
+def test15_index():
+    c = t.ClassWithEigenMember()
+    index = c.get_index()
+    assert isinstance(index, float)
+    assert index == 1.


### PR DESCRIPTION
Description
---

Support `Eigen::Block` API:
- disambiguate `Eigen::Ref`, `Eigen::Block` and `Eigen::Map`
- add tests

Closes https://github.com/wjakob/nanobind/discussions/218

Discussion
---

I'm not really happy with the composition pattern of casters.
This PR probably conflicts with https://github.com/wjakob/nanobind/pull/215
Happy to rebase or update on your recommendations!
