### PR TITLE
Function dispatcher optimization

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,10 +15,17 @@ case, both modules must use the same nanobind ABI version, or they will be
 isolated from each other. Releases that don't explicitly mention an ABI version
 below inherit that of the preceding release.
 
+Version 1.4.0 (TBA)
+-------------------
+
+* Improved the efficiency of the function dispatch loop. (PR `#227
+  <https://github.com/wjakob/nanobind/pull/227>`__).
+* ABI version 9.
+
 Version 1.3.2 (June 2, 2023)
 ----------------------------
 
-* Fixed compilation on 32 bit processorss (only i686 tested so far).
+* Fixed compilation on 32 bit processors (only ``i686`` tested so far).
   (PR `#224 <https://github.com/wjakob/nanobind/pull/224>`__).
 * Fixed compilation on PyPy 3.8. (commit `cd8135
   <https://github.com/wjakob/nanobind/commit/cd8135baa1da1213252272b5c9ecbf909e947597>`__).

--- a/docs/lowlevel.rst
+++ b/docs/lowlevel.rst
@@ -218,7 +218,7 @@ Here is what this might look like in an implementation:
   };
 
   // Register a new type MyTensor, and reserve space for sizeof(MyTensorMedadata)
-  nb::class_<MyTensor> cls(m, "MyTensor", nb::supplement<MyTensorMedadata>(), nb::is_final())
+  nb::class_<MyTensor> cls(m, "MyTensor", nb::supplement<MyTensorMedadata>())
 
   /// Mutable reference to 'MyTensorMedadata' portion in Python type object
   MyTensorMedadata &supplement = nb::type_supplement<MyTensorMedadata>(cls);

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -45,14 +45,11 @@ enum class type_flags : uint32_t {
     /// The class uses an intrusive reference counting approach
     intrusive_ptr            = (1 << 11),
 
-    /// Is this a trampoline class meant to be overloaded in Python?
-    is_trampoline            = (1 << 12),
-
     /// Is this a class that inherits from enable_shared_from_this?
     /// If so, type_data::keep_shared_from_this_alive is also set.
-    has_shared_from_this     = (1 << 13),
+    has_shared_from_this     = (1 << 12),
 
-    // Five more flag bits available (14 through 18) without needing
+    // Six more flag bits available (13 through 18) without needing
     // a larger reorganization
 };
 
@@ -360,9 +357,6 @@ public:
             d.base = &typeid(Base);
             d.flags |= (uint32_t) detail::type_init_flags::has_base;
         }
-
-        if constexpr (!std::is_same_v<Alias, T>)
-            d.flags |= (uint32_t) detail::type_flags::is_trampoline;
 
         if constexpr (detail::is_copy_constructible_v<T>) {
             d.flags |= (uint32_t) detail::type_flags::is_copy_constructible;

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -221,7 +221,9 @@ PyObject *nb_func_new(const void *in_) noexcept {
             PyErr_Clear();
         }
 
-        is_constructor = strcmp(f->name, "__init__") == 0;
+        // Is this method a constructor that takes a class binding as first parameter?
+        is_constructor = is_method && strcmp(f->name, "__init__") == 0 &&
+                         strncmp(f->descr, "({%}", 4) == 0;
 
         // Don't use implicit conversions in copy constructors (causes infinite recursion)
         if (is_constructor && f->nargs == 2 && f->descr_types[0] &&
@@ -460,37 +462,11 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
 
     func_data *fr = nb_func_data(self);
 
-    const bool is_method = fr->flags & (uint32_t) func_flags::is_method;
-    bool is_constructor = false;
+    const bool is_method      = fr->flags & (uint32_t) func_flags::is_method,
+               is_constructor = fr->flags & (uint32_t) func_flags::is_constructor;
 
-    uint32_t self_flags = 0;
-
-    PyObject *result = nullptr, *self_arg = nullptr;
-
-    if (is_method) {
-        self_arg = nargs_in > 0 ? args_in[0] : nullptr;
-
-        if (NB_LIKELY(self_arg)) {
-            PyTypeObject *self_tp = Py_TYPE(self_arg);
-
-            if (NB_LIKELY(nb_type_check((PyObject *) self_tp))) {
-                self_flags = nb_type_data(self_tp)->flags;
-                if (self_flags & (uint32_t) type_flags::is_trampoline)
-                    current_method_data = current_method{ fr->name, self_arg };
-
-                is_constructor = fr->flags & (uint32_t) func_flags::is_constructor;
-                if (is_constructor) {
-                    if (((nb_inst *) self_arg)->ready) {
-                        PyErr_SetString(
-                            PyExc_RuntimeError,
-                            "nanobind::detail::nb_func_vectorcall(): the __init__ "
-                            "method should not be called on an initialized object!");
-                        return nullptr;
-                    }
-                }
-            }
-        }
-    }
+    PyObject *result = nullptr,
+             *self_arg = (is_method && nargs_in > 0) ? args_in[0] : nullptr;
 
     /* The following lines allocate memory on the stack, which is very efficient
        but also potentially dangerous since it can be used to generate stack
@@ -502,7 +478,6 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
                         "1024) keyword arguments.");
         return nullptr;
     }
-
 
     // Handler routine that will be invoked in case of an error condition
     PyObject *(*error_handler)(PyObject *, PyObject *const *, size_t,
@@ -688,8 +663,7 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
                     nb_inst *self_arg_nb = (nb_inst *) self_arg;
                     self_arg_nb->destruct = true;
                     self_arg_nb->ready = true;
-
-                    if (NB_UNLIKELY(self_flags & (uint32_t) type_flags::intrusive_ptr))
+                    if (NB_UNLIKELY(self_arg_nb->intrusive))
                         nb_type_data(Py_TYPE(self_arg))
                             ->set_self_py(inst_ptr(self_arg_nb), self_arg);
                 }
@@ -704,11 +678,8 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
 done:
     cleanup.release();
 
-    if (error_handler)
+    if (NB_UNLIKELY(error_handler))
         result = error_handler(self, args_in, nargs_in, kwargs_in);
-
-    if (self_flags & (uint32_t) type_flags::is_trampoline)
-        current_method_data = current_method{ nullptr, nullptr };
 
     return result;
 }
@@ -724,36 +695,11 @@ static PyObject *nb_func_vectorcall_simple(PyObject *self,
     const size_t count         = (size_t) Py_SIZE(self),
                  nargs_in      = (size_t) NB_VECTORCALL_NARGS(nargsf);
 
-    const bool is_method = fr->flags & (uint32_t) func_flags::is_method;
-    bool is_constructor = false;
+    const bool is_method      = fr->flags & (uint32_t) func_flags::is_method,
+               is_constructor = fr->flags & (uint32_t) func_flags::is_constructor;
 
-    uint32_t self_flags = 0;
-
-    PyObject *result = nullptr, *self_arg = nullptr;
-
-    if (is_method) {
-        self_arg = nargs_in > 0 ? args_in[0] : nullptr;
-
-        if (NB_LIKELY(self_arg)) {
-            PyTypeObject *self_tp = Py_TYPE(self_arg);
-            if (NB_LIKELY(nb_type_check((PyObject *) self_tp))) {
-                self_flags = nb_type_data(self_tp)->flags;
-                if (NB_UNLIKELY(self_flags & (uint32_t) type_flags::is_trampoline))
-                    current_method_data = current_method{ fr->name, self_arg };
-
-                is_constructor = fr->flags & (uint32_t) func_flags::is_constructor;
-                if (is_constructor) {
-                    if (NB_UNLIKELY(((nb_inst *) self_arg)->ready)) {
-                        PyErr_SetString(PyExc_RuntimeError,
-                                        "nanobind::detail::nb_func_vectorcall_simple():"
-                                        " the __init__ method should not be called on "
-                                        "an initialized object!");
-                        return nullptr;
-                    }
-                }
-            }
-        }
-    }
+    PyObject *result = nullptr,
+             *self_arg = (is_method && nargs_in > 0) ? args_in[0] : nullptr;
 
     /// Small array holding temporaries (implicit conversion/*args/**kwargs)
     cleanup_list cleanup(self_arg);
@@ -817,8 +763,7 @@ static PyObject *nb_func_vectorcall_simple(PyObject *self,
                     nb_inst *self_arg_nb = (nb_inst *) self_arg;
                     self_arg_nb->destruct = true;
                     self_arg_nb->ready = true;
-
-                    if (NB_UNLIKELY(self_flags & (uint32_t) type_flags::intrusive_ptr))
+                    if (NB_UNLIKELY(self_arg_nb->intrusive))
                         nb_type_data(Py_TYPE(self_arg))
                             ->set_self_py(inst_ptr(self_arg_nb), self_arg);
                 }
@@ -835,9 +780,6 @@ done:
 
     if (NB_UNLIKELY(error_handler))
         result = error_handler(self, args_in, nargs_in, kwargs_in);
-
-    if (NB_UNLIKELY(self_flags & (uint32_t) type_flags::is_trampoline))
-        current_method_data = current_method{ nullptr, nullptr };
 
     return result;
 }
@@ -996,7 +938,7 @@ static void nb_func_render_signature(const func_data *f) noexcept {
 
             case '%':
                 check(*descr_type,
-                      "nb::detail::nb_func_finalize(): missing type!");
+                      "nb::detail::nb_func_render_signature(): missing type!");
 
                 if (!(is_method && arg_index == 0)) {
                     auto it = internals.type_c2p.find(std::type_index(**descr_type));
@@ -1023,7 +965,7 @@ static void nb_func_render_signature(const func_data *f) noexcept {
     }
 
     check(arg_index == f->nargs && !*descr_type,
-          "nanobind::detail::nb_func_finalize(%s): arguments inconsistent.",
+          "nanobind::detail::nb_func_render_signature(%s): arguments inconsistent.",
           f->name);
 }
 

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -17,7 +17,7 @@
 
 /// Tracks the ABI of nanobind
 #ifndef NB_INTERNALS_VERSION
-#  define NB_INTERNALS_VERSION 8
+#  define NB_INTERNALS_VERSION 9
 #endif
 
 /// On MSVC, debug and release builds are not ABI-compatible!
@@ -189,9 +189,6 @@ static PyType_Spec nb_bound_method_spec = {
                    NB_HAVE_VECTORCALL_PY39_OR_NEWER,
     /* .slots = */ nb_bound_method_slots
 };
-
-NB_THREAD_LOCAL current_method current_method_data =
-    current_method{ nullptr, nullptr };
 
 nb_internals *internals_p = nullptr;
 

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -66,6 +66,9 @@ struct nb_inst { // usually: 24 bytes
 
     /// Does this instance hold reference to others? (via internals.keep_alive)
     bool clear_keep_alive : 1;
+
+    /// Does this instance use intrusive reference counting?
+    bool intrusive : 1;
 };
 
 static_assert(sizeof(nb_inst) == sizeof(PyObject) + sizeof(uint32_t) * 2);
@@ -246,12 +249,6 @@ struct nb_internals {
 #  define NB_SLOT(internals, type, name) type.name
 #endif
 
-struct current_method {
-    const char *name;
-    PyObject *self;
-};
-
-extern NB_THREAD_LOCAL current_method current_method_data;
 extern nb_internals *internals_p;
 extern nb_internals *internals_fetch();
 

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -114,6 +114,8 @@ PyObject *inst_new_impl(PyTypeObject *tp, void *value) {
         self->internal = false;
     }
 
+    self->intrusive = t->flags & (uint32_t) type_flags::intrusive_ptr;
+
     // Update hash table that maps from C++ to Python instance
     auto [it, success] =
         internals_get().inst_c2p.try_emplace(value, self);
@@ -982,12 +984,14 @@ bool nb_type_get(const std::type_info *cpp_type, PyObject *src, uint8_t flags,
         if (valid) {
             nb_inst *inst = (nb_inst *) src;
 
-            if (!inst->ready &&
-                (flags & (uint8_t) cast_flags::construct) == 0) {
-                PyErr_WarnFormat(PyExc_RuntimeWarning, 1,
-                                 "nanobind: attempted to access an "
-                                 "uninitialized instance of type '%s'!\n",
-                                 t->name);
+            if (((flags & (uint8_t) cast_flags::construct) != 0) == inst->ready) {
+                PyErr_WarnFormat(
+                    PyExc_RuntimeWarning, 1, "nanobind: %s of type '%s'!\n",
+                    inst->ready
+                        ? "attempted to initialize an already-initialized "
+                          "instance"
+                        : "attempted to access an uninitialized instance",
+                    t->name);
                 return false;
             }
 

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -58,9 +58,9 @@ def test03_instantiate(clean):
 
 def test04_double_init():
     s = t.Struct()
-    with pytest.raises(RuntimeError) as excinfo:
-        s.__init__()
-    assert 'the __init__ method should not be called on an initialized object!' in str(excinfo.value)
+    with pytest.warns(RuntimeWarning, match='nanobind: attempted to initialize an already-initialized instance of type'):
+        with pytest.raises(TypeError):
+            s.__init__(3)
 
 
 def test05_rv_policy(clean):

--- a/tests/test_stl_bind_map.py
+++ b/tests/test_stl_bind_map.py
@@ -1,5 +1,6 @@
 import pytest
 import sys
+import platform
 
 import test_bind_map_ext as t
 
@@ -38,8 +39,14 @@ def test_map_string_double(capfd):
 
     with pytest.raises(TypeError):
         mm2.update({"a" : "b"})
-    captured = capfd.readouterr()
-    assert captured.err.strip() == "nanobind: implicit conversion from type 'dict' to type 'test_bind_map_ext.MapStringDouble' failed!"
+    captured = capfd.readouterr().err.strip()
+    ref = "nanobind: implicit conversion from type 'dict' to type 'test_bind_map_ext.MapStringDouble' failed!"
+
+    # Work around Pytest-related flakiness (https://github.com/pytest-dev/pytest/issues/10843)
+    if platform.system() == 'Windows':
+        assert captured == ref or captured == ''
+    else:
+        assert captured == ref
 
     mm2.update({"a" : 2.5})
     assert len(mm2) == 1

--- a/tests/test_stl_bind_vector.py
+++ b/tests/test_stl_bind_vector.py
@@ -1,4 +1,5 @@
 import pytest
+import platform
 
 import test_bind_vector_ext as t
 
@@ -43,8 +44,14 @@ def test01_vector_int(capfd):
     with pytest.raises(TypeError):
         v_int2.extend([8, "a"])
 
-    captured = capfd.readouterr()
-    assert captured.err.strip() == "nanobind: implicit conversion from type 'list' to type 'test_bind_vector_ext.VectorInt' failed!"
+    captured = capfd.readouterr().err.strip()
+    ref = "nanobind: implicit conversion from type 'list' to type 'test_bind_vector_ext.VectorInt' failed!"
+
+    # Work around Pytest-related flakiness (https://github.com/pytest-dev/pytest/issues/10843)
+    if platform.system() == 'Windows':
+        assert captured == ref or captured == ''
+    else:
+        assert captured == ref
 
     assert v_int2 == t.VectorInt([0, 99, 2, 3, 4, 5, 6, 7])
 


### PR DESCRIPTION
This commit simplifies and optimizes the performance-critical function dispatch loop (both simple + complex variants).

This previously did a few extra things that are now all moved to other places:

- Ensuring that an already initialized class cannot be initialized again (the class type caster now checks for this)

- Ensuring sure that ``super().function()`` within a trampoline reaches the parent class implementation of ``function()``, which required tracking some TLS state. This functionality is now moved to the trampolines.

- Double-checking that the 'self' type in a constructor is actually a class bound via nanobind. This is now checked when the binding is first created.