### PR TITLE
fix: add MANIFEST.in for SDist generation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,35 @@
+include *.txt
+include *.yaml
+recursive-include cmake *.cmake
+recursive-include cmake *.py
+recursive-include cmake *.sym
+recursive-include docs *.h
+recursive-include docs *.ipynb
+recursive-include docs *.jpg
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs *.svg
+recursive-include docs *.txt
+recursive-include ext *.conf
+recursive-include ext *.cpp
+recursive-include ext *.h
+recursive-include ext *.in
+recursive-include ext *.md
+recursive-include ext *.natvis
+recursive-include ext *.txt
+recursive-include ext *.yml
+recursive-include include *.h
+recursive-include include *.inl
+recursive-include src *.cpp
+recursive-include src *.h
+recursive-include src *.py
+recursive-include tests *.cpp
+recursive-include tests *.h
+recursive-include tests *.nb
+recursive-include tests *.py
+recursive-include tests *.pyi
+recursive-include tests *.ref
+recursive-include tests *.txt
+include ext/robin_map/LICENSE
+include .gitmodules
+include ext/robin_map/.clang-format

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include *.txt
+include CMakeLists.txt
 include *.yaml
 recursive-include cmake *.cmake
 recursive-include cmake *.py


### PR DESCRIPTION
This is missing. Mostly generated automatically by running `pipx run check-manifest -c`, then minor touchup to make `pipx run check-manifest` pass. (I used embarrassingly used check-manifest instead of check-sdist, which is my tool that works with all backends, due to the fact it can generate a MANIFEST.in due to it's setuptools integration and I'm lazy. Don't tell anyone ;) ).

This fixes `pipx run build`, and building SDists and wheels from SDists in general.

This makes the code saved in #618 even bigger. :D
