### PR TITLE
Fix pedantic warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ if (MSVC)
     add_compile_options(/W4)
   endif()
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-  add_compile_options(-Wall -Wextra -Wno-unused-local-typedefs)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-local-typedefs)
 endif()
 
 # ---------------------------------------------------------------------------

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -157,11 +157,7 @@ template <size_t Size> struct func_data_prelim {
     const char *doc;
     PyObject *scope;
 
-#if defined(_MSC_VER)
     arg_data args[Size == 0 ? 1 : Size];
-#else
-    arg_data args[Size];
-#endif
 };
 
 template <typename F>

--- a/include/nanobind/stl/optional.h
+++ b/include/nanobind/stl/optional.h
@@ -70,7 +70,7 @@ template <> struct type_caster<std::nullopt_t> {
         return none().release();
     }
 
-    NB_TYPE_CASTER(std::nullopt_t, const_name("None"));
+    NB_TYPE_CASTER(std::nullopt_t, const_name("None"))
 };
 
 NAMESPACE_END(detail)


### PR DESCRIPTION
Previously these yielded:

```sh
/home/willayd/clones/nanobind/tests/test_inter_module_2.cpp:8:10:   required from here
/home/willayd/clones/nanobind/include/nanobind/nb_attr.h:163:14: warning: ISO C++ forbids zero-size array [-Wpedantic]
  163 |     arg_data args[Size];
```

and 

```sh
In file included from /home/willayd/clones/nanobind/tests/test_stl.cpp:8:
/home/willayd/clones/nanobind/include/nanobind/stl/optional.h:73:55: warning: extra ‘;’ [-Wpedantic]
   73 |     NB_TYPE_CASTER(std::nullopt_t, const_name("None"));
```