### PR TITLE
Handle print leaks when `inst_c2p` has collisions

### DIFF
--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -243,9 +243,19 @@ static void internals_cleanup() {
             fprintf(stderr, "nanobind: leaked %zu instances!\n",
                     internals->inst_c2p.size());
             #if !defined(Py_LIMITED_API)
-                for (auto [k, v]: internals->inst_c2p) {
+                auto print_leak = [](void* k, PyObject* v) {
                     PyTypeObject *tp = Py_TYPE(v);
                     fprintf(stderr, " - leaked instance %p of type \"%s\"\n", k, tp->tp_name);
+                };
+
+                for (auto [k, v]: internals->inst_c2p) {
+                    if (NB_UNLIKELY(nb_is_seq(v))) {
+                        nb_inst_seq* seq = nb_get_seq(v);
+                        for(; seq != nullptr; seq = seq->next)
+                            print_leak(k, seq->inst);
+                    } else {
+                        print_leak(k, (PyObject*)v);
+                    }
                 }
             #endif
         }


### PR DESCRIPTION
Populating the internals `inst_c2p` map handles the case where there are C++ instance pointer key collisions. This can occur for example when there are several distinct Python objects which reference the same memory address, such as a struct and its first member. In this instance the value within the map becomes a linked-list of type `nb_inst_seq*`.

In the case where there are reported nanobind leaks, there was missing logic to handle the possibility of the values in our `inst_c2p` map being a linked-list and hence this PR adds this additional check.