### PR TITLE
Fix reference leak when adding a new function overload

### DIFF
--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -295,6 +295,8 @@ PyObject *nb_func_new(const void *in_) noexcept {
         check(it != internals->funcs.end(),
               "nanobind::detail::nb_func_new(): internal update failed (1)!");
         internals->funcs.erase(it);
+
+        Py_CLEAR(func_prev);
     }
 
     func->complex_call |= func->max_nargs >= NB_MAXARGS_SIMPLE;


### PR DESCRIPTION
Noticed this while reading through nb_func.cpp. I verified that the new test fails if run without the new `Py_CLEAR`.