### PR TITLE
Skip ndarray noninteger stride test for numpy<1.23.

### DIFF
--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -686,7 +686,10 @@ def test37_noninteger_stride():
     t.pass_float32(s)
     assert t.get_stride(s, 0) == 6;
     assert t.get_stride(s, 1) == 1;
-    v = s.view(np.complex64)
+    try:
+        v = s.view(np.complex64)
+    except:
+        pytest.skip('your version of numpy is too old')
     t.pass_complex64(v)
     assert t.get_stride(v, 0) == 3;
     assert t.get_stride(v, 1) == 1;


### PR DESCRIPTION
The ndarray test `test37_noninteger_stride` uses numpy to create an array with padding between rows and then uses numpy `view()`  to convert to a complex dtype.   This capability was added in numpy 1.23.  Previously, for this conversion to work, the entire array had to be C-contiguous.

This commit fixes issue #653.

