### PR TITLE
Support binding unions

### DIFF
--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -573,7 +573,8 @@ public:
     template <typename C, typename D, typename... Extra>
     NB_INLINE class_ &def_rw(const char *name, D C::*p,
                              const Extra &...extra) {
-        static_assert(std::is_base_of_v<C, T>,
+        // Unions never satisfy is_base_of, thus the is_same alternative
+        static_assert(std::is_base_of_v<C, T> || std::is_same_v<C, T>,
                       "def_rw() requires a (base) class member!");
 
         using Q =
@@ -605,7 +606,8 @@ public:
     template <typename C, typename D, typename... Extra>
     NB_INLINE class_ &def_ro(const char *name, D C::*p,
                              const Extra &...extra) {
-        static_assert(std::is_base_of_v<C, T>,
+        // Unions never satisfy is_base_of, thus the is_same alternative
+        static_assert(std::is_base_of_v<C, T> || std::is_same_v<C, T>,
                       "def_ro() requires a (base) class member!");
 
         def_prop_ro(name,

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -566,4 +566,13 @@ NB_MODULE(test_classes_ext, m) {
     nb::class_<StructWithWeakrefsAndDynamicAttrs, Struct>(m, "StructWithWeakrefsAndDynamicAttrs",
                nb::is_weak_referenceable(), nb::dynamic_attr())
         .def(nb::init<int>());
+
+    union Union {
+        int i;
+        float f;
+    };
+    nb::class_<Union>(m, "Union")
+        .def(nb::init<>())
+        .def_rw("i", &Union::i)
+        .def_rw("f", &Union::f);
 }

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -798,3 +798,14 @@ def test42_weak_references():
     gc.collect()
     gc.collect()
     assert w() is None
+
+
+def test43_union():
+    import struct
+
+    u = t.Union()
+    u.i = 42
+    assert u.i == 42
+
+    u.f = 2.125
+    assert u.f == 2.125

--- a/tests/test_classes_ext.pyi.ref
+++ b/tests/test_classes_ext.pyi.ref
@@ -186,6 +186,21 @@ class StructWithWeakrefsAndDynamicAttrs(Struct):
 class Subclass:
     pass
 
+class Union:
+    def __init__(self) -> None: ...
+
+    @property
+    def i(self) -> int: ...
+
+    @i.setter
+    def i(self, arg: int, /) -> None: ...
+
+    @property
+    def f(self) -> float: ...
+
+    @f.setter
+    def f(self, arg: float, /) -> None: ...
+
 class Wrapper:
     def __init__(self) -> None: ...
 


### PR DESCRIPTION
This almost works already, except that `is_base_of` never returns true for unions, even when testing whether something is a base of itself. Add an `is_same` alternative, and a test to make sure this doesn't regress.