### PR TITLE
Add failing Numpy read-only test to test suite

### DIFF
--- a/tests/test_ndarray.cpp
+++ b/tests/test_ndarray.cpp
@@ -70,7 +70,9 @@ NB_MODULE(test_ndarray_ext, m) {
     });
 
     m.def("pass_float32", [](const nb::ndarray<float> &) { }, "array"_a.noconvert());
+    m.def("pass_float32_const", [](const nb::ndarray<const float> &) { }, "array"_a.noconvert());
     m.def("pass_complex64", [](const nb::ndarray<std::complex<float>> &) { }, "array"_a.noconvert());
+    m.def("pass_complex64_const", [](nb::ndarray<const std::complex<float>>) { }, "array"_a.noconvert());
     m.def("pass_uint32", [](const nb::ndarray<uint32_t> &) { }, "array"_a.noconvert());
     m.def("pass_bool", [](const nb::ndarray<bool> &) { }, "array"_a.noconvert());
     m.def("pass_float32_shaped",

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -91,6 +91,14 @@ def test03_constrain_dtype():
     t.pass_complex64(a_cf64)
     t.pass_bool(a_bool)
 
+    a_f32_const = a_f32.copy()
+    a_f32_const.flags.writeable = False
+    t.pass_float32_const(a_f32_const)
+
+    a_cf64_const = a_cf64.copy()
+    a_cf64_const.flags.writeable = False
+    t.pass_complex64_const(a_cf64_const)
+
     with pytest.raises(TypeError) as excinfo:
         t.pass_uint32(a_f32)
     assert 'incompatible function arguments' in str(excinfo.value)


### PR DESCRIPTION
Following #https://github.com/wjakob/nanobind/pull/338#issuecomment-1779217448, tests added that fail with read-only complex Numpy array.

See #342.