### PR TITLE
Fix incorrect visibility when compiling on MinGW64 with gcc

### DIFF
--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -22,22 +22,29 @@
 #  define NAMESPACE_END(name) }
 #endif
 
-#if defined(_WIN32)
-#  define NB_EXPORT        __declspec(dllexport)
-#  define NB_IMPORT        __declspec(dllimport)
-#  define NB_INLINE        __forceinline
+#if defined _WIN32 || defined __CYGWIN__
+#  ifdef __GNUC__
+#    define NB_EXPORT        __attribute__ ((visibility("default")))
+#    define NB_IMPORT        NB_EXPORT
+#    define NB_INLINE        inline __attribute__((always_inline))
+#    define NB_NOINLINE      __attribute__((noinline))
+#  else
+#    define NB_EXPORT        __declspec(dllexport)
+#    define NB_IMPORT        __declspec(dllimport)
+#    define NB_INLINE        __forceinline
+#    define NB_NOINLINE      __declspec(noinline)
+#  endif
 #  define NB_INLINE_LAMBDA
-#  define NB_NOINLINE      __declspec(noinline)
 #else
-#  define NB_EXPORT        __attribute__ ((visibility("default")))
-#  define NB_IMPORT        NB_EXPORT
-#  define NB_INLINE        inline __attribute__((always_inline))
-#  define NB_NOINLINE      __attribute__((noinline))
-#if defined(__clang__)
+#  define NB_EXPORT          __attribute__ ((visibility("default")))
+#  define NB_IMPORT          NB_EXPORT
+#  define NB_INLINE          inline __attribute__((always_inline))
+#  define NB_NOINLINE        __attribute__((noinline))
+#  if defined(__clang__)
 #    define NB_INLINE_LAMBDA __attribute__((always_inline))
-#else
+#  else
 #    define NB_INLINE_LAMBDA
-#endif
+#  endif
 #endif
 
 #if defined(__GNUC__)

--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -22,18 +22,11 @@
 #  define NAMESPACE_END(name) }
 #endif
 
-#if defined(_WIN32)
-#  ifdef __GNUC__
-#    define NB_EXPORT        __attribute__ ((visibility("default")))
-#    define NB_IMPORT        NB_EXPORT
-#    define NB_INLINE        inline __attribute__((always_inline))
-#    define NB_NOINLINE      __attribute__((noinline))
-#  else
-#    define NB_EXPORT        __declspec(dllexport)
-#    define NB_IMPORT        __declspec(dllimport)
-#    define NB_INLINE        __forceinline
-#    define NB_NOINLINE      __declspec(noinline)
-#  endif
+#if defined(_WIN32) && !defined(__GNUC__)
+#  define NB_EXPORT        __declspec(dllexport)
+#  define NB_IMPORT        __declspec(dllimport)
+#  define NB_INLINE        __forceinline
+#  define NB_NOINLINE      __declspec(noinline)
 #  define NB_INLINE_LAMBDA
 #else
 #  define NB_EXPORT          __attribute__ ((visibility("default")))

--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -22,7 +22,7 @@
 #  define NAMESPACE_END(name) }
 #endif
 
-#if defined _WIN32 || defined __CYGWIN__
+#if defined(_WIN32)
 #  ifdef __GNUC__
 #    define NB_EXPORT        __attribute__ ((visibility("default")))
 #    define NB_IMPORT        NB_EXPORT


### PR DESCRIPTION
Whe compiling on ~~cygwin~~ mingw64 using gcc, errors like this occur:
```
nb_error.h:30:17: error: 'dllexport' implies default visibility, but 'class nanobind::python_error' has already been declared with a different visibility
     30 | class NB_EXPORT python_error : public std::exception {
        |                 ^~~~~~~~~~~~
```

This PR should fix this, with formatting changes in nearby code.

I made reference with https://gcc.gnu.org/wiki/Visibility