### PR TITLE
Add type_caster for `std::nullopt`

### DIFF
--- a/include/nanobind/stl/optional.h
+++ b/include/nanobind/stl/optional.h
@@ -59,5 +59,20 @@ struct type_caster<std::optional<T>> {
     }
 };
 
+
+template <> struct type_caster<std::nullopt_t> {
+  bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
+    if (src.is_none())
+      return true;
+    return false;
+  }
+
+  static handle from_cpp(std::nullopt_t, rv_policy, cleanup_list *) noexcept {
+    return none().release();
+  }
+
+  NB_TYPE_CASTER(std::nullopt_t, const_name("None"));
+};
+
 NAMESPACE_END(detail)
 NAMESPACE_END(NB_NAMESPACE)

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -253,6 +253,7 @@ NB_MODULE(test_stl_ext, m) {
     m.def("optional_ret_opt_movable_ptr", []() { return new std::optional<Movable *>(new Movable()); });
     m.def("optional_ret_opt_none", []() { return std::optional<Movable>(); });
     m.def("optional_unbound_type", [](std::optional<int> &x) { return x; }, nb::arg("x") = nb::none());
+    m.def("optional_unbound_type_with_nullopt_as_default", [](std::optional<int> &x) { return x; }, nb::arg("x") = std::nullopt);
 
     // ----- test43-test50 ------
     m.def("variant_copyable", [](std::variant<Copyable, int> &) {});

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -438,12 +438,14 @@ def test41_std_optional_ret_opt_none():
 
 
 def test42_std_optional_unbound_type():
-    assert t.optional_unbound_type(3) == 3
-    assert t.optional_unbound_type(None) is None
-    assert t.optional_unbound_type() is None
-    assert t.optional_unbound_type.__doc__ == (
-        "optional_unbound_type(x: Optional[int] = None) -> Optional[int]"
-    )
+    for method_name in ("optional_unbound_type", "optional_unbound_type_with_nullopt_as_default"):
+        method = getattr(t, method_name)
+        assert method(3) == 3
+        assert method(None) is None
+        assert method() is None
+        assert method.__doc__ == (
+            f"{method_name}(x: Optional[int] = None) -> Optional[int]"
+        )
 
 
 def test43_std_variant_copyable(clean):


### PR DESCRIPTION
Currently if any code uses `std::nullopt`, it will throw a `bast_cast` exception as no type_caster has been defined for it: https://github.com/wjakob/nanobind/discussions/274. 
As `std::nullopt` is a standard way to assign empty value to `std::optional`, so I think it is better to add the type_caster for it in `stl/optional.h`