### PR TITLE
Add built-in constant types

### DIFF
--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -593,7 +593,6 @@ inline void print(const char *str, handle end = handle(), handle file = handle()
     print(nanobind::str(str), end, file);
 }
 
-inline object none() { return borrow(Py_None); }
 inline dict builtins() { return borrow<dict>(PyEval_GetBuiltins()); }
 
 inline iterator iter(handle h) {
@@ -648,12 +647,12 @@ public:
     false_() : object(Py_False, detail::borrow_t()) {}
 };
 
-class none_ : public object {
+class none : public object {
     static bool is_none(PyObject *obj) { return obj == Py_None; }
 
 public:
-    NB_OBJECT(none_, object, "Literal[None]", is_none)
-    none_() : object(Py_None, detail::borrow_t()) {}
+    NB_OBJECT(none, object, "Literal[None]", is_none)
+    none() : object(Py_None, detail::borrow_t()) {}
 };
 
 class not_implemented : public object {

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -632,6 +632,30 @@ public:
     ellipsis() : object(Py_Ellipsis, detail::borrow_t()) {}
 };
 
+class true_ : public object {
+    static bool is_true(PyObject *obj) { return obj == Py_True; }
+
+public:
+    NB_OBJECT(true_, object, "Literal[True]", is_true)
+    true_() : object(Py_True, detail::borrow_t()) {}
+};
+
+class false_ : public object {
+    static bool is_false(PyObject *obj) { return obj == Py_False; }
+
+public:
+    NB_OBJECT(false_, object, "Literal[False]", is_false)
+    false_() : object(Py_False, detail::borrow_t()) {}
+};
+
+class none_ : public object {
+    static bool is_none(PyObject *obj) { return obj == Py_None; }
+
+public:
+    NB_OBJECT(none_, object, "Literal[None]", is_none)
+    none_() : object(Py_None, detail::borrow_t()) {}
+};
+
 class not_implemented : public object {
     static bool is_not_implemented(PyObject *obj) { return obj == Py_NotImplemented; }
 

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -239,4 +239,9 @@ NB_MODULE(test_functions_ext, m) {
 
     m.def("test_del_list", [](nb::list l) { nb::del(l[2]); });
     m.def("test_del_dict", [](nb::dict l) { nb::del(l["a"]); });
+
+    // Test built-in constant
+    m.def("test_40", [](nb::true_) { return nb::true_(); });
+    m.def("test_40", [](nb::false_) { return nb::false_(); });
+    m.def("test_40", [](nb::none_) { return nb::none_(); }, "arg"_a = nb::none_());
 }

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -243,5 +243,5 @@ NB_MODULE(test_functions_ext, m) {
     // Test built-in constant
     m.def("test_40", [](nb::true_) { return nb::true_(); });
     m.def("test_40", [](nb::false_) { return nb::false_(); });
-    m.def("test_40", [](nb::none_) { return nb::none_(); }, "arg"_a = nb::none_());
+    m.def("test_40", [](nb::none) { return nb::none(); }, "arg"_a = nb::none());
 }

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -348,3 +348,14 @@ def test39_del():
 
     with pytest.raises(KeyError):
         t.test_del_dict({})
+
+def test40_constant_values():
+    assert t.test_40(True) is True
+    assert t.test_40(False) is False
+    assert t.test_40(None) is None
+    assert t.test_40() is None
+    assert (
+        t.test_40.__doc__ == "test_40(arg: Literal[True], /) -> Literal[True]\n"
+        "test_40(arg: Literal[False], /) -> Literal[False]\n"
+        "test_40(arg: Optional[Literal[None]] = None) -> Literal[None]"
+    )


### PR DESCRIPTION
I would like to propose adding [built-in constant](https://docs.python.org/3/library/constants.html) types in this PR.

This enables to write literal-based overloads like:

```python
@overload
func(arg: Literal[True], /) -> Literal[True]: ...
@overload
func(arg: Literal[False], /) -> Literal[False]: ...
@overload
func(arg: Literal[None] = None) -> Literal[None]: ...
```

From:

```c++
m.def("func", [](nb::true_) { return nb::true_(); });
m.def("func", [](nb::false_) { return nb::false_(); });
m.def("func", [](nb::none_) { return nb::none_(); }, "arg"_a = nb::none_());
```

This is very convenient for me. It makes binding and typing simpler in some cases.

If it is OK, I found that the `nb::none()` function can be replaced with the constant `none` class without major changes for users (54d87f357bb539760dd0aaed08c43aab7cc15193).

