### PR TITLE
Fix None check in variant caster

### DIFF
--- a/include/nanobind/stl/variant.h
+++ b/include/nanobind/stl/variant.h
@@ -28,9 +28,7 @@ template <> struct type_caster<std::monostate> {
     NB_TYPE_CASTER(std::monostate, const_name("None"));
 
     bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
-        if (src.is_none())
-            return true;
-        return false;
+        return src.is_none();
     }
 
     static handle from_cpp(const std::monostate &, rv_policy,
@@ -53,6 +51,11 @@ template <typename... Ts> struct type_caster<std::variant<Ts...>> {
             "by nanobind's regular class binding mechanism. However, a "
             "type caster was registered to intercept this particular "
             "type, which is not allowed.");
+
+        if constexpr (!std::is_pointer_v<T> && is_base_caster_v<CasterT>) {
+            if (src.is_none())
+                return false;
+        }
 
         CasterT caster;
 

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -256,7 +256,7 @@ NB_MODULE(test_stl_ext, m) {
 
     // ----- test43-test50 ------
     m.def("variant_copyable", [](std::variant<Copyable, int> &) {});
-    m.def("variant_copyable_none", [](std::variant<std::monostate, Copyable, int> &) {}, nb::arg("x").none());
+    m.def("variant_copyable_none", [](std::variant<int, Copyable, std::monostate> &) {}, nb::arg("x").none());
     m.def("variant_copyable_ptr", [](std::variant<Copyable *, int> &) {});
     m.def("variant_copyable_ptr_none", [](std::variant<Copyable *, int> &) {}, nb::arg("x").none());
     m.def("variant_ret_var_copyable", []() { return std::variant<Copyable, int>(); });

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -464,7 +464,7 @@ def test44_std_variant_copyable_none(clean):
     t.variant_copyable_none(5)
     t.variant_copyable_none(None)
     assert t.variant_copyable_none.__doc__ == (
-        "variant_copyable_none(x: Optional[Union[test_stl_ext.Copyable, int]]) -> None"
+        "variant_copyable_none(x: Optional[Union[int, test_stl_ext.Copyable]]) -> None"
     )
     assert_stats(
         default_constructed=1,


### PR DESCRIPTION
This PR fixes the missing `None` check in the `std::variant` caster. 

The following code produces SIGABRT at runtime since the change in 1220156961ce2d0c96a525f3c27b88e824b997ce;

```c++
m.def("variant_copyable_none", [](std::variant<int, Copyable, std::monostate> &) {}, nb::arg("x").none());
```

```python
t.variant_copyable_none(None)
```

This PR include

* Improve test coverage
* Revert the `None` check
* Refactoring of redundant code