### PR TITLE
Create `CITATION.cff` for GitHub recommended citations

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/citation-file-format/citation-file-format/main/schema.json
+cff-version: 1.2.0
+message: "Please use the following to cite nanobind in scientific discourse:"
+authors:
+  - family-names: "Jakob"
+    given-names: "Wenzel"
+    orcid: "https://orcid.org/0000-0002-6090-1121"
+title: "nanobind: tiny and efficient C++/Python bindings"
+date-released: "2022-10-14" # initial v0.0.1 release
+url: "https://github.com/wjakob/nanobind"
+license: BSD-3-Clause


### PR DESCRIPTION
GitHub adds a UI for citing a repo, if it sees a CITATION.cff file, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files

If you merge this PR, this is what the "Cite this repository" button will look like:

![image](https://github.com/wjakob/nanobind/assets/19716675/8aa0b1a9-5d92-4174-ad32-a46d0e954b8c)

If you click on BibTeX, the output looks like the following (I've added some newline formatting myself to make this PR easier to read):

```bibtex
@software{Jakob_nanobind_tiny_and_2022,
  author = {Jakob, Wenzel},
  license = {BSD-3-Clause},
  month = oct,
  title = {{nanobind: tiny and efficient C++/Python bindings}},
  url = {https://github.com/wjakob/nanobind},
  year = {2022}
}
```

It's not exactly the same as the [attribution section in the README.md](https://github.com/wjakob/nanobind/blame/1b0967fbbc07a17f53c38b67186447bff8f2c7d4/README.md#L47-L54), but it's very similar.