### PR TITLE
type_caster<ref>::from_cpp: use ref->self_py

### DIFF
--- a/include/nanobind/intrusive/ref.h
+++ b/include/nanobind/intrusive/ref.h
@@ -136,6 +136,11 @@ template <typename T> struct type_caster<nanobind::ref<T>> {
 
     static handle from_cpp(const ref<T> &value, rv_policy policy,
                            cleanup_list *cleanup) noexcept {
+        if constexpr (std::is_base_of_v<intrusive_base, T>)
+            if (policy != rv_policy::copy && value.get())
+                if (PyObject* obj = value->self_py())
+                    return handle(obj).inc_ref();
+
         return Caster::from_cpp(value.get(), policy, cleanup);
     }
 };

--- a/include/nanobind/intrusive/ref.h
+++ b/include/nanobind/intrusive/ref.h
@@ -137,7 +137,7 @@ template <typename T> struct type_caster<nanobind::ref<T>> {
     static handle from_cpp(const ref<T> &value, rv_policy policy,
                            cleanup_list *cleanup) noexcept {
         if constexpr (std::is_base_of_v<intrusive_base, T>)
-            if (policy != rv_policy::copy && value.get())
+            if (policy != rv_policy::copy && policy != rv_policy::move && value.get())
                 if (PyObject* obj = value->self_py())
                     return handle(obj).inc_ref();
 


### PR DESCRIPTION
`type_caster<ref>::from_cpp` missed an optimization so far: if no copy shall be made and `intrusive_base::self_py` returns a valid pointer, then return it directly and spare the time to lookup the instance map.