### PR TITLE
Rename `forward_like` to avoid conflict with STL

### DIFF
--- a/include/nanobind/nb_traits.h
+++ b/include/nanobind/nb_traits.h
@@ -55,7 +55,7 @@ using forwarded_type = std::conditional_t<std::is_lvalue_reference_v<T>,
 
 /// Forwards a value U as rvalue or lvalue according to whether T is rvalue or lvalue; typically
 /// used for forwarding a container's elements.
-template <typename T, typename U> NB_INLINE forwarded_type<T, U> forward_like(U &&u) {
+template <typename T, typename U> NB_INLINE forwarded_type<T, U> forward_like_(U &&u) {
     return (forwarded_type<T, U>) u;
 }
 

--- a/include/nanobind/stl/detail/nb_array.h
+++ b/include/nanobind/stl/detail/nb_array.h
@@ -48,7 +48,7 @@ template <typename Array, typename Entry, size_t Size> struct array_caster {
             Py_ssize_t index = 0;
 
             for (auto &value : src) {
-                handle h = Caster::from_cpp(forward_like<T>(value), policy, cleanup);
+                handle h = Caster::from_cpp(forward_like_<T>(value), policy, cleanup);
 
                 if (!h.is_valid()) {
                     ret.reset();

--- a/include/nanobind/stl/detail/nb_dict.h
+++ b/include/nanobind/stl/detail/nb_dict.h
@@ -75,9 +75,9 @@ template <typename Dict, typename Key, typename Val> struct dict_caster {
         if (ret.is_valid()) {
             for (auto &item : src) {
                 object k = steal(KeyCaster::from_cpp(
-                    forward_like<T>(item.first), policy, cleanup));
+                    forward_like_<T>(item.first), policy, cleanup));
                 object e = steal(ValCaster::from_cpp(
-                    forward_like<T>(item.second), policy, cleanup));
+                    forward_like_<T>(item.second), policy, cleanup));
 
                 if (!k.is_valid() || !e.is_valid() ||
                     PyDict_SetItem(ret.ptr(), k.ptr(), e.ptr()) != 0) {

--- a/include/nanobind/stl/detail/nb_list.h
+++ b/include/nanobind/stl/detail/nb_list.h
@@ -64,7 +64,7 @@ template <typename List, typename Entry> struct list_caster {
             Py_ssize_t index = 0;
 
             for (auto &&value : src) {
-                handle h = Caster::from_cpp(forward_like<T>(value), policy, cleanup);
+                handle h = Caster::from_cpp(forward_like_<T>(value), policy, cleanup);
 
                 if (!h.is_valid()) {
                     ret.reset();

--- a/include/nanobind/stl/detail/nb_set.h
+++ b/include/nanobind/stl/detail/nb_set.h
@@ -64,7 +64,7 @@ template <typename Set, typename Key> struct set_caster {
         if (ret.is_valid()) {
             for (auto& key : src) {
                 object k = steal(
-                    Caster::from_cpp(forward_like<T>(key), policy, cleanup));
+                    Caster::from_cpp(forward_like_<T>(key), policy, cleanup));
 
                 if (!k.is_valid() || PySet_Add(ret.ptr(), k.ptr()) != 0) {
                     ret.reset();

--- a/include/nanobind/stl/optional.h
+++ b/include/nanobind/stl/optional.h
@@ -53,7 +53,7 @@ struct type_caster<std::optional<T>> {
         if (!value)
             return none().release();
 
-        return Caster::from_cpp(forward_like<T_>(*value), policy, cleanup);
+        return Caster::from_cpp(forward_like_<T_>(*value), policy, cleanup);
     }
 };
 

--- a/include/nanobind/stl/pair.h
+++ b/include/nanobind/stl/pair.h
@@ -58,12 +58,12 @@ template <typename T1, typename T2> struct type_caster<std::pair<T1, T2>> {
     static handle from_cpp(T &&value, rv_policy policy,
                            cleanup_list *cleanup) noexcept {
         object o1 = steal(
-            Caster1::from_cpp(forward_like<T>(value.first), policy, cleanup));
+            Caster1::from_cpp(forward_like_<T>(value.first), policy, cleanup));
         if (!o1.is_valid())
             return {};
 
         object o2 = steal(
-            Caster2::from_cpp(forward_like<T>(value.second), policy, cleanup));
+            Caster2::from_cpp(forward_like_<T>(value.second), policy, cleanup));
         if (!o2.is_valid())
             return {};
 

--- a/include/nanobind/stl/tuple.h
+++ b/include/nanobind/stl/tuple.h
@@ -78,7 +78,7 @@ template <typename... Ts> struct type_caster<std::tuple<Ts...>> {
         bool success =
             (... &&
              ((o[Is] = steal(make_caster<Ts>::from_cpp(
-                   forward_like<T>(std::get<Is>(value)), policy, cleanup))),
+                   forward_like_<T>(std::get<Is>(value)), policy, cleanup))),
               o[Is].is_valid()));
 
         if (!success)


### PR DESCRIPTION
When nanobind user code enables C++23, I found that `nanobind::detail::forward_like` has a naming conflict with  `std::forward_like` in STL due to ADL.

The situation is like [this](https://godbolt.org/z/98xP78v7o):

```c++
#include <utility>

namespace nanobind {
    template <typename T, typename U>
    auto forward_like(U&& t) { return t; }

    template <typename T>
    auto func(T&& t) { return forward_like<T>(t); }
}

int main() {
    auto p = std::pair(0, 0);
    nanobind::func(p);
    return 0;
}
```

```
x86-64 clang 17.0.1
x86-64 clang 17.0.1
-std=c++23 -stdlib=libc++ -Wall -Wextra 
123
<Compilation failed>

# For more information see the output window
x86-64 clang 17.0.1 - cached
<source>:8:31: error: call to 'forward_like' is ambiguous
    8 |     auto func(T&& t) { return forward_like<T>(t); }
      |                               ^~~~~~~~~~~~~~~
```

In particular, this will potentially occur when casting std object to a Python object using the nanobind STL caster.  
The simplest solution is to rename `forward_like` (in this PR). We can also avoid ADL in other ways.
