### PR TITLE
Fix incompatible MSVC options being passed through to nvcc

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -231,9 +231,9 @@ endfunction()
 
 function(nanobind_opt_size name)
   if (MSVC)
-    target_compile_options(${name} PRIVATE $<${NB_OPT_SIZE}:/Os>)
+    target_compile_options(${name} PRIVATE $<${NB_OPT_SIZE}:$<$<COMPILE_LANGUAGE:CXX>:/Os>>)
   else()
-    target_compile_options(${name} PRIVATE $<${NB_OPT_SIZE}:-Os>)
+    target_compile_options(${name} PRIVATE $<${NB_OPT_SIZE}:$<$<COMPILE_LANGUAGE:CXX>:-Os>>)
   endif()
 endfunction()
 

--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -262,7 +262,7 @@ endfunction()
 
 function (nanobind_compile_options name)
   if (MSVC)
-    target_compile_options(${name} PRIVATE /bigobj /MP)
+    target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/bigobj /MP>)
   endif()
 endfunction()
 


### PR DESCRIPTION
nanobind adds `/bigobj and /MP` as compiler options for MSVC which results in this issue previously seen in pybind11.

https://github.com/pybind/pybind11/issues/3883

The same fix has been ported over in this PR.