### PR TITLE
Allow custom dying words in fail_unspecified().

### DIFF
--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -447,10 +447,13 @@ NB_NOINLINE void init(const char *name) {
 }
 
 #if defined(NB_COMPACT_ASSERTIONS)
+#  if !defined(NB_COMPACT_ASSERTION_MESSAGE)
+#    define NB_COMPACT_ASSERTION_MESSAGE \
+"Recompile using the 'Debug' or 'RelWithDebInfo' modes to obtain further information about this problem."
+#  endif
 NB_NOINLINE void fail_unspecified() noexcept {
-    fail("nanobind: encountered an unrecoverable error condition. Recompile "
-         "using the 'Debug' or 'RelWithDebInfo' modes to obtain further "
-         "information about this problem.");
+    fail("encountered an unrecoverable error condition.\n"
+         NB_COMPACT_ASSERTION_MESSAGE);
 }
 #endif
 


### PR DESCRIPTION
This is a simpler alternative to PR #482.

The CMake build system is not changed and does not define the macro `NB_COMPACT_ASSERTION_MESSAGE`.   The default output will be:
```
Critical nanobind error: encountered an unrecoverable error condition.
Recompile using the 'Debug' or 'RelWithDebInfo' modes to obtain further information about this problem.
Aborted
```

I'm not expert enough with CMake to suggest the best way for a top-level project to set compile definitions for the targets in a subproject.   Perhaps it cannot be done using "modern" Cmake target-specific commands?
For my purposes, the older style command works:
```
add_definitions("-DNB_COMPACT_ASSERTION_MESSAGE=\"For help regarding ${CMAKE_PROJECT_NAME}, please visit ${CMAKE_PROJECT_HOMEPAGE_URL}\"")
```
and, given the settings in my particular `project()`, results in:
```
Critical nanobind error: encountered an unrecoverable error condition.
For help regarding hpk.fft, please visit https://hpkfft.com
Aborted
```
