### PR TITLE
Changes to the `intrusive_base` and `ref<T>` interfaces

### DIFF
--- a/include/nanobind/intrusive/counter.h
+++ b/include/nanobind/intrusive/counter.h
@@ -207,10 +207,10 @@ static_assert(
 class NB_INTRUSIVE_EXPORT intrusive_base {
 public:
     /// Increase the object's reference count
-    void inc_ref() noexcept { m_ref_count.inc_ref(); }
+    void inc_ref() const noexcept { m_ref_count.inc_ref(); }
 
     /// Decrease the object's reference count, return ``true`` if it should be deallocated
-    bool dec_ref() noexcept { return m_ref_count.dec_ref(); }
+    bool dec_ref() const noexcept { return m_ref_count.dec_ref(); }
 
     /// Set the Python object associated with this instance
     void set_self_py(PyObject *self) noexcept { m_ref_count.set_self_py(self); }
@@ -222,14 +222,14 @@ public:
     virtual ~intrusive_base() = default;
 
 private:
-    intrusive_counter m_ref_count;
+    mutable intrusive_counter m_ref_count;
 };
 
 /**
  * \brief Increase the reference count of an intrusively reference-counted
  * object ``o`` if ``o`` is non-NULL.
  */
-inline void inc_ref(intrusive_base *o) noexcept {
+inline void inc_ref(const intrusive_base *o) noexcept {
     if (o)
         o->inc_ref();
 }
@@ -238,7 +238,7 @@ inline void inc_ref(intrusive_base *o) noexcept {
  * \brief Decrease the reference count and potentially delete an intrusively
  * reference-counted object ``o`` if ``o`` is non-NULL.
  */
-inline void dec_ref(intrusive_base *o) noexcept {
+inline void dec_ref(const intrusive_base *o) noexcept {
     if (o && o->dec_ref())
         delete o;
 }

--- a/include/nanobind/intrusive/ref.h
+++ b/include/nanobind/intrusive/ref.h
@@ -38,20 +38,20 @@ public:
     ref() = default;
 
     /// Construct a reference from a pointer
-    ref(T *ptr) : m_ptr(ptr) { inc_ref(m_ptr); }
+    ref(T *ptr) : m_ptr(ptr) { inc_ref((intrusive_base *) m_ptr); }
 
     /// Copy a reference, increases the reference count
-    ref(const ref &r) : m_ptr(r.m_ptr) { inc_ref(m_ptr); }
+    ref(const ref &r) : m_ptr(r.m_ptr) { inc_ref((intrusive_base *) m_ptr); }
 
     /// Move a reference witout changing the reference count
     ref(ref &&r) noexcept : m_ptr(r.m_ptr) { r.m_ptr = nullptr; }
 
     /// Destroy this reference
-    ~ref() { dec_ref(m_ptr); }
+    ~ref() { dec_ref((intrusive_base *) m_ptr); }
 
     /// Move-assign another reference into this one
     ref &operator=(ref &&r) noexcept {
-        dec_ref(m_ptr);
+        dec_ref((intrusive_base *) m_ptr);
         m_ptr = r.m_ptr;
         r.m_ptr = nullptr;
         return *this;
@@ -59,23 +59,23 @@ public:
 
     /// Copy-assign another reference into this one
     ref &operator=(const ref &r) {
-        inc_ref(r.m_ptr);
-        dec_ref(m_ptr);
+        inc_ref((intrusive_base *) r.m_ptr);
+        dec_ref((intrusive_base *) m_ptr);
         m_ptr = r.m_ptr;
         return *this;
     }
 
     /// Overwrite this reference with a pointer to another object
     ref &operator=(T *ptr) {
-        inc_ref(ptr);
-        dec_ref(m_ptr);
+        inc_ref((intrusive_base *) ptr);
+        dec_ref((intrusive_base *) m_ptr);
         m_ptr = ptr;
         return *this;
     }
 
     /// Clear the currently stored reference
     void reset() {
-        dec_ref(m_ptr);
+        dec_ref((intrusive_base *) m_ptr);
         m_ptr = nullptr;
     }
 
@@ -104,12 +104,15 @@ public:
     const T &operator*() const { return *m_ptr; }
 
     /// Return a pointer to the referenced object
-    explicit operator T *() { return m_ptr; }
+    operator T *() { return m_ptr; }
 
     /// Return a const pointer to the referenced object
-    T *get() { return m_ptr; }
+    operator const T *() const { return m_ptr; }
 
     /// Return a pointer to the referenced object
+    T *get() { return m_ptr; }
+
+    /// Return a const pointer to the referenced object
     const T *get() const { return m_ptr; }
 
 private:


### PR DESCRIPTION
This PR introduces the following changes:
* Reference count changes on `intrusive_base` should be considered `const` operations
* Allow implicit casts from `ref<T>` to `T*` and `const T*`
* C-style casts on any use of `inc_ref` and `dec_ref`  to avoid type-checking.