### PR TITLE
[cmake] include nanobind-config.cmake instead of calling find_package()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,10 +139,7 @@ endif()
 # ---------------------------------------------------------------------------
 # Include nanobind cmake functionality
 # ---------------------------------------------------------------------------
-
-find_package(nanobind
-  PATHS ${CMAKE_CURRENT_SOURCE_DIR}/cmake
-  NO_DEFAULT_PATH)
+include(cmake/nanobind-config.cmake)
 
 if (NB_TEST)
   add_subdirectory(tests)


### PR DESCRIPTION
find_package() is an abstraction to be used to localize a package. When building this project, the same can be achieved by just including the  `cmake/nanobind-config.cmake` file directly.

Especially the current implementation breaks in cases of using CMake dependency providers, where the dependency provider executes an `add_subdirectory` call. In this specific case the find_package leads to an infinite recursion of `find_package(nanobind)` calls.