### PR TITLE
Fix leak of `nb_translator_seq` objects.

### DIFF
--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -301,6 +301,12 @@ static void internals_cleanup() {
     }
 
     if (!leak) {
+        nb_translator_seq* t = internals->translators.next;
+        while (t) {
+          nb_translator_seq* next = t->next;
+          delete t;
+          t = next;
+        }
         delete internals;
         internals = nullptr;
         nb_meta_cache = nullptr;


### PR DESCRIPTION
Exception handlers are kept in a linked list, but that list is never freed. Free exception translators immediately before deleting `nb_internals`.