### PR TITLE
ndarray import from buffer protocol requires integer stride.

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -634,13 +634,13 @@ section <ndarrays>`.
    .. cpp:function:: size_t itemsize() const
 
       Return the size of a single array element in bytes. The returned value
-      is rounded to the next full byte in case of bit-level representations
+      is rounded up to the next full byte in case of bit-level representations
       (query :cpp:member:`dtype::bits` for bit-level granularity).
 
    .. cpp:function:: size_t nbytes() const
 
       Return the size of the entire array bytes. The returned value is rounded
-      to the next full byte in case of bit-level representations.
+      up to the next full byte in case of bit-level representations.
 
    .. cpp:function:: size_t shape(size_t i) const
 
@@ -648,7 +648,7 @@ section <ndarrays>`.
 
    .. cpp:function:: int64_t stride(size_t i) const
 
-      Return the stride of dimension `i`.
+      Return the stride (in number of elements) of dimension `i`.
 
    .. cpp:function:: const int64_t* shape_ptr() const
 

--- a/tests/test_ndarray.cpp
+++ b/tests/test_ndarray.cpp
@@ -44,6 +44,10 @@ NB_MODULE(test_ndarray_ext, m) {
         return t.nbytes();
     }, "array"_a.noconvert());
 
+    m.def("get_stride", [](const nb::ndarray<> &t, size_t i) {
+        return t.stride(i);
+    }, "array"_a.noconvert(), "i"_a);
+
     m.def("check_shape_ptr", [](const nb::ndarray<> &t) {
         std::vector<int64_t> shape(t.ndim());
         std::copy(t.shape_ptr(), t.shape_ptr() + t.ndim(), shape.begin());


### PR DESCRIPTION
In the numpy buffer protocol, strides are measured in bytes.  If a stride (in any dimension) is not an integer multiple of itemsize, then the stride cannot be correctly converted to number of elements.

With this PR, a function taking such an nb::ndarray argument will raise a TypeError exception.
