### PR TITLE
Minor fixes and additions for complex `ndarray`

### DIFF
--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/complex.h>
 #include <initializer_list>
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
@@ -65,13 +66,6 @@ struct dltensor {
 
 NAMESPACE_END(dlpack)
 
-NAMESPACE_BEGIN(detail)
-
-template <typename T>
-struct is_complex : public std::false_type { };
-
-NAMESPACE_END(detail)
-
 constexpr size_t any = (size_t) -1;
 
 template <size_t... Is> struct shape {
@@ -121,10 +115,10 @@ template <typename T> constexpr dlpack::dtype dtype() {
 
     if constexpr (ndarray_traits<T>::is_float)
         result.code = (uint8_t) dlpack::dtype_code::Float;
-    else if constexpr (ndarray_traits<T>::is_signed)
-        result.code = (uint8_t) dlpack::dtype_code::Int;
     else if constexpr (ndarray_traits<T>::is_complex)
         result.code = (uint8_t) dlpack::dtype_code::Complex;
+    else if constexpr (ndarray_traits<T>::is_signed)
+        result.code = (uint8_t) dlpack::dtype_code::Int;
     else if constexpr (std::is_same_v<std::remove_cv_t<T>, bool>)
         result.code = (uint8_t) dlpack::dtype_code::Bool;
     else

--- a/include/nanobind/stl/complex.h
+++ b/include/nanobind/stl/complex.h
@@ -15,14 +15,9 @@
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
-template <typename T>
-struct is_complex  : std::false_type {};
-
-template <typename T>
-struct is_complex<std::complex<T>> : public std::true_type { };
-
-template <typename T>
-struct is_complex<const std::complex<T>> : public std::true_type { };
+template <typename T> struct is_complex  : std::false_type {};
+template <class T> struct is_complex<const T > : is_complex<T>{};
+template <typename T> struct is_complex<std::complex<T>> : public std::true_type {};
 
 template <typename T> struct type_caster<std::complex<T>> {
     NB_TYPE_CASTER(std::complex<T>, const_name("complex") )

--- a/include/nanobind/stl/complex.h
+++ b/include/nanobind/stl/complex.h
@@ -16,7 +16,7 @@ NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
 template <typename T>
-struct is_complex;
+struct is_complex  : std::false_type {};
 
 template <typename T>
 struct is_complex<std::complex<T>> : public std::true_type { };

--- a/include/nanobind/stl/complex.h
+++ b/include/nanobind/stl/complex.h
@@ -15,9 +15,9 @@
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
-template <typename T> struct is_complex  : std::false_type {};
-template <class T> struct is_complex<const T > : is_complex<T>{};
-template <typename T> struct is_complex<std::complex<T>> : public std::true_type {};
+template <typename T> struct is_complex : std::false_type {};
+template <typename T> struct is_complex<const T> : is_complex<T>{};
+template <typename T> struct is_complex<std::complex<T>> : std::true_type {};
 
 template <typename T> struct type_caster<std::complex<T>> {
     NB_TYPE_CASTER(std::complex<T>, const_name("complex") )

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -442,6 +442,7 @@ ndarray_handle *ndarray_import(PyObject *o, const ndarray_req *req,
                 case (uint8_t) dlpack::dtype_code::Int: prefix = "int"; break;
                 case (uint8_t) dlpack::dtype_code::UInt: prefix = "uint"; break;
                 case (uint8_t) dlpack::dtype_code::Float: prefix = "float"; break;
+                case (uint8_t) dlpack::dtype_code::Complex: prefix = "complex"; break;
                 default:
                     return nullptr;
             }

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -211,6 +211,9 @@ static PyObject *dlpack_from_buffer_protocol(PyObject *o, bool ro) {
             case 'f':
             case 'd': dt.code = (uint8_t) dlpack::dtype_code::Float; break;
 
+            case 'Zf':
+            case 'Zd': dt.code = (uint8_t) dlpack::dtype_code::Complex; break;
+
             case '?': dt.code = (uint8_t) dlpack::dtype_code::Bool; break;
 
             default:


### PR DESCRIPTION
Consistency fixes for complex ndarray and remove duplicated trait code.

Came across these issues when hunting down a problem passing read-only complex Numpy arrays to C++ (real-valued, read-only arrays work fine), which appears to be an issue with the Numpy  `__dlpack__` function, which fails for read-only complex.