### PR TITLE
Add cupy support

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -644,7 +644,7 @@ N-dimensional array type
 ------------------------
 
 The following type can be used to exchange n-dimension arrays with frameworks
-like NumPy, PyTorch, Tensorflow, JAX, and others. It requires an additional
+like NumPy, PyTorch, Tensorflow, JAX, CuPy, and others. It requires an additional
 include directive:
 
 .. code-block:: cpp
@@ -1005,6 +1005,8 @@ convert into an equivalent representation in one of the following frameworks:
 .. cpp:class:: pytorch
 
 .. cpp:class:: jax
+
+.. cpp:class:: cupy
 
 Eigen convenience type aliases
 ------------------------------

--- a/docs/ndarray.rst
+++ b/docs/ndarray.rst
@@ -8,7 +8,7 @@ The ``nb::ndarray<..>`` class
 nanobind can exchange n-dimensional arrays (henceforth "**ndarrays**") with
 popular array programming frameworks including `NumPy
 <https://numpy.org>`__, `PyTorch <https://pytorch.org>`__, `TensorFlow
-<https://www.tensorflow.org>`__, and `JAX <https://jax.readthedocs.io>`__.
+<https://www.tensorflow.org>`__, `JAX <https://jax.readthedocs.io>`__, and `CuPy <https://cupy.dev>`_.
 It supports *zero-copy* exchange using two protocols:
 
 -  The classic `buffer
@@ -342,6 +342,7 @@ values:
    ``tensorflow.python.framework.ops.EagerTensor``.
 -  :cpp:class:`nb::jax <jax>`. Returns the ndarray as a
    ``jaxlib.xla_extension.DeviceArray``.
+-  :cpp:class:`nb::cupy <cupy>`. Returns the ndarray as a ``cupy.ndarray``.
 -  No framework annotation. In this case, nanobind will return a raw
    Python ``dltensor``
    `capsule <https://docs.python.org/3/c-api/capsule.html>`__

--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -80,6 +80,7 @@ struct numpy { };
 struct tensorflow { };
 struct pytorch { };
 struct jax { };
+struct cupy { };
 struct ro { };
 
 template <typename T> struct ndarray_traits {
@@ -134,7 +135,7 @@ template <typename T> constexpr dlpack::dtype dtype() {
 
 NAMESPACE_BEGIN(detail)
 
-enum class ndarray_framework : int { none, numpy, tensorflow, pytorch, jax };
+enum class ndarray_framework : int { none, numpy, tensorflow, pytorch, jax, cupy };
 
 struct ndarray_req {
     dlpack::dtype dtype;
@@ -307,6 +308,10 @@ template <typename... Ts> struct ndarray_info<tensorflow, Ts...> : ndarray_info<
 template <typename... Ts> struct ndarray_info<jax, Ts...> : ndarray_info<Ts...> {
     constexpr static auto name = const_name("jaxlib.xla_extension.DeviceArray");
     constexpr static ndarray_framework framework = ndarray_framework::jax;
+};
+template <typename... Ts> struct ndarray_info<cupy, Ts...> : ndarray_info<Ts...> {
+    constexpr static auto name = const_name("cupy.ndarray");
+    constexpr static ndarray_framework framework = ndarray_framework::cupy;
 };
 
 

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -308,7 +308,9 @@ bool ndarray_check(PyObject *o) noexcept {
         // XLA
         strcmp(tp_name, "jaxlib.xla_extension.ArrayImpl") == 0 ||
         // Tensorflow
-        strcmp(tp_name, "tensorflow.python.framework.ops.EagerTensor") == 0;
+        strcmp(tp_name, "tensorflow.python.framework.ops.EagerTensor") == 0 ||
+        // Cupy
+        strcmp(tp_name, "cupy.ndarray") == 0;
 
     Py_DECREF(name);
     return result;
@@ -467,7 +469,7 @@ ndarray_handle *ndarray_import(PyObject *o, const ndarray_req *req,
 
         object converted;
         try {
-            if (strcmp(module_name, "numpy") == 0) {
+            if (strcmp(module_name, "numpy") == 0 || strcmp(module_name, "cupy") == 0) {
                 converted = handle(o).attr("astype")(dtype, order);
             } else if (strcmp(module_name, "torch") == 0) {
                 converted = handle(o).attr("to")(
@@ -723,6 +725,10 @@ PyObject *ndarray_wrap(ndarray_handle *th, ndarray_framework framework,
 
             case ndarray_framework::jax:
                 package = module_::import_("jax.dlpack");
+                break;
+
+            case ndarray_framework::cupy:
+                package = module_::import_("cupy");
                 break;
 
             default:

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -32,6 +32,12 @@ try:
 except:
     needs_jax = pytest.mark.skip(reason="JAX is required")
 
+try:
+    import cupy as cp
+    def needs_cupy(x):
+        return x
+except:
+    needs_cupy = pytest.mark.skip(reason="CuPy is required")
 
 
 @needs_numpy
@@ -694,3 +700,40 @@ def test37_noninteger_stride():
     with pytest.raises(TypeError) as excinfo:
         t.get_stride(v, 0);
     assert 'incompatible function arguments' in str(excinfo.value)
+
+@needs_cupy
+@pytest.mark.filterwarnings
+def test38_constrain_order_cupy():
+    try:
+        c = cp.zeros((3, 5))
+        c.__dlpack__()
+    except:
+        pytest.skip('cupy is missing')
+
+    f = cp.asarray(c, order="F")
+    assert t.check_order(c) == 'C'
+    assert t.check_order(f) == 'F'
+    assert t.check_order(c[:, 2:5]) == '?'
+    assert t.check_order(f[1:3, :]) == '?'
+    assert t.check_device(cp.zeros((3, 5))) == 'cuda'
+
+
+@needs_cupy
+def test39_implicit_conversion_cupy():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        try:
+            c = cp.zeros((3, 5))
+        except:
+            pytest.skip('cupy is missing')
+
+    t.implicit(cp.zeros((2, 2), dtype=cp.int32))
+    t.implicit(cp.zeros((2, 2, 10), dtype=cp.float32)[:, :, 4])
+    t.implicit(cp.zeros((2, 2, 10), dtype=cp.int32)[:, :, 4])
+    t.implicit(cp.zeros((2, 2, 10), dtype=cp.bool_)[:, :, 4])
+
+    with pytest.raises(TypeError) as excinfo:
+        t.noimplicit(cp.zeros((2, 2), dtype=cp.int32))
+
+    with pytest.raises(TypeError) as excinfo:
+        t.noimplicit(cp.zeros((2, 2), dtype=cp.uint8))


### PR DESCRIPTION
Hi, this PR adds cupy support.

What additional tests do you recommend adding?

Do you think it would make sense for `np.ndarray` with `nb::device::cuda` be considered `cp.ndarray` automatically?

Reference: #510 