### PR TITLE
enum metaclass methods

### DIFF
--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -192,6 +192,7 @@ NB_INLINE void type_extra_apply(type_init_data &t, supplement<T>) {
 struct enum_supplement {
     bool is_signed = false;
     PyObject* entries = nullptr;
+    PyObject* entries_by_name = nullptr;
     PyObject* scope = nullptr;
 };
 

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -192,7 +192,7 @@ NB_INLINE void type_extra_apply(type_init_data &t, supplement<T>) {
 struct enum_supplement {
     bool is_signed = false;
     PyObject* entries = nullptr;
-    PyObject* entries_by_name = nullptr;
+    PyObject* values_by_name = nullptr;
     PyObject* scope = nullptr;
 };
 

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -406,6 +406,8 @@ NB_CORE void implicitly_convertible(bool (*predicate)(PyTypeObject *,
 
 // ========================================================================
 
+NB_CORE extern PyType_Slot nb_enum_metaclass_type_slots[6];
+
 /// Fill in slots for an enum type being built
 NB_CORE void nb_enum_prepare(const type_init_data *t,
                              PyType_Slot *&slots, size_t max_slots) noexcept;

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -777,7 +777,7 @@ static PyTypeObject *nb_type_tp(size_t supplement, const char *custom_name,
         PyType_Slot slots[10];
 
         PyType_Slot *next_slot = &slots[0];
-        PyType_Slot *sentinel_slot = slots + sizeof(slots) / sizeof(slots[0]) - 1;
+        PyType_Slot *last_slot = slots + sizeof(slots) / sizeof(slots[0]) - 1;
         *next_slot++ = { Py_tp_base, &PyType_Type };
         *next_slot++ = { Py_tp_dealloc, (void *) nb_type_dealloc };
         *next_slot++ = { Py_tp_setattro, (void *) nb_type_setattro };
@@ -786,7 +786,7 @@ static PyTypeObject *nb_type_tp(size_t supplement, const char *custom_name,
         if (custom_slots) {
             const PyType_Slot* next_custom_slot = custom_slots;
             while (next_custom_slot->slot != 0) {
-                check(next_slot != sentinel_slot,
+                check(next_slot != last_slot,
                       "nanobind::detail::nb_type_tp(\"%s\"): ran out of "
                       "metaclass type slots!", custom_name);
                 *next_slot++ = *next_custom_slot++;

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -480,7 +480,7 @@ static int nb_type_setattro(PyObject* obj, PyObject* name, PyObject* value) {
 }
 
 static int nb_enum_type_contains(PyTypeObject *cls, PyObject *item) {
-    if (Py_IS_TYPE(item, cls)) {
+    if (Py_TYPE(item) == cls) {
         return 1;
     }
 

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -523,6 +523,7 @@ static PyObject *nb_enum_type_subscript(PyTypeObject *cls, PyObject *key) {
         return nullptr;
     }
 
+    Py_INCREF(value);
     return value;
 }
 

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -38,6 +38,8 @@ static PyType_Slot color_slots[] = {
     { 0, nullptr }
 };
 
+enum class EmptyEnum : uint8_t {};
+
 NB_MODULE(test_enum_ext, m) {
     nb::enum_<Enum>(m, "Enum", "enum-level docstring")
         .value("A", Enum::A, "Value A")
@@ -75,4 +77,7 @@ NB_MODULE(test_enum_ext, m) {
     nb::class_<EnumProperty>(m, "EnumProperty")
         .def(nb::init<>())
         .def_prop_ro("read_enum", &EnumProperty::get_enum);
+
+    // nb::enum_<EmptyEnum>(m, "EmptyEnum", "enum with no variants")
+    //     ;
 }

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -162,3 +162,32 @@ def test08_enum_comparisons():
     assert t.SEnum.B > t.Enum.A
     assert t.Enum.A <= t.SEnum.A and t.Enum.A >= t.SEnum.A
     assert t.Enum.A != t.SEnum.A
+
+def test09_enum_metaclass_methods():
+    for enum, variant_names in ((t.Enum, ["A", "B", "C"]),):
+        variants = [getattr(enum, name) for name in variant_names]
+
+        # __iter__
+        assert list(enum) == variants
+
+        # __contains__
+        for enum_variant in variants:
+            assert enum_variant in enum
+            assert enum_variant.value in enum
+
+        for not_enum_variant in (42, None, enum, "nope"):
+            assert not_enum_variant not in enum
+
+        # __getitem__
+        for variant, variant_name in zip(variants, variant_names):
+            assert variant is enum[variant_name]
+
+        for key in ("name", "value", "__class__", 42, None, enum):
+            with pytest.raises(KeyError):
+                enum[key]
+
+        # __len__
+        assert len(enum) == len(variant_names)
+
+        # __reversed__
+        assert list(reversed(enum)) == list(reversed(variants))


### PR DESCRIPTION
This PR implements the following metaclass methods for enum types: `__iter__`, `__contains__`, `__getitem__`, `__len__` and `__reversed__`, similar to those of standard Python enums.

Unfortunately, this also reintroduces entanglement between `nb_type.cpp` and `nb_enum.cpp`, so I'm marking this as a draft for now, but posting to start the discussion of possible implementations. To me it seems like keeping them detangled would require adding some kind of metaclass API, but maybe there is a more simple way?

I've also noticed that `stubgen.py` crashes when it encounters an empty enum due to them not having an `@entries` attribute and therefore not being recognized as an enum. Should we perhaps always create this attribute? Or handle `__doc__` more carefully in `stubgen.py`?

```
[27/29] Generating test_enum_ext.pyi
FAILED: tests/test_enum_ext.pyi /home/roman/projects/nanobind/build/tests/test_enum_ext.pyi

cd /home/roman/projects/nanobind/build/tests && /home/roman/venv/master-3.12/bin/python3 /home/roman/projects/nanobind/src/stubgen.py -q -i /home/roman/projects/nanobind/build/tests -m test_enum_ext -o test_enum_ext.pyi
Traceback (most recent call last):
  File "/home/roman/projects/nanobind/src/stubgen.py", line 1463, in <module>
    main()
  File "/home/roman/projects/nanobind/src/stubgen.py", line 1434, in main
    sg.put(mod_imported)
  File "/home/roman/projects/nanobind/src/stubgen.py", line 838, in put
    self.put(child, name=name, parent=value)
  File "/home/roman/projects/nanobind/src/stubgen.py", line 845, in put
    self.put_type(value, name)
  File "/home/roman/projects/nanobind/src/stubgen.py", line 544, in put_type
    self.put_docstr(docstr)
  File "/home/roman/projects/nanobind/src/stubgen.py", line 283, in put_docstr
    docstr = textwrap.dedent(docstr).strip()
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/roman/.pyenv/versions/3.12.2/lib/python3.12/textwrap.py", line 435, in dedent
    text = _whitespace_only_re.sub('', text)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'getset_descriptor'
```