### PR TITLE
remove two semicolons (-Wextra-semi ritual purification)

### DIFF
--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -453,7 +453,7 @@ namespace detail {
 template <typename T, typename... Ts>
 class class_ : public object {
 public:
-    NB_OBJECT_DEFAULT(class_, object, "type", PyType_Check);
+    NB_OBJECT_DEFAULT(class_, object, "type", PyType_Check)
     using Type = T;
     using Base  = typename detail::extract<T, detail::is_base,  Ts...>::type;
     using Alias = typename detail::extract<T, detail::is_alias, Ts...>::type;

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -314,7 +314,7 @@ inline void delattr(handle h, handle key) {
 
 class module_ : public object {
 public:
-    NB_OBJECT(module_, object, "types.ModuleType", PyModule_CheckExact);
+    NB_OBJECT(module_, object, "types.ModuleType", PyModule_CheckExact)
 
     template <typename Func, typename... Extra>
     module_ &def(const char *name_, Func &&f, const Extra &...extra);


### PR DESCRIPTION
I read the comment about "ritual purification" in nb_attr.h, but couldn't resist.
(I don't plan more such PRs)