### PR TITLE
Add a `__dict__` attribute to nanobind::dynamic_attr() classes.

### DIFF
--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -809,3 +809,9 @@ def test43_union():
 
     u.f = 2.125
     assert u.f == 2.125
+
+def test44_dynamic_attr_has_dict():
+    s = t.StructWithAttr(5)
+    assert s.__dict__ == {}
+    s.a_dynamic_attr = 101
+    assert s.__dict__ == {"a_dynamic_attr": 101}


### PR DESCRIPTION
I found it surprising that class with dynamic attributes (i.e., it must have a `__dict__` internally) didn't have a `o.__dict__` visible to Python users. It seems that simply setting `tp_dictoffset` isn't enough for `o.__dict__` to be present.

If the user didn't provide a `tp_getset`, populate it with `__dict__` for classes with dynamic attributes.