### PR TITLE
RFC: low-level API for changing the C++ object managed by a Python object

### DIFF
--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -284,6 +284,9 @@ inline object inst_alloc(handle h) {
 inline object inst_alloc_zero(handle h) {
     return steal(detail::nb_inst_alloc_zero((PyTypeObject *) h.ptr()));
 }
+inline object inst_alloc_indirect(handle h) {
+    return steal(detail::nb_inst_alloc_indirect((PyTypeObject *) h.ptr()));
+}
 inline object inst_take_ownership(handle h, void *p) {
     return steal(detail::nb_inst_take_ownership((PyTypeObject *) h.ptr(), p));
 }
@@ -304,6 +307,9 @@ inline void inst_copy(handle dst, handle src) { detail::nb_inst_copy(dst.ptr(), 
 inline void inst_move(handle dst, handle src) { detail::nb_inst_move(dst.ptr(), src.ptr()); }
 inline void inst_replace_copy(handle dst, handle src) { detail::nb_inst_replace_copy(dst.ptr(), src.ptr()); }
 inline void inst_replace_move(handle dst, handle src) { detail::nb_inst_replace_move(dst.ptr(), src.ptr()); }
+inline void inst_reset(handle h, void *p, bool cpp_delete) {
+    detail::nb_inst_reset(h.ptr(), p, cpp_delete);
+}
 template <typename T> T *inst_ptr(handle h) { return (T *) detail::nb_inst_ptr(h.ptr()); }
 inline void *type_get_slot(handle h, int slot_id) {
 #if NB_TYPE_GET_SLOT_IMPL

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -333,6 +333,11 @@ NB_CORE PyObject *nb_inst_alloc(PyTypeObject *t);
 /// Allocate an zero-initialized instance of type 't'
 NB_CORE PyObject *nb_inst_alloc_zero(PyTypeObject *t);
 
+/// Allocate an instance of type 't' with space for 'nb_inst_reset'
+/// to later associate it with a heap-allocated C++ object.
+/// Until 'nb_inst_reset' is called, 'nb_inst_ptr' will return null.
+NB_CORE PyObject *nb_inst_alloc_indirect(PyTypeObject *t);
+
 /// Allocate an instance of type 't' referencing the existing 'ptr'
 NB_CORE PyObject *nb_inst_reference(PyTypeObject *t, void *ptr,
                                     PyObject *parent);
@@ -357,6 +362,14 @@ NB_CORE void nb_inst_replace_copy(PyObject *dst, const PyObject *src) noexcept;
 
 /// Destruct 'dst', move-construct 'dst' from 'src', mark ready and retain 'destruct' status (must have the same nb_type)
 NB_CORE void nb_inst_replace_move(PyObject *dst, const PyObject *src) noexcept;
+
+/// Reset the instance 'obj' so it now refers to the C++ object 'ptr', which
+/// may be null. 'obj' must have originally been created using
+/// 'nb_inst_alloc_indirect()'. The C++ object previously associated with
+/// 'obj', if any, will be treated as it would have been if 'obj' were
+/// deallocated. 'obj' takes ownership of 'ptr' if cpp_delete is true,
+/// and stores a reference otherwise.
+NB_CORE void nb_inst_reset(PyObject *obj, void *ptr, bool cpp_delete) noexcept;
 
 /// Check if a particular instance uses a Python-derived type
 NB_CORE bool nb_inst_python_derived(PyObject *o) noexcept;

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1944,7 +1944,7 @@ void nb_inst_reset(PyObject *obj, void *ptr, bool cpp_delete) noexcept {
           "inst_alloc_indirect()!");
 
     if (oldptr != nullptr) {
-        clear_instance(nb_type_data(Py_TYPE(inst)), inst, ptr);
+        clear_instance(nb_type_data(Py_TYPE(obj)), inst, ptr);
         inst->ready = 0;
         inst->destruct = 0;
         inst->cpp_delete = 0;


### PR DESCRIPTION
I'm submitting this initially without tests and with minimal documentation because I want to know if you like the direction before I invest more time in it.

This extends the low-level API with two functions that allow the creation of nanobind instances that can manage different heap-allocated C++ objects over the course of a single Python object's lifetime:
* `inst_alloc_indirect()` creates an instance that can participate in this system, which initially manages no C++ object (`inst_ptr` returns null for it)
* `inst_reset()` changes the C++ object associated with an instance, which must have originally been created by `inst_alloc_indirect()`. The new object can be either owned or referenced. The previously-associated C++ object is destroyed if it had been advertised as owned in the previous `inst_reset()` call. keep_alive callbacks are also cleared by `inst_reset()` in order to be compatible with shared ownership techniques such as are used by the `shared_ptr` type caster.

I think this is the smallest coherent core change that would allow me to handle some tricky situations I'm running into. (Illustrative example: support unpickling for a class that can only be constructed on the heap.) It might be possible to make smaller, but at the cost of being more specialized to my specific problem.

Size cost to libnanobind is currently 472 bytes text + 128 bytes rodata. (I'm not sure where the latter is coming from, so it might be something easily fixable.)