### PR TITLE
Accept `none` arg in RW properties at 1st positional annotation

### DIFF
--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -132,7 +132,9 @@ NB_MODULE(test_classes_ext, m) {
                     nb::rv_policy::reference)
         .def_static("create_copy", &Struct::create_copy,
                     nb::rv_policy::copy)
-        .def_static("create_take", &Struct::create_take);
+        .def_static("create_take", &Struct::create_take)
+        .def_prop_rw("none_prop", [](Struct *) {}, [](Struct *, nb::handle) {}, nb::arg().none())
+        .def_prop_rw_static("none_prop_static", []() {}, [](nb::handle) {}, nb::arg().none());
 
     if (!nb::type<Struct>().is(cls))
         nb::detail::raise("type lookup failed!");


### PR DESCRIPTION
I noticed that the RW properties can't accept `nb::arg().none()`, eg:

```c++
    auto cls = nb::class_<Struct>(m, "Struct")
        .def_prop_rw("none_prop", [](Struct *) {}, [](Struct *, nb::handle) {}, nb::arg().none())
        .def_prop_rw_static("none_prop_static", []() {}, [](nb::handle) {}, nb::arg().none());
```

The above code causes that the static assertion fails with `The number of nb::arg annotations must match the argument count!` because the extra arguments is passed to both getter and setter, like:

```
class_ &def_prop_rw(const char *name_, Getter &&getter, Setter &&setter, const Extra &...extra) {
        get_p = cpp_function((detail::forward_t<Getter>) getter, scope(*this), is_method(), rv_policy::reference_internal, extra...);
        set_p = cpp_function((detail::forward_t<Setter>) setter, scope(*this), is_method(), extra...);
```

Is this by design? If not, I would like to ask you about how to fix it. There are several options on how to separate the extra arguments for the setter and the getter.

1. **(Changes in this PR)** Add the overload that the `nb::arg` type can be accepted only at the first extra argument, eg:

```c++
class_ &def_prop_rw(const char *name_, Getter &&getter, Setter &&setter, const arg &arg_, const Extra &...extra) {
        get_p = cpp_function((detail::forward_t<Getter>) getter, scope(*this), is_method(), rv_policy::reference_internal, extra...);
        set_p = cpp_function((detail::forward_t<Setter>) setter, scope(*this), is_method(), arg_, extra...);
```

2. The `nb::arg().none()` is always passed to the setter. This may be preferable to having `nb::arg` specified by users since the name or default value of arg for properties is meaningless.

```c++
class_ &def_prop_rw(const char *name_, Getter &&getter, Setter &&setter, const Extra &...extra) {
        get_p = cpp_function((detail::forward_t<Getter>) getter, scope(*this), is_method(), rv_policy::reference_internal, extra...);
        set_p = cpp_function((detail::forward_t<Setter>) setter, scope(*this), is_method(), nb::arg().none(), extra...);
```

3. Implement compile time removal of `nb::arg` in extra arguments and set them to getters. We need additional meta classes and functions. I can try it but it may seem exaggerated implementation.

@wjakob  Do you have any idea?