### PR TITLE
Fix visibility for GCC on Windows (mingw64)

### DIFF
--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -22,7 +22,7 @@
 #  define NAMESPACE_END(name) }
 #endif
 
-#if defined(_WIN32) && !defined(__GNUC__)
+#if defined(_WIN32)
 #  define NB_EXPORT          __declspec(dllexport)
 #  define NB_IMPORT          __declspec(dllimport)
 #  define NB_INLINE          __forceinline
@@ -40,7 +40,7 @@
 #  endif
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(_WIN32)
 #  define NB_NAMESPACE nanobind __attribute__((visibility("hidden")))
 #else
 #  define NB_NAMESPACE nanobind
@@ -64,7 +64,7 @@
 #  define NB_CORE
 #endif
 
-#if !defined(NB_SHARED) && defined(__GNUC__)
+#if !defined(NB_SHARED) && defined(__GNUC__) && !defined(_WIN32)
 #  define NB_EXPORT_SHARED __attribute__ ((visibility("hidden")))
 #else
 #  define NB_EXPORT_SHARED


### PR DESCRIPTION
- revert change from https://github.com/wjakob/nanobind/pull/440
  - `dllexport` was/is correct on Windows, including with mingw64 gcc compiler
- don't set `visibility("hidden")` attribute for namespaces on windows
  - this resolves the original mingw64 compilation error seen in #440