### PR TITLE
Decouple complex ndarray from stl/complex.h.

### DIFF
--- a/docs/ndarray.rst
+++ b/docs/ndarray.rst
@@ -115,9 +115,8 @@ The following constraints are available
 - A scalar type (``float``, ``uint8_t``, etc.) constrains the representation
   of the ndarray.
 
-  Complex arrays (i.e., ones based on ``std::complex<float>`` or
-  ``std::complex<double>``) are supported but additionally require including
-  the header file ``<nanobind/stl/complex.h>``.
+  Complex arrays (e.g., based on ``std::complex<float>`` or
+  ``std::complex<double>``) are supported.
 
 - This scalar type can be further annotated with ``const``, which is necessary
   if you plan to call nanobind functions with arrays that do not permit write

--- a/include/nanobind/nb_traits.h
+++ b/include/nanobind/nb_traits.h
@@ -173,6 +173,28 @@ template <typename T> using is_class_caster_test = std::enable_if_t<T::IsClass>;
 template <typename Caster>
 constexpr bool is_class_caster_v = detail::detector<void, is_class_caster_test, Caster>::value;
 
+// Primary template
+template<typename T, typename SFINAE = void>
+struct is_complex : std::false_type {};
+
+// Specialization if `T` is complex, i.e., `T` has a member type `value_type`,
+// member functions `real()` and `imag()` that return such, and the size of
+// `T` is twice that of `value_type`.
+template<typename T>
+struct is_complex<T, std::enable_if_t<std::is_same_v<
+                                          decltype(std::declval<T>().real()),
+                                          typename T::value_type>
+                                   && std::is_same_v<
+                                          decltype(std::declval<T>().imag()),
+                                          typename T::value_type>
+                                   && (sizeof(T) ==
+                                       2 * sizeof(typename T::value_type))>>
+    : std::true_type {};
+
+/// True if the type `T` is a complete type representing a complex number.
+template<typename T>
+inline constexpr bool is_complex_v = is_complex<T>::value;
+
 NAMESPACE_END(detail)
 
 template <typename... Args>

--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -65,12 +65,6 @@ struct dltensor {
 
 NAMESPACE_END(dlpack)
 
-NAMESPACE_BEGIN(detail)
-
-template <typename T> struct is_complex : std::false_type { };
-
-NAMESPACE_END(detail)
-
 template <ssize_t... Is> struct shape {
     static_assert(
         ((Is >= 0 || Is == -1) && ...),
@@ -89,7 +83,7 @@ struct jax { };
 struct ro { };
 
 template <typename T> struct ndarray_traits {
-    static constexpr bool is_complex = detail::is_complex<T>::value;
+    static constexpr bool is_complex = detail::is_complex_v<T>;
     static constexpr bool is_float   = std::is_floating_point_v<T>;
     static constexpr bool is_bool    = std::is_same_v<std::remove_cv_t<T>, bool>;
     static constexpr bool is_int     = std::is_integral_v<T> && !is_bool;

--- a/include/nanobind/stl/complex.h
+++ b/include/nanobind/stl/complex.h
@@ -15,10 +15,6 @@
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
-template <typename T> struct is_complex;
-template<typename T> struct is_complex<const T> : is_complex<T> {};
-template<typename T> struct is_complex<std::complex<T>> : std::true_type {};
-
 template <typename T> struct type_caster<std::complex<T>> {
     NB_TYPE_CASTER(std::complex<T>, const_name("complex"))
 

--- a/tests/test_ndarray.cpp
+++ b/tests/test_ndarray.cpp
@@ -1,7 +1,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
-#include <nanobind/stl/complex.h>
 #include <algorithm>
+#include <complex>
 #include <vector>
 
 namespace nb = nanobind;
@@ -21,7 +21,7 @@ namespace nanobind {
        static constexpr bool is_int     = false;
        static constexpr bool is_signed  = true;
    };
-};
+}
 #endif
 
 NB_MODULE(test_ndarray_ext, m) {

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -89,6 +89,7 @@ def test03_constrain_dtype():
     t.pass_uint32(a_u32)
     t.pass_float32(a_f32)
     t.pass_complex64(a_cf64)
+    t.pass_complex64_const(a_cf64)
     t.pass_bool(a_bool)
 
     a_f32_const = a_f32.copy()
@@ -646,7 +647,7 @@ def test_uint32_complex_do_not_convert(variant):
     assert np.all(data == data2)
 
 @needs_numpy
-def test26_check_generic():
+def test36_check_generic():
     class DLPackWrapper:
         def __init__(self, o):
             self.o = o


### PR DESCRIPTION
As an extension developer using complex numbers and having custom bindings, I do not want to use a type caster for std::complex.  However, I do want to use nb::ndarray for arrays of std::complex.

This PR adds `is_complex_v<T>` to nb_traits.h so that it is not necessary to include nanobind/stl/complex.h in order to use nb::ndarray with complex numbers.  Note that the standard library `<complex>` is **not** included so that those not using complex numbers do not pay the cost of its inclusion.
