### PR TITLE
Fix `intrusive_base` documentation

### DIFF
--- a/include/nanobind/intrusive/counter.h
+++ b/include/nanobind/intrusive/counter.h
@@ -212,10 +212,10 @@ public:
     /// Decrease the object's reference count, return ``true`` if it should be deallocated
     bool dec_ref() noexcept { return m_ref_count.dec_ref(); }
 
-    /// Return the Python object associated with this instance (or NULL)
+    /// Set the Python object associated with this instance
     void set_self_py(PyObject *self) noexcept { m_ref_count.set_self_py(self); }
 
-    /// Set the Python object associated with this instance
+    /// Return the Python object associated with this instance (or NULL)
     PyObject *self_py() const noexcept { return m_ref_count.self_py(); }
 
     /// Virtual destructor


### PR DESCRIPTION
Source documentation for `instrusive_base::set_self_py()` and `intrusive_base::self_py()` were swapped.

The `api_extra.rst` documentation does not need to be changed - it is already correct.