### PR TITLE
nb_cast: Add support for `parent` arg to allow for `reference_internal` rv policy

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1494,6 +1494,15 @@ Casting
 
    The function raises a :cpp:type:`cast_error` when the conversion fails.
 
+.. cpp:function:: template <typename T> object cast(T &&value, rv_policy policy, handle parent)
+
+   Convert the C++ object ``value`` into a Python object. The return value
+   policy `policy` is used to handle ownership-related questions when a new
+   Python object must be created. A valid `parent` object is required when 
+   specifying a `reference_internal` return value policy.
+
+   The function raises a :cpp:type:`cast_error` when the conversion fails.
+
 .. cpp:function:: template <typename T> object find(const T &value) noexcept
 
    Return the Python object associated with the C++ instance `value`. When no

--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -606,6 +606,20 @@ object cast(T &&value, rv_policy policy = rv_policy::automatic_reference) {
     return steal(h);
 }
 
+template <typename T>
+object cast(T &&value, rv_policy policy, handle parent) {
+    detail::cleanup_list cleanup(parent.ptr());
+    handle h = detail::make_caster<T>::from_cpp((detail::forward_t<T>) value,
+                                                policy, &cleanup);
+
+    cleanup.release();
+
+    if (!h.is_valid())
+        detail::raise_cast_error();
+
+    return steal(h);
+}
+
 template <typename T> object find(const T &value) noexcept {
     return steal(detail::make_caster<T>::from_cpp(value, rv_policy::none, nullptr));
 }

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -872,7 +872,7 @@ class StubGen:
             return name
 
         # Rewrite module name if this is relative import from a submodule
-        if module.startswith(self.module.__name__) and module is not self.module.__name__:
+        if module.startswith(self.module.__name__) and module != self.module.__name__:
             module_short = module[len(self.module.__name__) :]
             if not name and as_name and module_short[0] == ".":
                 name = as_name = module_short[1:]


### PR DESCRIPTION
Also small stubgen fix. Need to use != operator for string comparison