### PR TITLE
fix named copy ctor argument

### DIFF
--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -254,6 +254,12 @@ PyObject *nb_func_new(const void *in_) noexcept {
                          strncmp(f->descr, "({%}", 4) == 0;
 
         // Don't use implicit conversions in copy constructors (causes infinite recursion)
+        // Notes:
+        //   f->nargs = C++ argument count.
+        //   f->descr_types = zero-terminated array of bound types among them.
+        //     Hence of size >= 2 for constructors, where f->descr_types[1] my be null.
+        //   f->args = array of Python arguments (nb::arg). Non-empty if has_args.
+        //   By contrast, fc->args below has size f->nargs.
         if (is_constructor && f->nargs == 2 && f->descr_types[0] &&
             f->descr_types[0] == f->descr_types[1]) {
             if (has_args) {

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -257,7 +257,7 @@ PyObject *nb_func_new(const void *in_) noexcept {
         if (is_constructor && f->nargs == 2 && f->descr_types[0] &&
             f->descr_types[0] == f->descr_types[1]) {
             if (has_args) {
-                f->args[1].convert = false;
+                f->args[0].convert = false;
             } else {
                 args_in = method_args + 1;
                 has_args = true;

--- a/tests/test_issue.cpp
+++ b/tests/test_issue.cpp
@@ -58,4 +58,11 @@ NB_MODULE(test_issue_ext, m) {
           [](const std::vector<Example>& v) {
               return v.size();
           }, nb::arg("v"));
+
+
+    // v2.0.0: stack corruption when binding a copy constructor with a named argument.
+    struct Empty {};
+    nb::class_<Empty>(m, "Empty")
+      .def(nb::init<const Empty&>(), nb::arg("original"));
+
 }

--- a/tests/test_issue.cpp
+++ b/tests/test_issue.cpp
@@ -60,7 +60,7 @@ NB_MODULE(test_issue_ext, m) {
           }, nb::arg("v"));
 
 
-    // v2.0.0: stack corruption when binding a copy constructor with a named argument.
+    // pull/602: stack corruption when binding a copy constructor with a named argument.
     struct Empty {};
     nb::class_<Empty>(m, "Empty")
       .def(nb::init<const Empty&>(), nb::arg("original"));


### PR DESCRIPTION
Currently, binding a copy constructor with a named argument corrupts the stack due to writing past the end of a stack-allocated array.