### PR TITLE
Use cmake-style path in nanobind_add_stub

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -421,9 +421,9 @@ function (nanobind_add_stub name)
     list(APPEND NB_STUBGEN_OUTPUTS "${ARG_OUTPUT}")
   endif()
 
-  file(TO_CMAKE_PATH ${Python_EXECUTABLE} Python_EXECUTABLE)
+  file(TO_CMAKE_PATH ${Python_EXECUTABLE} NB_Python_EXECUTABLE)
 
-  set(NB_STUBGEN_CMD "${Python_EXECUTABLE}" "${NB_STUBGEN}" ${NB_STUBGEN_ARGS})
+  set(NB_STUBGEN_CMD "${NB_Python_EXECUTABLE}" "${NB_STUBGEN}" ${NB_STUBGEN_ARGS})
 
   if (NOT ARG_INSTALL_TIME)
     add_custom_command(

--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -421,6 +421,8 @@ function (nanobind_add_stub name)
     list(APPEND NB_STUBGEN_OUTPUTS "${ARG_OUTPUT}")
   endif()
 
+  file(TO_CMAKE_PATH ${Python_EXECUTABLE} Python_EXECUTABLE)
+
   set(NB_STUBGEN_CMD "${Python_EXECUTABLE}" "${NB_STUBGEN}" ${NB_STUBGEN_ARGS})
 
   if (NOT ARG_INSTALL_TIME)


### PR DESCRIPTION
The path of Python executable should be converted to cmake-style path to avoid invalid escape sequence.

Otherwise, `NB_STUBGEN_CMD` may contain string like `D:\mambaforge\python.exe` on Windows and will make this line writes incorrect string:
https://github.com/wjakob/nanobind/blob/c5ae2a36a704c1c62da99a81fad919261a3e9848/cmake/nanobind-config.cmake#L446