### PR TITLE
Add a document explaining nanobind extension building using Bazel

### DIFF
--- a/docs/api_bazel.rst
+++ b/docs/api_bazel.rst
@@ -1,0 +1,125 @@
+.. _api_bazel:
+
+Bazel API Reference (third-party)
+=================================
+
+This page contains a reference of the basic APIs of
+`nanobind-bazel <https://github.com/nicholasjng/nanobind-bazel>`__.
+
+.. _rules-bazel:
+
+Rules
+-----
+
+nanobind-bazel's rules can be used to declare different types of targets in
+your Bazel project. Each of these rules is a thin wrapper around a
+corresponding builtin Bazel rule producing the equivalent C++ target.
+
+The main tool to build nanobind extensions is the ``nanobind_extension`` rule.
+
+.. cmake:command:: nanobind_extension
+
+    Declares a Bazel target representing a nanobind extension, which contains
+    the Python bindings of your C++ code.
+
+    .. code-block:: python
+
+        def nanobind_extension(
+            name,
+            domain = "",
+            srcs = [],
+            copts = [],
+            deps = [],
+            local_defines = [],
+            **kwargs):
+
+    It corresponds directly to the builtin
+    `cc_binary <https://bazel.build/reference/be/c-cpp#cc_binary>`__ rule,
+    with all keyword arguments being directly forwarded to a ``cc_binary`` 
+    target.
+
+    The ``domain`` argument can be used to build the target extension under a
+    different ABI domain, as described in the :ref:`FAQ <type-visibility>`
+    section.
+
+To build a C++ library with nanobind as a dependency, use the 
+``nanobind_library`` rule.
+
+.. cmake:command:: nanobind_library
+
+    Declares a Bazel target representing a C++ library depending on nanobind.
+
+    .. code-block:: python
+
+        def nanobind_library(
+            name,
+            copts = [],
+            deps = [],
+            **kwargs):
+
+    It corresponds directly to the builtin
+    `cc_library <https://bazel.build/reference/be/c-cpp#cc_library>`__ rule,
+    with all keyword arguments being directly forwarded to a ``cc_library``
+    target.
+
+To build a C++ shared library with nanobind as a dependency, use the
+``nanobind_shared_library`` rule.
+
+.. cmake:command:: nanobind_shared_library
+
+    Declares a Bazel target representing a C++ shared library depending on
+    nanobind.
+
+    .. code-block:: python
+
+        def nanobind_shared_library(
+            name,
+            deps = [],
+            **kwargs):
+
+    It corresponds directly to the builtin
+    `cc_shared_library <https://bazel.build/reference/be/
+    c-cpp#cc_shared_library>`__ rule, with all keyword arguments being directly
+    forwarded to a ``cc_shared_library`` target.
+
+    *New in nanobind-bazel version 2.1.0 (unreleased).*
+
+To build a C++ test target requiring nanobind, use the ``nanobind_test`` rule.
+
+.. cmake:command:: nanobind_test
+
+    Declares a Bazel target representing a C++ test depending on nanobind.
+
+    .. code-block:: python
+
+        def nanobind_test(
+            name,
+            copts = [],
+            deps = [],
+            **kwargs):
+
+    It corresponds directly to the builtin
+    `cc_test <https://bazel.build/reference/be/c-cpp#cc_test>`__ rule, with all
+    keyword arguments being directly forwarded to a ``cc_test`` target.
+
+.. _flags-bazel:
+
+Flags
+-----
+
+To customize some of nanobind's build options, nanobind-bazel exposes the 
+following flag settings.
+
+.. cmake:command:: @nanobind_bazel//:minsize (boolean)
+
+    Apply nanobind's size optimizations to the built extensions. Size
+    optimizations are turned on by default, similarly to the CMake build.
+    To turn off size optimizations, you can use the shorthand notation
+    ``--no@nanobind_bazel//:minsize``.
+
+.. cmake:command:: @nanobind_bazel//:py-limited-api (string)
+
+    Build nanobind extensions against the stable ABI of the configured Python
+    version. Allowed values are ``"cp312"``, ``"cp313"``, which target the
+    stable ABI starting from Python 3.12 or 3.13, respectively. By default, all
+    extensions are built without any ABI limitations.

--- a/docs/bazel.rst
+++ b/docs/bazel.rst
@@ -1,0 +1,140 @@
+.. _bazel:
+
+Building nanobind extensions with Bazel
+=======================================
+
+If you prefer the Bazel build system to CMake, you can build extensions using
+the `nanobind-bazel <https://github.com/nicholasjng/nanobind-bazel>`__ project.
+
+.. note::
+
+    This project is a community contribution maintained by
+    `Nicholas Junge <https://github.com/nicholasjng>`__, please report issues
+    directly in the nanobind-bazel repository linked above.
+
+.. _bazel-setup:
+
+Adding nanobind-bazel to your Bazel project
+-------------------------------------------
+
+To use nanobind-bazel in your project, you need to add it to your project's
+dependency graph. Using bzlmod, the de-facto dependency management system
+in Bazel starting with version 7.0, you can simply specify it as a ``bazel_dep``
+in your MODULE.bazel file:
+
+.. code-block:: python
+
+    # Place this in your MODULE.bazel file.
+    # The major version of nanobind-bazel is equal to the major version
+    # of the internally used nanobind.
+    # In this case, we are building bindings with nanobind@v2.
+    bazel_dep(name = "nanobind_bazel", version = "2.0.0")
+
+To instead use a development version from GitHub, you can declare the
+dependency as a ``git_override()`` in your MODULE.bazel:
+
+.. code-block:: python
+
+    # MODULE.bazel
+    bazel_dep(name = "nanobind_bazel", version = "")
+    git_override(
+        module_name = "nanobind_bazel",
+        commit = COMMIT_SHA, # replace this with the actual commit you want.
+        remote = "https://github.com/nicholasjng/nanobind-bazel",
+    )
+
+In local development scenarios, you can clone nanobind-bazel to your machine,
+and then declare it as a ``local_path_override()`` dependency:
+
+.. code-block:: python
+
+    # MODULE.bazel
+    bazel_dep(name = "nanobind_bazel", version = "")
+    local_path_override(
+        module_name = "nanobind_bazel",
+        path = "/path/to/nanobind-bazel/", # replace this with the actual path.
+    )
+
+.. note::
+
+    At minimum, Bazel version 6.4.0 is required to use nanobind-bazel.
+
+
+.. _bazel-build:
+
+Declaring and building nanobind extension targets
+-------------------------------------------------
+
+The main tool to build nanobind C++ extensions for your Python bindings is the
+:cmake:command:`nanobind_extension` rule.
+
+Like all public nanobind-bazel APIs, it resides in the ``build_defs`` submodule.
+To import it into a BUILD file, use the builtin ``load`` command:
+
+.. code-block:: python
+        
+    # In a BUILD file, e.g. my_project/BUILD
+    load("@nanobind_bazel//:build_defs.bzl", "nanobind_extension")
+
+    nanobind_extension(
+        name = "my_ext",
+        srcs = ["my_ext.cpp"],
+    )
+
+In this short snippet, a nanobind Python module called ``my_ext`` is declared,
+with its contents coming from the C++ source file of the same name.
+Conveniently, only the actual module name must be declared - its place in your
+Python project hierarchy is automatically determined by the location of your
+build file.
+
+For a comprehensive list of all available build rules in nanobind-bazel, refer
+to the rules section in the :ref:`nanobind-bazel API reference <rules-bazel>`.
+
+.. _bazel-stable-abi:
+
+Building against the stable ABI
+-------------------------------
+
+As in nanobind's CMake config, you can build bindings targeting Python's
+stable ABI, starting from version 3.12. To do this, specify the target
+version using the ``@nanobind_bazel//:py-limited-api`` flag. For example,
+to build extensions against the CPython 3.12 stable ABI, pass the option
+``@nanobind_bazel//:py-limited-api="cp312"`` to your ``bazel build`` command.
+
+For more information about available flags, refer to the flags section in the 
+:ref:`nanobind-bazel API reference <flags-bazel>`.
+
+nanobind-bazel and Python packaging
+-----------------------------------
+
+Unlike CMake, which has a variety of projects supporting PEP517-style
+Python package builds, Bazel does not currently have a fully featured
+PEP517-compliant packaging backend available.
+
+To produce Python wheels containing bindings built with nanobind-bazel,
+you have various options, with two of the most prominent strategies being
+
+1. Using a wheel builder script with the facilities provided by a Bazel
+support package for Python, such as ``py_binary`` or ``py_wheel`` from 
+`rules_python <https://github.com/bazelbuild/rules_python/>`__. This is
+a lower-level, more complex workflow, but it provides more granular
+control of how your Python wheel is built.
+
+2. Building all extensions with Bazel through a subprocess, by extending
+a Python build backend such as ``setuptools``. This allows you to stick to 
+those well-established build tools, like ``setuptools``, at the expense
+of more boilerplate Python code and slower build times, since Bazel is
+only invoked to build the bindings extensions (and its dependencies).
+
+In general, while the latter method requires less setup and customization, 
+its drawbacks weigh more severely for large projects with more extensions.
+
+.. note::
+
+    An example of packaging with the mentioned setuptools customization method 
+    can be found in the
+    `nanobind_example <https://github.com/wjakob/nanobind_example/tree/bazel>`__
+    repository, specifically, on the ``bazel`` branch. It also contains an 
+    example of how to customize flag names and set default build options across
+    platforms with a ``.bazelrc`` file.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,6 +111,7 @@ The nanobind logo was designed by `AndoTwin Studio
    installing
    building
    basics
+   bazel
 
 .. toctree::
    :caption: Intermediate
@@ -141,3 +142,4 @@ The nanobind logo was designed by `AndoTwin Studio
    api_core
    api_extra
    api_cmake
+   api_bazel


### PR DESCRIPTION
This is designed to be a better-exposed (re: SEO) doc on how to use nanobind with Bazel, aimed at people who would like to get started with nanobind but do not want to search around reading outside documentation.

Contains sections on declaring the dependency, importing nanobind-bazel's APIs, how to use it in BUILD files, and lastly how to build extensions with Bazel.

Mentions a few noteworthy special points of information, such as constraints on the Bazel version, overriding versions with bzlmod APIs, etc.

-------------------------

This is a first draft, I still need to finish the sections on the APIs and the extension builds themselves.

Happy for comments - especially regarding depth, style, and flow. Ideally (in my opinion), the user should be able to get started by creating (at minimum) a MODULE.bazel and a BUILD file in their project with zero outside clicks.

Also still missing: Python packaging. I don't have a good example of a wheel build with Bazel with C++ extensions in the mix, I could present the setuptools config from the nanobind example, though.