### PR TITLE
Fix support for None in unique_ptr caster

### DIFF
--- a/tests/test_holders.cpp
+++ b/tests/test_holders.cpp
@@ -169,7 +169,8 @@ NB_MODULE(test_holders_ext, m) {
         .def("get", [](UniqueWrapper2 *uw) { return std::move(uw->value); });
 
     m.def("passthrough_unique",
-          [](std::unique_ptr<Example> unique) { return unique; });
+          [](std::unique_ptr<Example> unique) { return unique; },
+          nb::arg().none());
     m.def("passthrough_unique_2",
           [](std::unique_ptr<Example, nb::deleter<Example>> unique) { return unique; });
 

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -195,6 +195,7 @@ def test06_uniqueptr_from_py(clean):
 
 
 def test07_uniqueptr_passthrough(clean):
+    assert t.passthrough_unique(None) is None
     assert t.passthrough_unique(t.unique_from_cpp()).value == 1
     assert t.passthrough_unique(t.unique_from_cpp_2()).value == 2
     assert t.passthrough_unique_2(t.unique_from_cpp()).value == 1


### PR DESCRIPTION
Support passing None where a `unique_ptr<T>` is needed (subject to argument nullability rules), and producing None when a null `unique_ptr<T>` is returned to Python.

Previously from-python conversion would pass a None object to `nb_type_relinquish_ownership` which would try to reinterpret it as a nanobind instance. Similarly, in from-cpp conversion, `nb_type_put_unique` would call `nb_type_put_unique_finalize` which would try to modify some bits in `Py_None`.