### PR TITLE
Fix doc typo in `nanobind_add_stubgen`

### DIFF
--- a/docs/api_cmake.rst
+++ b/docs/api_cmake.rst
@@ -458,8 +458,8 @@ Nanobind's CMake tooling includes a convenience command to interface with the
           empty file named ``py.typed`` in each module directory. When this
           parameter is specified, :cmake:command:`nanobind_add_stub` will
           automatically generate such an empty file as well.
-      * - ``PATCH_FILE``
-        - Specify a patch file used to replace declarations in the stub. The
+      * - ``PATTERN_FILE``
+        - Specify a pattern file used to replace declarations in the stub. The
           syntax is described in the section on :ref:`stub generation <stubs>`.
       * - ``COMPONENT``
         - Specify a component when ``INSTALL_TIME`` stub generation is used.


### PR DESCRIPTION
I was trying to use the PATTERN_FILE mechanism to rewrite the type's inferred for c++ `Eigen::` from `numpy.typing.ArrayLike` (which is overly broad) to `numpy.typing.NDArray`.  

While [testing to see if that mechanism](https://github.com/wjakob/nanobind/discussions/630) could work for what I need -- I noticed this documentation bug.

It seems the PATTERN_FILE mechanism won't work for what I need -- but thought I'd file this doc fix anyway.