### PR TITLE
Fix for zero length array warning and gcc

### DIFF
--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -164,11 +164,11 @@ template <size_t Size> struct func_data_prelim {
     #pragma clang diagnostic ignored "-Wzero-length-array"
     arg_data args[Size];
     #pragma clang diagnostic pop
-#elif defined(__GNUC__) && !defined(__clang__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wpedantic"
-    arg_data args[Size];
-    #pragma GCC diagnostic pop
+// #elif defined(__GNUC__) && !defined(__clang__)
+//     #pragma GCC diagnostic push
+//     #pragma GCC diagnostic ignored "-Wpedantic"
+//     arg_data args[Size];
+//     #pragma GCC diagnostic pop
 #else
     arg_data args[Size];
 #endif

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -166,7 +166,7 @@ template <size_t Size> struct func_data_prelim {
     #pragma clang diagnostic pop
 #elif defined(__GNUC__) && !defined(__clang__)
     #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wpedantic"
+    #pragma GCC diagnostic ignored "-Werror=pedantic"
     arg_data args[Size];
     #pragma GCC diagnostic pop
 #else

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -164,6 +164,11 @@ template <size_t Size> struct func_data_prelim {
     #pragma clang diagnostic ignored "-Wzero-length-array"
     arg_data args[Size];
     #pragma clang diagnostic pop
+#elif defined(__GNUC__) && !defined(__clang__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wpedantic"
+    arg_data args[Size];
+    #pragma GCC diagnostic pop
 #else
     arg_data args[Size];
 #endif

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -164,11 +164,11 @@ template <size_t Size> struct func_data_prelim {
     #pragma clang diagnostic ignored "-Wzero-length-array"
     arg_data args[Size];
     #pragma clang diagnostic pop
-// #elif defined(__GNUC__) && !defined(__clang__)
-//     #pragma GCC diagnostic push
-//     #pragma GCC diagnostic ignored "-Wpedantic"
-//     arg_data args[Size];
-//     #pragma GCC diagnostic pop
+#elif defined(__GNUC__) && !defined(__clang__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wpedantic"
+    arg_data args[Size];
+    #pragma GCC diagnostic pop
 #else
     arg_data args[Size];
 #endif

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -166,7 +166,7 @@ template <size_t Size> struct func_data_prelim {
     #pragma clang diagnostic pop
 #elif defined(__GNUC__) && !defined(__clang__)
     #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Werror=pedantic"
+    #pragma GCC diagnostic ignored "-Wpedantic"
     arg_data args[Size];
     #pragma GCC diagnostic pop
 #else

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -159,11 +159,11 @@ template <size_t Size> struct func_data_prelim {
 
 #if defined(_MSC_VER)
     arg_data args[Size == 0 ? 1 : Size];
-#elif defined(__GNUC__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wzero-length-array"
+#elif defined(__clang__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wzero-length-array"
     arg_data args[Size];
-    #pragma GCC diagnostic pop
+    #pragma clang diagnostic pop
 #else
     arg_data args[Size];
 #endif


### PR DESCRIPTION
GCC doesn't have `"-Wzero-length-array"` (unlike clang) [1], which caused #345. This change allows `-Werror -pedantic` builds with GCC and clang.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94428