### PR TITLE
Made type_caster<Eigen::Map<T>> correctly consider T's constness

### DIFF
--- a/include/nanobind/eigen/dense.h
+++ b/include/nanobind/eigen/dense.h
@@ -244,7 +244,7 @@ struct type_caster<Eigen::Map<T, Options, StrideType>,
                                is_ndarray_scalar_v<typename T::Scalar>>> {
     using Map = Eigen::Map<T, Options, StrideType>;
     using NDArray =
-        array_for_eigen_t<Map, std::conditional_t<std::is_const_v<Map>,
+        array_for_eigen_t<Map, std::conditional_t<std::is_const_v<T>,
                                                   const typename Map::Scalar,
                                                   typename Map::Scalar>>;
     using NDArrayCaster = type_caster<NDArray>;

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -199,9 +199,12 @@ NB_MODULE(test_eigen_ext, m) {
         .def(nb::init<>())
         .def_rw("member", &ClassWithEigenMember::member);
 
-    m.def("castToMapVXi", [](nb::object obj) -> Eigen::Map<Eigen::VectorXi> {
+    m.def("castToMapVXi", [](nb::object obj) {
         return nb::cast<Eigen::Map<Eigen::VectorXi>>(obj);
     });
+    m.def("castToMapCnstVXi", [](nb::object obj) {
+      return nb::cast<Eigen::Map<const Eigen::VectorXi>>(obj);
+      });
     m.def("castToRefVXi", [](nb::object obj) -> Eigen::VectorXi {
         return nb::cast<Eigen::Ref<Eigen::VectorXi>>(obj);
     });

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -334,8 +334,11 @@ def test12_cast():
     vec2 = vec[::2]
     vecf = np.float32(vec)
     assert_array_equal(t.castToMapVXi(vec), vec)
+    assert_array_equal(t.castToMapCnstVXi(vec), vec)
     assert_array_equal(t.castToRefVXi(vec), vec)
     assert_array_equal(t.castToRefCnstVXi(vec), vec)
+    assert t.castToMapVXi(vec).flags.writeable
+    assert not t.castToMapCnstVXi(vec).flags.writeable
     assert_array_equal(t.castToDRefCnstVXi(vec), vec)
     for v in vec2, vecf:
         with pytest.raises(RuntimeError, match="bad[_ ]cast"):


### PR DESCRIPTION
There is a flaw in type_caster<Eigen::Map<T>>: instead of testing T's constness, it tests the constness of Map itself, which can never be const. 
The writability of numpy.ndarray's returned for Eigen::Map is not tested yet, and so I have added respective tests.