### PR TITLE
add a note about running on Windows

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -79,6 +79,8 @@ session:
    cd build
    python3
 
+(The default build output directory is different on Windows: use ``cd build\Debug`` and ``python`` instead of the above.)
+
 You should be able to import the extension and call the newly defined function ``my_ext.add()``.
 
 .. code-block:: pycon


### PR DESCRIPTION
The cmake outputs for the built extensions go under build\Debug so the run instructions are not the same as on other OSs.  In addition, python is just `python.exe` on Windows, not `python3`.

for #517