### PR TITLE
Allow custom dying words in fail_unspecified().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@ if (NB_MASTER_PROJECT AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES
     "MinSizeRel" "RelWithDebInfo")
 endif()
 
+set(NB_COMPACT_ASSERTION_MESSAGE
+    "Recompile using the 'Debug' or 'RelWithDebInfo' modes to obtain further information about this problem."
+    CACHE STRING
+    "Printed in Release or MinSizeRel builds if internal checks fail")
+
 # ---------------------------------------------------------------------------
 # Check whether all dependencies are present
 # ---------------------------------------------------------------------------

--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -202,6 +202,8 @@ function (nanobind_build_library TARGET_NAME)
   # included in Release/MinSizeRel modes
   target_compile_definitions(${TARGET_NAME} PRIVATE
     $<${NB_OPT_SIZE}:NB_COMPACT_ASSERTIONS>)
+  target_compile_definitions(${TARGET_NAME} PRIVATE
+    -DNB_COMPACT_ASSERTION_MESSAGE=\"${NB_COMPACT_ASSERTION_MESSAGE}\")
 
   # If nanobind was installed without submodule dependencies, then the
   # dependencies directory won't exist and we need to find them.

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -447,10 +447,12 @@ NB_NOINLINE void init(const char *name) {
 }
 
 #if defined(NB_COMPACT_ASSERTIONS)
+#  if !defined(NB_COMPACT_ASSERTION_MESSAGE)
+#    define NB_COMPACT_ASSERTION_MESSAGE
+#  endif
 NB_NOINLINE void fail_unspecified() noexcept {
-    fail("nanobind: encountered an unrecoverable error condition. Recompile "
-         "using the 'Debug' or 'RelWithDebInfo' modes to obtain further "
-         "information about this problem.");
+    fail("encountered an unrecoverable error condition.\n"
+         NB_COMPACT_ASSERTION_MESSAGE);
 }
 #endif
 


### PR DESCRIPTION
It seems impolite for an extension library developer (such as myself) to have an error message that would likely direct problems with a particular extension to nanobind rather than directly to the extension developer.
This commit allows the fail message to be customized by setting a CMake cache variable.

Since the default message is giving CMake build mode advice, I think it makes sense for this string to be initialized in the CMake layer anyway.   If someone were to support an alternate build tool/environment, they would want to provide a different message.

With this commit, the default message is:
```
Critical nanobind error: encountered an unrecoverable error condition.
Recompile using the 'Debug' or 'RelWithDebInfo' modes to obtain further information about this problem.
Aborted
```

An extension can, for example, do the following before configuring nanobind:
```
set(NB_COMPACT_ASSERTION_MESSAGE
    "For help regarding ${CMAKE_PROJECT_NAME}, please visit ${CMAKE_PROJECT_HOMEPAGE_URL}"
    CACHE STRING "Printed in Release builds if internal checks fail")
```
In my project, a failure then would print the following:
```
Critical nanobind error: encountered an unrecoverable error condition.
For help regarding hpk.fft, please visit https://hpkfft.com
Aborted
```

If you like this idea, I will add something to the docs in a separate PR in a week or two.