### PR TITLE
Eigen: fix overloaded call to make_tuple is ambiguous

### DIFF
--- a/include/nanobind/eigen/sparse.h
+++ b/include/nanobind/eigen/sparse.h
@@ -131,9 +131,9 @@ template <typename T> struct type_caster<T, enable_if_t<is_eigen_sparse_matrix_v
         StorageIndexNDArray inner_indices(src->innerIndexPtr(), 1, data_shape, owner);
 
         try {
-            return matrix_type(make_tuple(
+            return matrix_type(nanobind::make_tuple(
                                    std::move(data), std::move(inner_indices), std::move(outer_indices)),
-                               make_tuple(rows, cols))
+                               nanobind::make_tuple(rows, cols))
                 .release();
         } catch (python_error &e) {
             e.restore();

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -1,3 +1,4 @@
+#include <nanobind/stl/complex.h>
 #include <nanobind/eigen/dense.h>
 #include <nanobind/eigen/sparse.h>
 #include <nanobind/trampoline.h>
@@ -165,6 +166,7 @@ NB_MODULE(test_eigen_ext, m) {
         assert(!m.isCompressed());
         return m.markAsRValue();
     });
+    m.def("sparse_complex", []() -> Eigen::SparseMatrix<std::complex<double>> { return {}; });
 
     /// issue #166
     using Matrix1d = Eigen::Matrix<double,1,1>;


### PR DESCRIPTION
Without fully qualifying `nanobind::make_tuple` the new test raises the following compiler error.

```c++
In file included from /home/henri/Code/nanobind/tests/test_eigen.cpp:3:
/home/henri/Code/nanobind/include/nanobind/eigen/sparse.h: In instantiation of ‘static nanobind::handle nanobind::detail::type_caster<T, typename std::enable_if<is_eigen_sparse_matrix_v<T>, int>::type>::from_cpp(const T&, nanobind::rv_policy, nanobind::detail::cleanup_list*) [with T = Eigen::SparseMatrix<std::complex<double> >]’:
/home/henri/Code/nanobind/include/nanobind/eigen/sparse.h:99:24:   required from ‘static nanobind::handle nanobind::detail::type_caster<T, typename std::enable_if<is_eigen_sparse_matrix_v<T>, int>::type>::from_cpp(T&&, nanobind::rv_policy, nanobind::detail::cleanup_list*) [with T = Eigen::SparseMatrix<std::complex<double> >]’
/home/henri/Code/nanobind/include/nanobind/nb_func.h:153:40:   required from ‘PyObject* nanobind::detail::func_create(Func&&, Return (*)(Args ...), std::index_sequence<Is2 ...>, const Extra& ...) [with bool ReturnRef = false; bool CheckGuard = true; Func = nanobind_init_test_eigen_ext(nanobind::module_&)::<lambda()>; Return = Eigen::SparseMatrix<std::complex<double> >; Args = {}; long unsigned int ...Is = {}; Extra = {nanobind::scope, nanobind::name}; PyObject = _object; std::index_sequence<Is2 ...> = std::integer_sequence<long unsigned int>]’
/home/henri/Code/nanobind/include/nanobind/nb_func.h:207:37:   required from ‘void nanobind::cpp_function_def(Func&&, const Extra& ...) [with Func = nanobind_init_test_eigen_ext(nanobind::module_&)::<lambda()>; Extra = {scope, name}; typename std::enable_if<is_lambda_v<typename std::remove_reference<_Tp>::type>, int>::type <anonymous> = 0]’
/home/henri/Code/nanobind/include/nanobind/nb_func.h:256:21:   required from ‘nanobind::module_& nanobind::module_::def(const char*, Func&&, const Extra& ...) [with Func = nanobind_init_test_eigen_ext(nanobind::module_&)::<lambda()>; Extra = {}]’
/home/henri/Code/nanobind/tests/test_eigen.cpp:169:10:   required from here
/home/henri/Code/nanobind/include/nanobind/eigen/sparse.h:134:42: error: call of overloaded ‘make_tuple(std::remove_reference<nanobind::ndarray<nanobind::numpy, std::complex<double>, nanobind::shape<18446744073709551615> >&>::type, std::remove_reference<nanobind::ndarray<nanobind::numpy, int, nanobind::shape<18446744073709551615> >&>::type, std::remove_reference<nanobind::ndarray<nanobind::numpy, int, nanobind::shape<18446744073709551615> >&>::type)’ is ambiguous
  134 |             return matrix_type(make_tuple(
      |                                ~~~~~~~~~~^
  135 |                                    std::move(data), std::move(inner_indices), std::move(outer_indices)),
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/henri/Code/nanobind/include/nanobind/nanobind.h:49,
                 from /home/henri/Code/nanobind/include/nanobind/stl/complex.h:12,
                 from /home/henri/Code/nanobind/tests/test_eigen.cpp:1:
/home/henri/Code/nanobind/include/nanobind/nb_cast.h:455:7: note: candidate: ‘nanobind::tuple nanobind::make_tuple(Args&& ...) [with rv_policy policy = nanobind::rv_policy::automatic; Args = {ndarray<numpy, std::complex<double>, shape<18446744073709551615> >, ndarray<numpy, int, shape<18446744073709551615> >, ndarray<numpy, int, shape<18446744073709551615> >}]’
  455 | tuple make_tuple(Args &&...args) {
      |       ^~~~~~~~~~
In file included from /nix/store/f94yr35af3xdiscbj6cp6kafvmn55gv9-gcc-12.3.0/include/c++/12.3.0/functional:54,
                 from /nix/store/wfcm6p8wh1lnk2iwcvyx0fkg9sjqrq72-eigen-3.4.0/include/eigen3/Eigen/Core:85,
                 from /home/henri/Code/nanobind/include/nanobind/eigen/dense.h:14,
                 from /home/henri/Code/nanobind/tests/test_eigen.cpp:2:
/nix/store/f94yr35af3xdiscbj6cp6kafvmn55gv9-gcc-12.3.0/include/c++/12.3.0/tuple:1577:5: note: candidate: ‘constexpr std::tuple<typename std::__strip_reference_wrapper<typename std::decay<Ts>::type>::__type ...> std::make_tuple(_Elements&& ...) [with _Elements = {nanobind::ndarray<nanobind::numpy, complex<double>, nanobind::shape<18446744073709551615> >, nanobind::ndarray<nanobind::numpy, int, nanobind::shape<18446744073709551615> >, nanobind::ndarray<nanobind::numpy, int, nanobind::shape<18446744073709551615> >}]’
 1577 |     make_tuple(_Elements&&... __args)
      |     ^~~~~~~~~~
```