### PR TITLE
Swap target/source in implicitly_convertible example code

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -2768,7 +2768,7 @@ Miscellaneous
       nb::class_<Target>(m, "Target")
           .def(nb::init<Source>());
 
-      nb::implicitly_convertible<Target, Source>();
+      nb::implicitly_convertible<Source, Target>();
 
    The function is provided for reasons of compatibility with pybind11, and as
    an escape hatch to enable use cases where :cpp:struct:`init_implicit`


### PR DESCRIPTION
Match the order of `implicitly_convertible()` `Source` and `Target` template parameters in the example code.

Here's a screenshot of the docs for context:

![image](https://github.com/wjakob/nanobind/assets/297823/48f9349f-2860-4628-b43f-1532b8f0dcd6)
