### PR TITLE
clang-tidy fixups

### DIFF
--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -246,7 +246,7 @@ NB_CORE PyObject *capsule_new(const void *ptr, const char *name,
 // ========================================================================
 
 /// Create a Python function object for the given function record
-NB_CORE PyObject *nb_func_new(const void *data) noexcept;
+NB_CORE PyObject *nb_func_new(const void *data);
 
 // ========================================================================
 
@@ -357,11 +357,11 @@ NB_CORE std::pair<bool, bool> nb_inst_state(PyObject *o) noexcept;
 
 // Create and install a Python property object
 NB_CORE void property_install(PyObject *scope, const char *name,
-                              PyObject *getter, PyObject *setter) noexcept;
+                              PyObject *getter, PyObject *setter);
 
 NB_CORE void property_install_static(PyObject *scope, const char *name,
                                      PyObject *getter,
-                                     PyObject *setter) noexcept;
+                                     PyObject *setter);
 
 // ========================================================================
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -275,8 +275,8 @@ PyObject *obj_vectorcall(PyObject *base, PyObject *const *args, size_t nargsf,
     PyObject *res = nullptr;
     bool gil_error = false, cast_error = false;
 
-    size_t nargs_total = (size_t) (NB_VECTORCALL_NARGS(nargsf) +
-                         (kwnames ? NB_TUPLE_GET_SIZE(kwnames) : 0));
+    auto nargs_total = (size_t) (NB_VECTORCALL_NARGS(nargsf) +
+                       (kwnames ? NB_TUPLE_GET_SIZE(kwnames) : 0));
 
 #if !defined(Py_LIMITED_API)
     if (!PyGILState_Check()) {
@@ -775,12 +775,12 @@ static void property_install_impl(PyTypeObject *tp, PyObject *scope,
 }
 
 void property_install(PyObject *scope, const char *name, PyObject *getter,
-                      PyObject *setter) noexcept {
+                      PyObject *setter) {
     property_install_impl(&PyProperty_Type, scope, name, getter, setter);
 }
 
 void property_install_static(PyObject *scope, const char *name,
-                             PyObject *getter, PyObject *setter) noexcept {
+                             PyObject *getter, PyObject *setter) {
     property_install_impl(nb_static_property_tp(), scope, name, getter,
                           setter);
 }
@@ -884,7 +884,7 @@ template <typename T, bool Recurse = true>
 NB_INLINE bool load_int(PyObject *o, uint32_t flags, T *out) noexcept {
     if (NB_LIKELY(PyLong_CheckExact(o))) {
 #if !defined(Py_LIMITED_API) && !defined(PYPY_VERSION)
-        PyLongObject *l = (PyLongObject *) o;
+        auto *l = (PyLongObject *) o;
 
         // Fast path for compact integers
         if (NB_LIKELY(PyUnstable_Long_IsCompact(l))) {

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -151,7 +151,7 @@ const char *python_error::what() const noexcept {
 #else
     buf.clear();
     if (exc_traceback.is_valid()) {
-        PyTracebackObject *to = (PyTracebackObject *) exc_traceback.ptr();
+        auto *to = (PyTracebackObject *) exc_traceback.ptr();
 
         // Get the deepest trace possible
         while (to->tb_next)
@@ -210,7 +210,7 @@ const char *python_error::what() const noexcept {
 
 builtin_exception::builtin_exception(exception_type type, const char *what)
     : std::runtime_error(what ? what : ""), m_type(type) { }
-builtin_exception::~builtin_exception() { }
+builtin_exception::~builtin_exception() = default;
 
 NAMESPACE_BEGIN(detail)
 

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -35,7 +35,7 @@ static PyObject *nb_func_vectorcall_complex(PyObject *, PyObject *const *,
 static void nb_func_render_signature(const func_data *f) noexcept;
 
 int nb_func_traverse(PyObject *self, visitproc visit, void *arg) {
-    size_t size = (size_t) Py_SIZE(self);
+    auto size = (size_t) Py_SIZE(self);
 
     if (size) {
         func_data *f = nb_func_data(self);
@@ -54,7 +54,7 @@ int nb_func_traverse(PyObject *self, visitproc visit, void *arg) {
 }
 
 int nb_func_clear(PyObject *self) {
-    size_t size = (size_t) Py_SIZE(self);
+    auto size = (size_t) Py_SIZE(self);
 
     if (size) {
         func_data *f = nb_func_data(self);
@@ -111,21 +111,21 @@ void nb_func_dealloc(PyObject *self) {
 }
 
 int nb_bound_method_traverse(PyObject *self, visitproc visit, void *arg) {
-    nb_bound_method *mb = (nb_bound_method *) self;
+    auto *mb = (nb_bound_method *) self;
     Py_VISIT((PyObject *) mb->func);
     Py_VISIT(mb->self);
     return 0;
 }
 
 int nb_bound_method_clear(PyObject *self) {
-    nb_bound_method *mb = (nb_bound_method *) self;
+    auto *mb = (nb_bound_method *) self;
     Py_CLEAR(mb->func);
     Py_CLEAR(mb->self);
     return 0;
 }
 
 void nb_bound_method_dealloc(PyObject *self) {
-    nb_bound_method *mb = (nb_bound_method *) self;
+    auto *mb = (nb_bound_method *) self;
     PyObject_GC_UnTrack(self);
     Py_DECREF((PyObject *) mb->func);
     Py_DECREF(mb->self);
@@ -172,7 +172,7 @@ void *malloc_check(size_t size) {
  *
  * This is an implementation detail of nanobind::cpp_function.
  */
-PyObject *nb_func_new(const void *in_) noexcept {
+PyObject *nb_func_new(const void *in_) {
     func_data_prelim<0> *f = (func_data_prelim<0> *) in_;
     arg_data *args_in = std::launder((arg_data *) f->args);
 
@@ -242,7 +242,7 @@ PyObject *nb_func_new(const void *in_) noexcept {
 
     // Create a new function and destroy the old one
     Py_ssize_t to_copy = func_prev ? Py_SIZE(func_prev) : 0;
-    nb_func *func = (nb_func *) PyType_GenericAlloc(
+    auto *func = (nb_func *) PyType_GenericAlloc(
         is_method ? internals->nb_method : internals->nb_func, to_copy + 1);
     check(func, "nb::detail::nb_func_new(\"%s\"): alloc. failed (1).",
           has_name ? f->name : "<anonymous>");
@@ -363,7 +363,7 @@ PyObject *nb_func_new(const void *in_) noexcept {
 static NB_NOINLINE PyObject *
 nb_func_error_overload(PyObject *self, PyObject *const *args_in,
                        size_t nargs_in, PyObject *kwargs_in) noexcept {
-    const uint32_t count = (uint32_t) Py_SIZE(self);
+    const auto count = (uint32_t) Py_SIZE(self);
     func_data *f = nb_func_data(self);
 
     if (f->flags & (uint32_t) func_flags::is_operator)
@@ -659,7 +659,7 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
 
             if (result != NB_NEXT_OVERLOAD) {
                 if (is_constructor) {
-                    nb_inst *self_arg_nb = (nb_inst *) self_arg;
+                    auto *self_arg_nb = (nb_inst *) self_arg;
                     self_arg_nb->destruct = true;
                     self_arg_nb->ready = true;
                     if (NB_UNLIKELY(self_arg_nb->intrusive))
@@ -692,8 +692,8 @@ static PyObject *nb_func_vectorcall_simple(PyObject *self,
     uint8_t args_flags[NB_MAXARGS_SIMPLE];
     func_data *fr = nb_func_data(self);
 
-    const size_t count         = (size_t) Py_SIZE(self),
-                 nargs_in      = (size_t) NB_VECTORCALL_NARGS(nargsf);
+    const auto count         = (size_t) Py_SIZE(self),
+               nargs_in      = (size_t) NB_VECTORCALL_NARGS(nargsf);
 
     const bool is_method      = fr->flags & (uint32_t) func_flags::is_method,
                is_constructor = fr->flags & (uint32_t) func_flags::is_constructor;
@@ -1009,7 +1009,7 @@ static PyObject *nb_func_get_module(PyObject *self) {
 
 PyObject *nb_func_get_doc(PyObject *self, void *) {
     func_data *f = nb_func_data(self);
-    uint32_t count = (uint32_t) Py_SIZE(self);
+    auto count = (uint32_t) Py_SIZE(self);
 
     buf.clear();
 

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -317,7 +317,7 @@ NB_NOINLINE void init(const char *name) {
         return;
     }
 
-    nb_internals *p = new nb_internals();
+    auto *p = new nb_internals();
 
     str nb_name("nanobind");
     p->nb_module = PyModule_NewObject(nb_name.ptr());

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -31,7 +31,7 @@ static void nb_ndarray_dealloc(PyObject *self) {
 }
 
 static int nd_ndarray_tpbuffer(PyObject *exporter, Py_buffer *view, int) {
-    nb_ndarray *self = (nb_ndarray *) exporter;
+    auto *self = (nb_ndarray *) exporter;
 
     dlpack::dltensor &t = self->th->ndarray->dltensor;
 
@@ -221,7 +221,7 @@ static PyObject *dlpack_from_buffer_protocol(PyObject *o, bool ro) {
 
     mt->deleter = [](managed_dltensor *mt2) {
         gil_scoped_acquire guard;
-        Py_buffer *buf = (Py_buffer *) mt2->manager_ctx;
+        auto *buf = (Py_buffer *) mt2->manager_ctx;
         PyBuffer_Release(buf);
         PyMem_Free(mt2->dltensor.shape);
         PyMem_Free(mt2->dltensor.strides);
@@ -376,7 +376,7 @@ ndarray_handle *ndarray_import(PyObject *o, const ndarray_req *req,
         int64_t accum = 1;
 
         if (req->req_order == 'C' || !t.strides) {
-            for (size_t i = (size_t) (t.ndim - 1);;) {
+            for (auto i = (size_t) (t.ndim - 1);;) {
                 strides[i] = accum;
                 accum *= t.shape[i];
                 if (i == 0)
@@ -552,7 +552,7 @@ ndarray_handle *ndarray_create(void *value, size_t ndim, const size_t *shape_in,
 
     auto deleter = [](managed_dltensor *mt) {
         gil_scoped_acquire guard;
-        ndarray_handle *th = (ndarray_handle *) mt->manager_ctx;
+        auto *th = (ndarray_handle *) mt->manager_ctx;
         ndarray_dec_ref(th);
     };
 
@@ -597,7 +597,7 @@ ndarray_handle *ndarray_create(void *value, size_t ndim, const size_t *shape_in,
 
 static void ndarray_capsule_destructor(PyObject *o) {
     error_scope scope; // temporarily save any existing errors
-    managed_dltensor *mt =
+    auto *mt =
         (managed_dltensor *) PyCapsule_GetPointer(o, "dltensor");
 
     if (mt)

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1428,7 +1428,7 @@ static void nb_type_put_unique_finalize(PyObject *o,
           "ownership status has become corrupted.",
           type_name(cpp_type), cpp_delete);
 
-    nb_inst *inst = (nb_inst *) o;
+    auto *inst = (nb_inst *) o;
 
     if (cpp_delete) {
         check((bool) inst->ready == is_new && (bool) inst->destruct == is_new &&
@@ -1479,7 +1479,7 @@ PyObject *nb_type_put_unique_p(const std::type_info *cpp_type,
 }
 
 void nb_type_relinquish_ownership(PyObject *o, bool cpp_delete) {
-    nb_inst *inst = (nb_inst *) o;
+    auto *inst = (nb_inst *) o;
 
     // This function is called to indicate ownership *changes*
     check(inst->ready,
@@ -1561,7 +1561,7 @@ PyObject *nb_inst_reference(PyTypeObject *t, void *ptr, PyObject *parent) {
     PyObject *result = inst_new_ext(t, ptr);
     if (!result)
         raise_python_error();
-    nb_inst *nbi = (nb_inst *) result;
+    auto *nbi = (nb_inst *) result;
     nbi->destruct = nbi->cpp_delete = false;
     nbi->ready = true;
     if (parent)
@@ -1573,7 +1573,7 @@ PyObject *nb_inst_take_ownership(PyTypeObject *t, void *ptr) {
     PyObject *result = inst_new_ext(t, ptr);
     if (!result)
         raise_python_error();
-    nb_inst *nbi = (nb_inst *) result;
+    auto *nbi = (nb_inst *) result;
     nbi->destruct = nbi->cpp_delete = true;
     nbi->ready = true;
     return result;
@@ -1584,7 +1584,7 @@ void *nb_inst_ptr(PyObject *o) noexcept {
 }
 
 void nb_inst_zero(PyObject *o) noexcept {
-    nb_inst *nbi = (nb_inst *) o;
+    auto *nbi = (nb_inst *) o;
     type_data *td = nb_type_data(Py_TYPE(o));
     memset(inst_ptr(nbi), 0, td->size);
     nbi->ready = nbi->destruct = true;
@@ -1594,7 +1594,7 @@ PyObject *nb_inst_alloc_zero(PyTypeObject *t) {
     PyObject *result = inst_new_int(t);
     if (!result)
         raise_python_error();
-    nb_inst *nbi = (nb_inst *) result;
+    auto *nbi = (nb_inst *) result;
     type_data *td = nb_type_data(t);
     memset(inst_ptr(nbi), 0, td->size);
     nbi->ready = nbi->destruct = true;
@@ -1602,19 +1602,19 @@ PyObject *nb_inst_alloc_zero(PyTypeObject *t) {
 }
 
 void nb_inst_set_state(PyObject *o, bool ready, bool destruct) noexcept {
-    nb_inst *nbi = (nb_inst *) o;
+    auto *nbi = (nb_inst *) o;
     nbi->ready = ready;
     nbi->destruct = destruct;
     nbi->cpp_delete = destruct && !nbi->internal;
 }
 
 std::pair<bool, bool> nb_inst_state(PyObject *o) noexcept {
-    nb_inst *nbi = (nb_inst *) o;
+    auto *nbi = (nb_inst *) o;
     return { (bool) nbi->ready, (bool) nbi->destruct };
 }
 
 void nb_inst_destruct(PyObject *o) noexcept {
-    nb_inst *nbi = (nb_inst *) o;
+    auto *nbi = (nb_inst *) o;
     type_data *t = nb_type_data(Py_TYPE(o));
 
     if (nbi->destruct) {
@@ -1638,7 +1638,7 @@ void nb_inst_copy(PyObject *dst, const PyObject *src) noexcept {
               (t->flags & (uint32_t) type_flags::is_copy_constructible),
           "nanobind::detail::nb_inst_copy(): invalid arguments!");
 
-    nb_inst *nbi = (nb_inst *) dst;
+    auto *nbi = (nb_inst *) dst;
     const void *src_data = inst_ptr((nb_inst *) src);
     void *dst_data = inst_ptr(nbi);
 
@@ -1658,7 +1658,7 @@ void nb_inst_move(PyObject *dst, const PyObject *src) noexcept {
               (t->flags & (uint32_t) type_flags::is_move_constructible),
           "nanobind::detail::nb_inst_move(): invalid arguments!");
 
-    nb_inst *nbi = (nb_inst *) dst;
+    auto *nbi = (nb_inst *) dst;
     void *src_data = inst_ptr((nb_inst *) src);
     void *dst_data = inst_ptr(nbi);
 
@@ -1673,7 +1673,7 @@ void nb_inst_move(PyObject *dst, const PyObject *src) noexcept {
 }
 
 void nb_inst_replace_move(PyObject *dst, const PyObject *src) noexcept {
-    nb_inst *nbi = (nb_inst *) dst;
+    auto *nbi = (nb_inst *) dst;
     bool destruct = nbi->destruct;
     nbi->destruct = true;
     nb_inst_destruct(dst);
@@ -1682,7 +1682,7 @@ void nb_inst_replace_move(PyObject *dst, const PyObject *src) noexcept {
 }
 
 void nb_inst_replace_copy(PyObject *dst, const PyObject *src) noexcept {
-    nb_inst *nbi = (nb_inst *) dst;
+    auto *nbi = (nb_inst *) dst;
     bool destruct = nbi->destruct;
     nbi->destruct = true;
     nb_inst_destruct(dst);


### PR DESCRIPTION
nanobind is built in userspace, and userspace warning policies are applied. If `clang-tidy` warnings are enabled, we see messages such as:

```
~venv/lib/python3.9/site-packages/nanobind/src/nb_type.cpp:1587:5: warning: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto]
    nb_inst *nbi = (nb_inst *) o;
    ^~~~~~~
    auto
~venv/lib/python3.9/site-packages/nanobind/src/error.cpp:213:20: warning: use '= default' to define a trivial destructor [modernize-use-equals-default]
builtin_exception::~builtin_exception() { }
                   ^                    ~~~
                                        = default;
~venv/lib/python3.9/site-packages/nanobind/src/nb_type.cpp:1167:18: warning: an exception may be thrown in function 'nb_type_put_common' which should not throw exceptions [bugprone-exception-escape]
static PyObject *nb_type_put_common(void *value, type_data *t, rv_policy rvp,
                 ^
```

The first two messages are nitpicks, but the third seems to be a genuine problem.

Fix these `clang-tidy` warnings.