### PR TITLE
Fix building tests with Ninja on Windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,8 +53,8 @@ foreach (NAME functions classes ndarray stl enum typing make_iterator)
     set(EXTRA "")
   endif()
 
-  if (MSVC)
-    # On MSVC, put stubs in the 'Debug' / 'Release' /.. folders
+  if (CMAKE_CONFIGURATION_TYPES)
+    # On multi-config generators like Visual Studio, put stubs in the 'Debug' / 'Release' /.. folders
     set(PYI_PREFIX $<CONFIG>/)
   endif()
 
@@ -130,7 +130,7 @@ set(TEST_FILES
 )
 
 if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR) OR MSVC)
-  if (MSVC)
+  if (CMAKE_CONFIGURATION_TYPES)
     set(OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
   else()
     set(OUT_DIR ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Putting outputs in Release/ folders etc is a result of using a multi-config cmake generator like Visual Studio, not of using MSVC. This fixes using ninja on windows, and presumably using multi config generators with compilers other than MSVC.