### PR TITLE
Add missing cmake parameter

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -247,7 +247,7 @@ function (nanobind_lto name)
     INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON)
 endfunction()
 
-function (nanobind_compile_options)
+function (nanobind_compile_options name)
   if (MSVC)
     target_compile_options(${name} PRIVATE /bigobj /MP)
   endif()

--- a/docs/api_cmake.rst
+++ b/docs/api_cmake.rst
@@ -31,7 +31,7 @@ The high-level interface consists of just one CMake command:
 
    .. code-block:: cmake
 
-      nanobind_build_library(
+      nanobind_add_module(
         my_ext                   # Target name
         NB_STATIC STABLE_ABI LTO # Optional flags (see below)
         my_ext.h                 # Source code files below


### PR DESCRIPTION
This fixes a small bug in the cmake function `nanobind_compile_options`, where the `name` parameter was missing.
I also noticed a small error in the documentation of `nanobind_add_module`, not sure if this should go into a separate pull request.