### PR TITLE
fix MSVC compilation error in DEBUG mode due to free macro

### DIFF
--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -108,7 +108,7 @@ enum class func_flags : uint32_t {
     is_implicit = (1 << 12),
     /// Is this function an arithmetic operator?
     is_operator = (1 << 13),
-    /// When the function is GCed, do we need to call func_data_prelim::free?
+    /// When the function is GCed, do we need to call func_data_prelim::free_capture?
     has_free = (1 << 14),
     /// Should the func_new() call return a new reference?
     return_ref = (1 << 15),
@@ -129,7 +129,7 @@ template <size_t Size> struct func_data_prelim {
     void *capture[3];
 
     // Callback to clean up the 'capture' field
-    void (*free)(void *);
+    void (*free_capture)(void *);
 
     /// Implementation of the function call
     PyObject *(*impl)(void *, PyObject **, uint8_t *, rv_policy,

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -88,7 +88,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
 
         if constexpr (!std::is_trivially_destructible_v<capture>) {
             f.flags |= (uint32_t) func_flags::has_free;
-            f.free = [](void *p) {
+            f.free_capture = [](void *p) {
                 ((capture *) p)->~capture();
             };
         }
@@ -97,7 +97,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
         cap[0] = new capture{ (forward_t<Func>) func };
 
         f.flags |= (uint32_t) func_flags::has_free;
-        f.free = [](void *p) {
+        f.free_capture = [](void *p) {
             delete (capture *) ((void **) p)[0];
         };
     }

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -91,7 +91,7 @@ void nb_func_dealloc(PyObject *self) {
 
         for (size_t i = 0; i < size; ++i) {
             if (f->flags & (uint32_t) func_flags::has_free)
-                f->free(f->capture);
+                f->free_capture(f->capture);
 
             if (f->flags & (uint32_t) func_flags::has_args) {
                 for (size_t j = 0; j < f->nargs; ++j) {


### PR DESCRIPTION
Thanks for your library!

Using nanobind release 1.5.0, I faced the following compilation error with MSVC 2022 in DEBUG mode (`_DEBUG` defined) only due to macro `free` being defined as `_free_dbg` by Windows headers:

```
nb_func.cpp(94,20): error C2039: '_free_dbg': is not a member of 'nanobind::detail::func_data'
```

I am aware you wish to keep the project easily maintainable and this is a quick and least intrusive fix, however I am not yet familiar with nanobind so not sure it is the most ideal or correct approach.

Anyway here it is just in case :)