### PR TITLE
type_caster<std::optional>: support non-assignable types

### DIFF
--- a/include/nanobind/stl/optional.h
+++ b/include/nanobind/stl/optional.h
@@ -45,7 +45,7 @@ struct type_caster<std::optional<T>> {
             "type caster was registered to intercept this particular "
             "type, which is not allowed.");
 
-        value = caster.operator cast_t<T>();
+        value.emplace(caster.operator cast_t<T>());
 
         return true;
     }

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -44,6 +44,12 @@ struct Copyable {
     ~Copyable() { destructed++; }
 };
 
+struct NonAssignable {
+  int value = 5;
+
+  NonAssignable &operator=(const NonAssignable &) = delete;
+};
+
 struct StructWithReadonlyMap {
     std::map<std::string, uint64_t> map;
 };
@@ -101,6 +107,10 @@ NB_MODULE(test_stl_ext, m) {
         .def(nb::init<>())
         .def(nb::init<int>())
         .def_rw("value", &Copyable::value);
+
+    nb::class_<NonAssignable>(m, "NonAssignable")
+        .def(nb::init<>())
+        .def_rw("value", &NonAssignable::value);
 
     nb::class_<StructWithReadonlyMap>(m, "StructWithReadonlyMap")
         .def(nb::init<>())
@@ -254,6 +264,7 @@ NB_MODULE(test_stl_ext, m) {
     m.def("optional_ret_opt_none", []() { return std::optional<Movable>(); });
     m.def("optional_unbound_type", [](std::optional<int> &x) { return x; }, nb::arg("x") = nb::none());
     m.def("optional_unbound_type_with_nullopt_as_default", [](std::optional<int> &x) { return x; }, nb::arg("x") = std::nullopt);
+    m.def("optional_non_assignable", [](std::optional<NonAssignable> &x) { return x; });
 
     // ----- test43-test50 ------
     m.def("variant_copyable", [](std::variant<Copyable, int> &) {});

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -448,6 +448,10 @@ def test42_std_optional_unbound_type():
         )
 
 
+def test42a_std_optional_non_assignable():
+    assert t.optional_non_assignable(t.NonAssignable()).value == 5
+
+
 def test43_std_variant_copyable(clean):
     t.variant_copyable(t.Copyable())
     t.variant_copyable(5)


### PR DESCRIPTION
So far, type_caster<std::optional<T>>::from_python requires T to support copy-assignment. Removed this requirement by replacing std::optional<T>::operator= with std::optional<T>::emplace, which always uses in-place construction.

There should be no other change in behaviour, because std::optional<T>::operator= uses
- in-place construction if empty, or
- copy-assignment if non-empty,
and since type_caster<std::optional<T>>::from_python is called only once on each instance, its member `value` is always empty, anyway.