### PR TITLE
make_key/value_iterator: support iterators that return a non-reference from operator*

### DIFF
--- a/tests/test_make_iterator.cpp
+++ b/tests/test_make_iterator.cpp
@@ -40,8 +40,47 @@ NB_MODULE(test_make_iterator_ext, m) {
         return nb::make_iterator(mod, "pt_iterator", std::begin(s), std::end(s));
     });
 
+    // test of map where dereferencing the iterator returns a value,
+    // not a reference
+    struct IdentityMap {
+        struct iterator {
+            int val;
+            std::pair<int, int> operator*() const { return {val, val}; }
+            iterator& operator++() { ++val; return *this; }
+            bool operator==(const iterator& other) const {
+                return val == other.val;
+            }
+        };
+
+        iterator begin() const { return iterator{0}; }
+        iterator end() const { return iterator{10}; }
+    };
+    nb::class_<IdentityMap>(m, "IdentityMap")
+        .def(nb::init<>())
+        .def("__iter__",
+             [](const IdentityMap &map) {
+                 return nb::make_key_iterator(nb::type<IdentityMap>(),
+                                              "key_iterator",
+                                              map.begin(),
+                                              map.end());
+             }, nb::keep_alive<0, 1>())
+        .def("items",
+             [](const IdentityMap &map) {
+                 return nb::make_iterator(nb::type<IdentityMap>(),
+                                          "item_iterator",
+                                          map.begin(),
+                                          map.end());
+             }, nb::keep_alive<0, 1>())
+        .def("values", [](const IdentityMap &map) {
+            return nb::make_value_iterator(nb::type<IdentityMap>(),
+                                           "value_iterator",
+                                           map.begin(),
+                                           map.end());
+        }, nb::keep_alive<0, 1>());
+
     nb::list all;
     all.append("iterator_passthrough");
     all.append("StringMap");
+    all.append("IdentityMap");
     m.attr("__all__") = all;
 }

--- a/tests/test_make_iterator.py
+++ b/tests/test_make_iterator.py
@@ -33,3 +33,10 @@ def test04_passthrough_iterator():
     for d in data:
         m = t.StringMap(d)
         assert list(t.iterator_passthrough(m.values())) == list(m.values())
+
+
+def test05_iterator_returning_temporary():
+    im = t.IdentityMap()
+    assert list(im) == list(range(10))
+    assert list(im.values()) == list(range(10))
+    assert list(im.items()) == list(zip(range(10), range(10)))

--- a/tests/test_make_iterator_ext.pyi.ref
+++ b/tests/test_make_iterator_ext.pyi.ref
@@ -1,5 +1,14 @@
-from collections.abc import Mapping, Iterator
+from collections.abc import Iterator, Mapping
 from typing import overload
+
+class IdentityMap:
+    def __init__(self) -> None: ...
+
+    def __iter__(self) -> Iterator[int]: ...
+
+    def items(self) -> Iterator[tuple[int, int]]: ...
+
+    def values(self) -> Iterator[int]: ...
 
 class StringMap:
     @overload
@@ -14,6 +23,6 @@ class StringMap:
 
     def values(self) -> Iterator[str]: ...
 
-__all__: list = ['iterator_passthrough', 'StringMap']
+__all__: list = ['iterator_passthrough', 'StringMap', 'IdentityMap']
 
 def iterator_passthrough(arg: Iterator, /) -> Iterator: ...


### PR DESCRIPTION
These can show up in certain map-like containers where the keys are stored implicitly. For example, you can imagine a map where the keys are relatively dense iterators, which chooses to store the values in a contiguous array/vector and have the key for each value be implied by its index in that vector. Dereferencing an iterator for such a map returns `pair<Key, Value&>` rather than `pair<const Key, Value>&`. Previously, nanobind's `make_key_iterator` and `make_value_iterator` functions would try to form a reference to a temporary (complete with compiler warning) if you passed them an iterator like that; after this change, they work correctly.

I verified that the unit test added here fails if I run it without the change to make_iterator.h that's being made here.