### PR TITLE
use qualified name when aliasing types

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -491,7 +491,7 @@ class StubGen:
             if same_module:
                 # This is an alias of a type in the same module or same top-level module
                 alias_tp = self.import_object("typing", "TypeAlias")
-                self.write_ln(f"{name}: {alias_tp} = {tp_name}\n")
+                self.write_ln(f"{name}: {alias_tp} = {tp.__qualname__}\n")
             elif self.include_external_imports or (same_toplevel_module and self.include_internal_imports):
                 # Import from a different module
                 self.put_value(tp, name)


### PR DESCRIPTION
Use qualified name when writing type aliases.

If you have some bindings like this:
```c++
nb::class_<A> a(m, "A");
nb::enum_<E> e(a, "E");
nb::class_<B> b(m, "B");
b.attr("E") = a.attr("E");
```

you currently get:

```python
class A:
    class E(_Enum):
        ...

class B:
    E: TypeAlias = E  
```

with this fix you get:
```python
class B:
    E: TypeAlias = A.E
```