### PR TITLE
Changes nb::tuple() to construct an empty tuple.

### DIFF
--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -413,7 +413,8 @@ class bytes : public object {
 };
 
 class tuple : public object {
-    NB_OBJECT_DEFAULT(tuple, object, "tuple", PyTuple_Check)
+    NB_OBJECT(tuple, object, "tuple", PyTuple_Check)
+    tuple() : object(PyTuple_New(0), detail::steal_t()) { }
     size_t size() const { return (size_t) NB_TUPLE_GET_SIZE(m_ptr); }
     template <typename T, detail::enable_if_t<std::is_arithmetic_v<T>> = 1>
     detail::accessor<detail::num_item_tuple> operator[](T key) const;


### PR DESCRIPTION
This is consistent with both `list` and `dict`. However, it looks like this might have been done this way for a reason so I'm posting this patch for comment.

Default initializing to nullptr differs from what pybind11 does, and I found this difference due to a segfault while porting some existing code.

Fixes #241