### PR TITLE
Add exception to assert introduced in #549 when the type caster of `U*` can produce the actual underlying object `U`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,15 @@ case, both modules must use the same nanobind ABI version, or they will be
 isolated from each other. Releases that don't explicitly mention an ABI version
 below inherit that of the preceding release.
 
+Version 2.0.1 (TBA)
+---------------------------
+
+* nanobind no longer prevents casting to a C++ container of pointers ``T*``
+  where ``T`` is a type with a user-defined type caster if the caster seems
+  to operate by extracting a ``T*`` from the Python object rather than a ``T``.
+  This change was prompted by discussion
+  `#605 <https://github.com/wjakob/nanobind/discussions/605>`__.
+
 Version 2.0.0 (May 23, 2024)
 ----------------------------
 

--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -108,8 +108,9 @@ using precise_cast_t =
 /// where the template argument T is the type you plan to extract.
 template <typename T>
 NB_INLINE uint8_t flags_for_local_caster(uint8_t flags) noexcept {
+    using Caster = make_caster<T>;
     constexpr bool is_ref = std::is_pointer_v<T> || std::is_reference_v<T>;
-    if constexpr (is_base_caster_v<make_caster<T>>) {
+    if constexpr (is_base_caster_v<Caster>) {
         if constexpr (is_ref) {
             /* References/pointers to a type produced by implicit conversions
                refer to storage owned by the cleanup_list. In a nb::cast() call,
@@ -123,7 +124,9 @@ NB_INLINE uint8_t flags_for_local_caster(uint8_t flags) noexcept {
            into storage owned by the caster, which won't live long enough.
            Exception: the 'char' caster produces a result that points to
            storage owned by the incoming Python 'str' object, so it's OK. */
-        static_assert(!is_ref || std::is_same_v<T, const char*>,
+        static_assert(!is_ref || std::is_same_v<T, const char*> ||
+                      std::conjunction_v<std::is_pointer<T>,
+                                         std::is_constructible<T*, Caster>>,
                       "nanobind generally cannot produce objects that "
                       "contain interior pointers T* (or references T&) if "
                       "the pointee T is not handled by nanobind's regular "

--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -125,8 +125,7 @@ NB_INLINE uint8_t flags_for_local_caster(uint8_t flags) noexcept {
            Exception: the 'char' caster produces a result that points to
            storage owned by the incoming Python 'str' object, so it's OK. */
         static_assert(!is_ref || std::is_same_v<T, const char*> ||
-                      std::conjunction_v<std::is_pointer<T>,
-                                         std::is_constructible<T*, Caster>>,
+                      (std::is_pointer_v<T> && std::is_constructible_v<T*, Caster>),
                       "nanobind generally cannot produce objects that "
                       "contain interior pointers T* (or references T&) if "
                       "the pointee T is not handled by nanobind's regular "


### PR DESCRIPTION
Follow up to discussion #605.

I confirmed with my downstream project that the patch does indeed fix the regression introduced in nanobind 2.0.
Please note that, even though the commit has my name and email address, the actual patch was provided by @oremanj.