### PR TITLE
Allow `ndarray_check` on objects of arbitrary modules

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -541,8 +541,11 @@ section <ndarrays>`.
 
 .. cpp:function:: bool ndarray_check(handle h) noexcept
 
-   Test whether the Python object represents an ndarray. Currently, the
-   function considers NumPy, PyTorch, TensorFlow, and XLA arrays.
+   Test whether the Python object represents an ndarray.
+
+   Objects with a ``__dlpack__`` attribute or objects that implement the buffer
+   protocol are considered as ndarray objects. In addition, arrays from NumPy,
+   PyTorch, TensorFlow and XLA are also regarded as ndarrays.
 
 .. cpp:class:: template <typename... Args> ndarray
 

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -455,7 +455,7 @@ NB_CORE void ndarray_dec_ref(ndarray_handle *) noexcept;
 NB_CORE PyObject *ndarray_wrap(ndarray_handle *, int framework,
                                rv_policy policy, cleanup_list *cleanup) noexcept;
 
-/// Check if an object is a known ndarray type (NumPy, PyTorch, Tensorflow, JAX)
+/// Check if an object represents an ndarray
 NB_CORE bool ndarray_check(PyObject *o) noexcept;
 
 // ========================================================================

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -285,6 +285,9 @@ static PyObject *dlpack_from_buffer_protocol(PyObject *o, bool ro) {
 }
 
 bool ndarray_check(PyObject *o) noexcept {
+    if (PyObject_HasAttrString(o, "__dlpack__") || PyObject_CheckBuffer(o))
+        return true;
+
     PyTypeObject *tp = Py_TYPE(o);
 
     PyObject *name = nb_type_name((PyObject *) tp);
@@ -294,8 +297,6 @@ bool ndarray_check(PyObject *o) noexcept {
     check(tp_name, "Could not obtain type name! (2)");
 
     bool result =
-        // NumPy
-        strcmp(tp_name, "ndarray") == 0 ||
         // PyTorch
         strcmp(tp_name, "torch.Tensor") == 0 ||
         // XLA

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -644,3 +644,14 @@ def test_uint32_complex_do_not_convert(variant):
     t.set_item(data, arg)
     data2 = np.array([123, 3.0 + 4.0j])
     assert np.all(data == data2)
+
+@needs_numpy
+def test26_check_generic():
+    class DLPackWrapper:
+        def __init__(self, o):
+            self.o = o
+        def __dlpack__(self):
+            return self.o.__dlpack__()
+
+    arr = DLPackWrapper(np.zeros((1)))
+    assert t.check(arr)


### PR DESCRIPTION
This PR changes `ndarray_check` such that it returns `True` if one of the following conditions is met:

* The given object has a `__dlpack__` attribute
* The given object supports the CPython buffer interface
* The given object is an object from NumPy (implicit through buffer protocol), PyTorch, XLA, TensorFlow

With this change, `ndarray_check` more closely matches the logic of supported imports through `ndarray_import`.

I've added a straightforward test which checks this new behavior on an object with a `__dlpack__` attribute.