### PR TITLE
Model relinquished instances as a separate state from not-ready

### DIFF
--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -744,7 +744,7 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
                 if (is_constructor) {
                     nb_inst *self_arg_nb = (nb_inst *) self_arg;
                     self_arg_nb->destruct = true;
-                    self_arg_nb->ready = true;
+                    self_arg_nb->state = nb_inst::state_ready;
                     if (NB_UNLIKELY(self_arg_nb->intrusive))
                         nb_type_data(Py_TYPE(self_arg))
                             ->set_self_py(inst_ptr(self_arg_nb), self_arg);
@@ -845,7 +845,7 @@ static PyObject *nb_func_vectorcall_simple(PyObject *self,
                 if (is_constructor) {
                     nb_inst *self_arg_nb = (nb_inst *) self_arg;
                     self_arg_nb->destruct = true;
-                    self_arg_nb->ready = true;
+                    self_arg_nb->state = nb_inst::state_ready;
                     if (NB_UNLIKELY(self_arg_nb->intrusive))
                         nb_type_data(Py_TYPE(self_arg))
                             ->set_self_py(inst_ptr(self_arg_nb), self_arg);

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -51,6 +51,16 @@ struct nb_inst { // usually: 24 bytes
     /// Offset to the actual instance data
     int32_t offset;
 
+    /// State of the C++ object this instance points to: is it constructed?
+    /// can we use it?
+    uint32_t state : 2;
+
+    // Values for `state`. Note that the numeric values of these are relied upon
+    // for an optimization in `nb_type_get()`.
+    static constexpr uint32_t state_uninitialized = 0; // not constructed
+    static constexpr uint32_t state_relinquished = 1; // owned by C++, don't touch
+    static constexpr uint32_t state_ready = 2; // constructed and usable
+
     /**
      * The variable 'offset' can either encode an offset relative to the
      * nb_inst address that leads to the instance data, or it can encode a
@@ -61,9 +71,6 @@ struct nb_inst { // usually: 24 bytes
 
     /// Is the instance data co-located with the Python object?
     uint32_t internal : 1;
-
-    /// Is the instance properly initialized?
-    uint32_t ready : 1;
 
     /// Should the destructor be called when this instance is GCed?
     uint32_t destruct : 1;
@@ -78,7 +85,7 @@ struct nb_inst { // usually: 24 bytes
     uint32_t intrusive : 1;
 
     // That's a lot of unused space. I wonder if there is a good use for it..
-    uint32_t unused: 25;
+    uint32_t unused : 24;
 };
 
 static_assert(sizeof(nb_inst) == sizeof(PyObject) + sizeof(uint32_t) * 2);

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -91,11 +91,11 @@ def test05a_uniqueptr_from_cpp(clean):
     b = t.unique_from_cpp_2()
     wa = t.UniqueWrapper(a)
     wb = t.UniqueWrapper(b)
-    with pytest.warns(RuntimeWarning, match='nanobind: attempted to access an uninitialized instance of type \'test_holders_ext.Example\'!'):
+    with pytest.warns(RuntimeWarning, match='nanobind: attempted to access a relinquished instance of type \'test_holders_ext.Example\'!'):
         with pytest.raises(TypeError) as excinfo:
             assert a.value == 1
         assert 'incompatible function arguments' in str(excinfo.value)
-    with pytest.warns(RuntimeWarning, match='nanobind: attempted to access an uninitialized instance of type \'test_holders_ext.Example\'!'):
+    with pytest.warns(RuntimeWarning, match='nanobind: attempted to access a relinquished instance of type \'test_holders_ext.Example\'!'):
         with pytest.raises(TypeError) as excinfo:
             assert b.value == 2
         assert 'incompatible function arguments' in str(excinfo.value)
@@ -133,7 +133,7 @@ def test05b_uniqueptr_list(clean):
     res = t.passthrough_unique_pairs([(k, v)], clear=True)
     assert res == []
     for obj in (k, v):
-        with pytest.warns(RuntimeWarning, match='nanobind: attempted to access an uninitialized instance of type \'test_holders_ext.Example\'!'):
+        with pytest.warns(RuntimeWarning, match='nanobind: attempted to access a relinquished instance of type \'test_holders_ext.Example\'!'):
             with pytest.raises(TypeError) as excinfo:
                 obj.value
     collect()
@@ -154,6 +154,19 @@ def test05c_uniqueptr_structure_duplicate(clean):
     collect()
     assert t.stats() == (1, 1)
 
+def test05d_uniqueptr_reinit(clean):
+    x = t.unique_from_cpp()
+    assert x.value == 1
+    w = t.UniqueWrapper(x)
+    with pytest.warns(RuntimeWarning, match='nanobind: attempted to access a relinquished instance of type \'test_holders_ext.Example\'!'):
+        with pytest.raises(TypeError):
+            x.value
+    with pytest.warns(RuntimeWarning, match='nanobind: attempted to access a relinquished instance of type \'test_holders_ext.Example\'!'):
+        with pytest.raises(TypeError):
+            x.__init__(3)
+    y = w.get()
+    assert y is x and y.value == 1
+
 
 def test06_uniqueptr_from_py(clean):
     # Test ownership exchange when the object has been created on the Python side
@@ -162,7 +175,7 @@ def test06_uniqueptr_from_py(clean):
         with pytest.raises(TypeError) as excinfo:
             wa = t.UniqueWrapper(a)
     wa = t.UniqueWrapper2(a)
-    with pytest.warns(RuntimeWarning, match='nanobind: attempted to access an uninitialized instance of type \'test_holders_ext.Example\'!'):
+    with pytest.warns(RuntimeWarning, match='nanobind: attempted to access a relinquished instance of type \'test_holders_ext.Example\'!'):
         with pytest.raises(TypeError) as excinfo:
             assert a.value == 1
         assert 'incompatible function arguments' in str(excinfo.value)


### PR DESCRIPTION
Instances become relinquished when the object they wrap has its ownership transferred to a C++ `unique_ptr`. Unlike ready instances, they can't be validly accessed (because the C++ object might have been destroyed without our knowledge). Unlike non-ready instances, they can't be validly constructed (because the C++ object might still be within its lifetime). They need a new state. This PR handles them by expanding the previous `nb_inst::ready` flag into a two-bit field `nb_inst::state`. Due to a careful choice of which number represents which state, this should have negligible overhead.

Fixes #550.