### PR TITLE
Handle nested class names in stubgen

### DIFF
--- a/tests/py_stub_test.py
+++ b/tests/py_stub_test.py
@@ -30,6 +30,9 @@ def f4() -> typing.Callable[[T], T]:
 class AClass:
     STATIC_VAR: int = 5
 
+    class NestedClass:
+        pass
+
     def __init__(self, x):
         pass
 

--- a/tests/py_stub_test.pyi
+++ b/tests/py_stub_test.pyi
@@ -7,6 +7,9 @@ class AClass:
 
     STATIC_VAR: int = 5
 
+    class NestedClass:
+        pass
+
     def __init__(self, x): ...
 
     def method(self, x: str): ...

--- a/tests/py_stub_test.pyi.ref
+++ b/tests/py_stub_test.pyi.ref
@@ -7,6 +7,9 @@ class AClass:
 
     STATIC_VAR: int = 5
 
+    class NestedClass:
+        pass
+
     def __init__(self, x): ...
 
     def method(self, x: str): ...

--- a/tests/test_typing.cpp
+++ b/tests/test_typing.cpp
@@ -4,6 +4,29 @@
 namespace nb = nanobind;
 using namespace nb::literals;
 
+class NestedClass {};
+
+namespace nanobind {
+namespace detail {
+template <>
+struct type_caster<NestedClass> {
+    NB_TYPE_CASTER(NestedClass, const_name("py_stub_test.AClass.NestedClass"));
+
+    bool from_python(handle /*src*/, uint8_t /*flags*/, cleanup_list*) noexcept {
+        return true;
+    }
+
+    static handle from_cpp(const NestedClass&, rv_policy, cleanup_list*) noexcept {
+        nanobind::object py_class =
+            nanobind::module_::import_("py_stub_test").attr("AClass").attr("NestedClass");
+        nanobind::object py_proto = py_class();
+        py_proto.inc_ref();
+        return py_proto;
+    }
+};
+}
+}
+
 // Declarations of various advanced constructions to test the stub generator
 NB_MODULE(test_typing_ext, m) {
     // A submodule which won't be included, but we must be able to import it
@@ -33,6 +56,8 @@ NB_MODULE(test_typing_ext, m) {
         .def(nb::self >= nb::self);
 
     m.def("f", []{});
+
+    m.def("makeNestedClass", [] { return NestedClass(); });
 
     // Aliases to local functoins and types
     m.attr("FooAlias") = m.attr("Foo");

--- a/tests/test_typing.cpp
+++ b/tests/test_typing.cpp
@@ -19,9 +19,7 @@ struct type_caster<NestedClass> {
     static handle from_cpp(const NestedClass&, rv_policy, cleanup_list*) noexcept {
         nanobind::object py_class =
             nanobind::module_::import_("py_stub_test").attr("AClass").attr("NestedClass");
-        nanobind::object py_proto = py_class();
-        py_proto.inc_ref();
-        return py_proto;
+        return py_class().release();
     }
 };
 }

--- a/tests/test_typing_ext.pyi.ref
+++ b/tests/test_typing_ext.pyi.ref
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+import py_stub_test
 from typing import Generic, Optional, Self, TypeAlias, TypeVar
 
 from . import submodule as submodule
@@ -48,6 +49,8 @@ class WrapperFoo(Wrapper[Foo]):
 def f() -> None: ...
 
 f_alias = f
+
+def makeNestedClass() -> py_stub_test.AClass.NestedClass: ...
 
 pytree: dict = {'a' : ('b', [123])}
 


### PR DESCRIPTION
Correct `stubgen`'s handling of nested types (e.g. a class defined inside another class).

Previously, `stubgen` generated `import` statements in the .pyi file which includes the outer type.

I fix this by testing that the module name in the generated `import` is a module by using `importlib.util.find_spec`. This is the approach [recommended by the python docs](https://docs.python.org/3/library/importlib.html#checking-if-a-module-can-be-imported): "If you need to find out if a module can be imported without actually doing the import, then you should use `importlib.util.find_spec()`."

If `stubgen` is not able to access the referenced module, the new functionality does have a graceful fall-back behavior: if none of the possible partitions of module_name and class_name result in a successful import, it will default to the previous behavior of assuming that just the last segment of the type name is the class name (and the rest is the module name).

This may add some performance overhead from needing to call `importlib.util.find_spec` on each referenced type, but I don't know of another way to handle this nested-type case, unless we rely only on some sort of naming convention to distinguish type names from module names.

A unit test for the nested-type case is included.

Closes #633