### PR TITLE
Don't leak enum names.

### DIFF
--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -79,6 +79,7 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
         delete (enum_map *) t->enum_tbl.fwd;
         delete (enum_map *) t->enum_tbl.rev;
         nb_type_unregister(t);
+        free((char*)t->name);
         delete t;
     });
 


### PR DESCRIPTION
The ->name field of the typeinfo is never freed at the moment.