### PR TITLE
added from_cpp() method for the Eigen::Ref type_caster

### DIFF
--- a/include/nanobind/eigen/dense.h
+++ b/include/nanobind/eigen/dense.h
@@ -435,6 +435,7 @@ struct type_caster<Eigen::Ref<T, Options, StrideType>,
         return false;
     }
 
+    /*Duplicate of Eigen::Map caster*/
     static handle from_cpp(const Ref &v, rv_policy, cleanup_list *cleanup) noexcept {
         size_t shape[ndim_v<T>];
         int64_t strides[ndim_v<T>];

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -206,16 +206,16 @@ NB_MODULE(test_eigen_ext, m) {
     m.def("castToMapCnstVXi", [](nb::object obj) {
       return nb::cast<Eigen::Map<const Eigen::VectorXi>>(obj);
       });
-    m.def("castToRefVXi", [](nb::object obj) {
+    m.def("castToRefVXi", [](nb::object obj) -> Eigen::VectorXi {
         return nb::cast<Eigen::Ref<Eigen::VectorXi>>(obj);
     });
-    m.def("castToRefCnstVXi", [](nb::object obj) {
+    m.def("castToRefCnstVXi", [](nb::object obj) -> Eigen::VectorXi {
         return nb::cast<Eigen::Ref<const Eigen::VectorXi>>(obj);
     });
-    m.def("castToDRefCnstVXi", [](nb::object obj) {
+    m.def("castToDRefCnstVXi", [](nb::object obj) -> Eigen::VectorXi {
         return nb::cast<nb::DRef<const Eigen::VectorXi>>(obj);
     });
-    m.def("castToRef03CnstVXi", [](nb::object obj) {
+    m.def("castToRef03CnstVXi", [](nb::object obj) -> Eigen::VectorXi {
         return nb::cast<Eigen::Ref<const Eigen::VectorXi, Eigen::Unaligned, Eigen::InnerStride<3>>>(obj);
     });
 

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -352,3 +352,18 @@ def test12_cast():
     for v in vec, vec2, vecf:
         with pytest.raises(RuntimeError, match='bad[_ ]cast'):
             t.castToRef03CnstVXi(v)
+
+@needs_numpy_and_eigen
+def test13_mutate_python():
+    class Derived(t.Base):
+        def modRefData(self, input):
+            input[0] = 3.0
+
+        def modRefDataConst(self, input):
+            input[0] = 3.0
+
+    vecRef = np.array([3.0, 2.0])
+    der = Derived()
+    assert_array_equal(t.modifyRef(der), vecRef)
+    with pytest.raises(ValueError):
+        t.modifyRefConst(der)


### PR DESCRIPTION
As discussed in issue https://github.com/wjakob/nanobind/issues/330, Eigen::Ref was missing the `from_cpp()` method in it's type caster. I essentially copied the from_cpp() method from the Eigen::Map type caster.