### PR TITLE
type_caster<char>: allow conversion of "\0" to C++ char

### DIFF
--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -275,12 +275,13 @@ template <> struct type_caster<bool> {
 template <> struct type_caster<char> {
     using Value = const char *;
     Value value;
+    Py_ssize_t size;
     static constexpr auto Name = const_name("str");
     template <typename T_>
     using Cast = std::conditional_t<is_pointer_v<T_>, const char *, char>;
 
     bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
-        value = PyUnicode_AsUTF8AndSize(src.ptr(), nullptr);
+        value = PyUnicode_AsUTF8AndSize(src.ptr(), &size);
         if (!value) {
             PyErr_Clear();
             return false;
@@ -304,7 +305,7 @@ template <> struct type_caster<char> {
 
     template <typename T_>
     NB_INLINE bool can_cast() const noexcept {
-        return std::is_pointer_v<T_> || (value && value[0] && value[1] == '\0');
+        return std::is_pointer_v<T_> || (value && size == 1);
     }
 
     explicit operator const char *() { return value; }

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -388,8 +388,11 @@ def test35_return_capture():
 
 def test36_test_char():
     assert t.test_cast_char("c") == "c"
+    assert t.test_cast_char("\x00") == "\x00"
     with pytest.raises(TypeError):
         assert t.test_cast_char("abc")
+    with pytest.raises(TypeError):
+        assert t.test_cast_char("")
     with pytest.raises(RuntimeError):
         assert t.test_cast_char(123)
 


### PR DESCRIPTION
Fixes #657

Stores the size from `PyUnicode_AsUTF8AndSize()` and checks it in `can_cast<char>`.

I stored the size rather than a boolean is-length-equal-one flag, because the total struct size is the same anyway, and if we'd want to convert 2-byte UTF8 characters (U+0080 - U+00FF) to C++ chars (128-255) in the future, we'll need to check if size==2.