### PR TITLE
Add type caster for complex numbers

### DIFF
--- a/include/nanobind/stl/complex.h
+++ b/include/nanobind/stl/complex.h
@@ -19,10 +19,7 @@ NAMESPACE_BEGIN(detail)
 
 template <typename T1> struct type_caster<std::complex<T1>> {
 
-    // Sub type caster
-    // TODO This definition seems useless, but I can't find a neat way to replace `Caster::Name` below.
-    using Caster = make_caster<T1>; 
-    NB_TYPE_CASTER(std::complex<T1>, const_name("complex [") + Caster::Name + const_name("]") )
+    NB_TYPE_CASTER(std::complex<T1>, const_name("complex") )
 
     bool from_python(handle src, uint8_t flags,
                      cleanup_list *cleanup) noexcept {

--- a/include/nanobind/stl/complex.h
+++ b/include/nanobind/stl/complex.h
@@ -12,8 +12,6 @@
 #include <nanobind/nanobind.h>
 #include <complex>
 
-#include <iostream>
-
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
@@ -36,6 +34,8 @@ template <typename T1> struct type_caster<std::complex<T1>> {
     template <typename T>
     static handle from_cpp(T &&value, rv_policy policy,
                            cleanup_list *cleanup) noexcept {
+        (void)policy;
+        (void)cleanup;
 
         // Conversion from 2xfloat to 2xdouble if needs be
         return PyComplex_FromDoubles(value.real(), value.imag());

--- a/include/nanobind/stl/complex.h
+++ b/include/nanobind/stl/complex.h
@@ -30,8 +30,6 @@ template <typename T1> struct type_caster<std::complex<T1>> {
         (void)cleanup;
 
         PyObject* obj = src.ptr();
-        // Real and Imaginary parts of a python complex object are always double:
-        //   https://docs.python.org/3/c-api/complex.html#c.Py_complex
         value.real(PyComplex_RealAsDouble(obj));
         value.imag(PyComplex_ImagAsDouble(obj));
 
@@ -43,9 +41,7 @@ template <typename T1> struct type_caster<std::complex<T1>> {
                            cleanup_list *cleanup) noexcept {
 
         // Conversion from 2xfloat to 2xdouble if needs be
-        PyObject* r = PyComplex_FromDoubles(value.real(), value.imag());
-
-        return r;
+        return PyComplex_FromDoubles(value.real(), value.imag());
     }
 };
 

--- a/include/nanobind/stl/complex.h
+++ b/include/nanobind/stl/complex.h
@@ -1,0 +1,53 @@
+/*
+    nanobind/stl/complex.h: type caster for std::complex<...>
+
+    Copyright (c) 2023 Degottex Gilles
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+#include <complex>
+
+#include <iostream>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename T1> struct type_caster<std::complex<T1>> {
+
+    // Sub type caster
+    // TODO This definition seems useless, but I can't find a neat way to replace `Caster::Name` below.
+    using Caster = make_caster<T1>; 
+    NB_TYPE_CASTER(std::complex<T1>, const_name("complex [") + Caster::Name + const_name("]") )
+
+    bool from_python(handle src, uint8_t flags,
+                     cleanup_list *cleanup) noexcept {
+        (void)flags;
+        (void)cleanup;
+
+        PyObject* obj = src.ptr();
+        // Real and Imaginary parts of a python complex object are always double:
+        //   https://docs.python.org/3/c-api/complex.html#c.Py_complex
+        value.real(PyComplex_RealAsDouble(obj));
+        value.imag(PyComplex_ImagAsDouble(obj));
+
+        return true;
+    }
+
+    template <typename T>
+    static handle from_cpp(T &&value, rv_policy policy,
+                           cleanup_list *cleanup) noexcept {
+
+        // Conversion from 2xfloat to 2xdouble if needs be
+        PyObject* r = PyComplex_FromDoubles(value.real(), value.imag());
+
+        return r;
+    }
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/complex.h
+++ b/include/nanobind/stl/complex.h
@@ -25,8 +25,13 @@ template <typename T1> struct type_caster<std::complex<T1>> {
         (void)cleanup;
 
         PyObject* obj = src.ptr();
-        value.real(PyComplex_RealAsDouble(obj));
-        value.imag(PyComplex_ImagAsDouble(obj));
+
+        // TODO Faster way to get real part without string mapping? (and imag part below)
+        PyObject* obj_real = PyObject_GetAttrString(obj, "real");
+        // TODO If T1==float32 and obj==numpy.float32, PyFloat_AsDouble implies 2 useless conversions
+        value.real(PyFloat_AsDouble(obj_real));
+        PyObject* obj_imag = PyObject_GetAttrString(obj, "imag");
+        value.imag(PyFloat_AsDouble(obj_imag));
 
         return true;
     }

--- a/include/nanobind/stl/complex.h
+++ b/include/nanobind/stl/complex.h
@@ -37,7 +37,8 @@ template <typename T1> struct type_caster<std::complex<T1>> {
         (void)policy;
         (void)cleanup;
 
-        // Conversion from 2xfloat to 2xdouble if needs be
+        // There is no such float32 in Python, so always build as double.
+        // We could build a numpy.float32, though it would force dependency to numpy.
         return PyComplex_FromDoubles(value.real(), value.imag());
     }
 };

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -12,6 +12,7 @@
 #include <nanobind/stl/unordered_set.h>
 #include <nanobind/stl/set.h>
 #include <nanobind/stl/filesystem.h>
+#include <nanobind/stl/complex.h>
 
 NB_MAKE_OPAQUE(std::vector<float, std::allocator<float>>)
 
@@ -422,4 +423,20 @@ NB_MODULE(test_stl_ext, m) {
         vec.flip();
         return vec;
     });
+
+
+    m.def("complex_value_float", [](const std::complex<float>& x){
+        return x;
+    });
+    m.def("complex_value_double", [](const std::complex<double>& x){
+        return x;
+    });
+
+    m.def("complex_array_float", [](const std::vector<std::complex<float>>& x){
+        return x;
+    });
+    m.def("complex_array_double", [](const std::vector<std::complex<double>>& x){
+        return x;
+    });
+
 }

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -3,6 +3,7 @@ import pytest
 import sys
 from common import collect, skip_on_pypy
 
+import numpy as np
 
 @pytest.fixture
 def clean():
@@ -759,3 +760,47 @@ def test67_vector_bool():
     bool_vector = [True, False, True, False]
     result = t.flip_vector_bool(bool_vector)
     assert result == [not x for x in bool_vector]
+
+
+def test68_complex_value():
+
+    # double: 64bits
+    assert t.complex_value_double(1.0) == 1.0
+    assert t.complex_value_double(1.0j) == 1.0j
+    assert t.complex_value_double(0.0) == 0.0
+    assert t.complex_value_double(0.0j) == 0.0j
+    assert t.complex_value_double(2.7+3.2j) == (2.7+3.2j)
+    assert t.complex_value_double(2.7-3.2j) == (2.7-3.2j)
+    assert t.complex_value_double(np.complex128(2.7-3.2j)) == (2.7-3.2j)
+    assert t.complex_value_double(np.complex64(2.7-3.2j)) == (2.700000047683716-3.200000047683716j) # written as double, converted to complex of float32 (difference introduced), converted to complex of float64 (no difference introduced) -> difference introduced
+
+    # float: 32bits
+    assert t.complex_value_float(1.0) == 1.0
+    assert t.complex_value_float(1.0j) == 1.0j
+    assert t.complex_value_float(0.0) == 0.0
+    assert t.complex_value_float(0.0j) == 0.0j
+    # written as double, converted to complex of float32 (difference introduced) -> difference introduced
+    assert t.complex_value_float(2.7+3.2j) == (2.700000047683716+3.200000047683716j)
+    # same as above
+    assert t.complex_value_float(2.7-3.2j) == (2.700000047683716-3.200000047683716j)
+    
+    # written as double, converted to complex of float64 (no difference introduced), converted to complex of float32 (difference introduced) -> difference introduced
+    assert t.complex_value_float(np.complex128(2.7-3.2j)) == (2.700000047683716-3.200000047683716j)
+
+    # written as double, converted to complex of float32 (difference introduced), converted to complex of float32 (no difference introduced) -> difference introduced
+    assert t.complex_value_float(np.complex64(2.7-3.2j)) == (2.700000047683716-3.200000047683716j)
+
+def test69_complex_array():
+
+    # double: 64bits
+    assert t.complex_array_double([2.7-3.2j, -1j, +3.1415]) == [(2.7-3.2j), (-0-1j), (+3.1415)]
+    assert t.complex_array_double(np.array([2.7-3.2j, -1j, +3.1415])) == [(2.7-3.2j), (-0-1j), (+3.1415)]
+    assert t.complex_array_double(np.array([2.7-3.2j, -1j, +3.1415],dtype=np.complex128)) == [(2.7-3.2j), (-0-1j), (+3.1415)]
+    assert t.complex_array_double(np.array([2.7-3.2j, -1j, +3.1415],dtype=np.complex64)) == [(2.700000047683716-3.200000047683716j), (-0-1j), (3.1414999961853027+0j)]
+
+    # float: 32bits
+    # Always go through double to float conversion bcs python's complex numbers are always written as double (there is no such thing as 1.0f notation)
+    assert t.complex_array_float([2.7-3.2j, -1j, +3.1415]) == [(2.700000047683716-3.200000047683716j), (-0-1j), (3.1414999961853027+0j)]
+    assert t.complex_array_float(np.array([2.7-3.2j, -1j, +3.1415])) == [(2.700000047683716-3.200000047683716j), (-0-1j), (3.1414999961853027+0j)]
+    assert t.complex_array_float(np.array([2.7-3.2j, -1j, +3.1415],dtype=np.complex128)) == [(2.700000047683716-3.200000047683716j), (-0-1j), (3.1414999961853027+0j)]
+    assert t.complex_array_float(np.array([2.7-3.2j, -1j, +3.1415],dtype=np.complex64)) == [(2.700000047683716-3.200000047683716j), (-0-1j), (3.1414999961853027+0j)]


### PR DESCRIPTION
This is an attempt to add support for complex numbers using a `type_caster` (previously discussed as #286 ).

With test code:
```
#include <nanobind/nanobind.h>
#include <nanobind/stl/vector.h>
#include <nanobind/stl/complex.h>

namespace nb = nanobind;

#include <iostream>

typedef double value_t;
// typedef float value_t;

std::complex<value_t> foo(const std::complex<value_t>& x){
    std::cout << "x=" << x << " sizeof(complex value)=" << 8*sizeof(x) << "b" << std::endl;
    return x;
}

std::vector<std::complex<value_t>> foo_array(const std::vector<std::complex<value_t>>& x){
    std::cout << "x[0]=" << x[0] << " sizeof(complex element)=" << 8*sizeof(x[0]) << "b" << std::endl;
    std::cout << "x[1]=" << x[1] << " sizeof(complex element)=" << 8*sizeof(x[1]) << "b" << std::endl;
    return x;
}

NB_MODULE(pybar, m) {
    m.def("foo", &foo);
    m.def("foo_array", &foo_array);
}
```

This works with test commands:
```
>> python3 -c 'import pybar; import numpy as np; x = 2.7-3.2j; print(pybar.foo(x))'
>> python3 -c 'import pybar; x = [2.7-3.2j, -1j]; print(pybar.foo_array(x))'
>> python3 -c 'import pybar; import numpy as np; x = np.array([2.7-3.2j, -1j]); print(pybar.foo_array(x))'
>> python3 -c 'import pybar; import numpy as np; x = np.array([2.7-3.2j, -1j],dtype=np.complex128); print(pybar.foo_array(x))'
```

However, it fails when numpy input is 32b float (i.e. np.complex64), ex:
```
>> python3 -c 'import pybar; import numpy as np; x = np.array([2.7-3.2j, -1j],dtype=np.complex64); print(pybar.foo_array(x))'
<string>:1: ComplexWarning: Casting complex values to real discards the imaginary part
[...]
```
This happens, no matter if I'm using `std::complex<float>` or `std::complex<double>` in test code.
My understanding is that a `PyComplex` seems to be built at some point assuming double size (because base python (not numpy) complex type is always double) and I can't find where this is built (I guess before call to `type_caster<std::complex<T1>>::from_python(.)` ).
If anybody has an idea about this issue, it is very much welcome!

Even though forcing to 64b float could be enough, this is clearly not optimal both in terms of efficiency and memory.


Elements to review:
- [ ] See copyright notice. I don't know how you handle this in nanobind.
- [x] Tests: Done.
- [x] `np.complex64` inputs, as mentioned above: Now supported.
- [x] Unnecessary use of `make_caster<T1>` I think. See TODO tag in file `stl/complex.h`: Cleaned.
