### PR TITLE
fix memory leak when implicitely converting bytes into ndarray

### DIFF
--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -239,6 +239,7 @@ static PyObject *dlpack_from_buffer_protocol(PyObject *o, bool ro) {
         gil_scoped_acquire guard;
         Py_buffer *buf = (Py_buffer *) mt2->manager_ctx;
         PyBuffer_Release(buf);
+        PyMem_Free(mt2->manager_ctx);
         PyMem_Free(mt2->dltensor.shape);
         PyMem_Free(mt2->dltensor.strides);
         PyMem_Free(mt2);


### PR DESCRIPTION
there is a 80 bytes leak everytime a bytes is implicitely converted into ndarray

```=================================================================
==190==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7fd4e29e961f in malloc (/lib64/libasan.so.8+0xdd61f) (BuildId: 1d5b30c36844ba264ef3e2de667e7a3b01c75e84)
    #1 0x7fd4e2300848 in PyMem_Malloc (/lib64/libpython3.11.so.1.0+0x1dd848) (BuildId: 1c275add58b260eaed423bcf6f89cf5b753a0389)
    #2 0x7fd4e06b2117  (/mnt/docker/.venv/lib64/python3.11/site-packages/mre.cpython-311-x86_64-linux-gnu.so+0x53117) (BuildId: 453c323ff2f76c062da0865a220d35eb8a5b7614)
    #3 0x7fd4e06b4430  (/mnt/docker/.venv/lib64/python3.11/site-packages/mre.cpython-311-x86_64-linux-gnu.so+0x55430) (BuildId: 453c323ff2f76c062da0865a220d35eb8a5b7614)
    #4 0x7fd4e06793d9  (/mnt/docker/.venv/lib64/python3.11/site-packages/mre.cpython-311-x86_64-linux-gnu.so+0x1a3d9) (BuildId: 453c323ff2f76c062da0865a220d35eb8a5b7614)
    #5 0x7fd4e0678a85  (/mnt/docker/.venv/lib64/python3.11/site-packages/mre.cpython-311-x86_64-linux-gnu.so+0x19a85) (BuildId: 453c323ff2f76c062da0865a220d35eb8a5b7614)
    #6 0x7fd4e0678ffb  (/mnt/docker/.venv/lib64/python3.11/site-packages/mre.cpython-311-x86_64-linux-gnu.so+0x19ffb) (BuildId: 453c323ff2f76c062da0865a220d35eb8a5b7614)
    #7 0x7fd4e0689b43  (/mnt/docker/.venv/lib64/python3.11/site-packages/mre.cpython-311-x86_64-linux-gnu.so+0x2ab43) (BuildId: 453c323ff2f76c062da0865a220d35eb8a5b7614)
    #8 0x7fd4e235f712 in PyObject_Vectorcall (/lib64/libpython3.11.so.1.0+0x23c712) (BuildId: 1c275add58b260eaed423bcf6f89cf5b753a0389)

SUMMARY: AddressSanitizer: 80 byte(s) leaked in 1 allocation(s).
```

[reproducer](https://github.com/gdemengin/nanobind/tree/ndarray-leak-mre )