### PR TITLE
Update documentation with new nanobind-bazel v2.1.0 functionality

### DIFF
--- a/docs/api_bazel.rst
+++ b/docs/api_bazel.rst
@@ -35,14 +35,46 @@ The main tool to build nanobind extensions is the ``nanobind_extension`` rule.
 
     It corresponds directly to the builtin
     `cc_binary <https://bazel.build/reference/be/c-cpp#cc_binary>`__ rule,
-    with all keyword arguments being directly forwarded to a ``cc_binary`` 
+    with all keyword arguments being directly forwarded to a ``cc_binary``
     target.
 
     The ``domain`` argument can be used to build the target extension under a
     different ABI domain, as described in the :ref:`FAQ <type-visibility>`
     section.
 
-To build a C++ library with nanobind as a dependency, use the 
+To generate typing stubs for an extension, you can use the ``nanobind_stubgen``
+rule.
+
+.. cmake:command:: nanobind_stubgen
+
+    Declares a Bazel target for generating a stub file from a previously
+    built nanobind bindings extension.
+
+    .. code-block:: python
+
+        def nanobind_stubgen(
+            name,
+            module,
+            output_file = None,
+            imports = [],
+            pattern_file = None,
+            marker_file = None,
+            include_private_members = False,
+            exclude_docstrings = False):
+
+    It generates a `py_binary <https://bazel.build/reference/be/
+    python#py_binary>`__ rule with a corresponding runfiles distribution,
+    which invokes nanobind's builtin stubgen script, outputs a stub file and,
+    optionally, a typing marker file into the build
+    output directory (commonly called "bindir" in Bazel terms).
+
+    All arguments (except the name, which is used only to refer to the target
+    in Bazel) correspond directly to nanobind's stubgen command line interface,
+    which is described in more detail in the :ref:`typing documentation <stubs>`.
+
+    *New in nanobind-bazel version 2.1.0.*
+
+To build a C++ library with nanobind as a dependency, use the
 ``nanobind_library`` rule.
 
 .. cmake:command:: nanobind_library
@@ -82,7 +114,7 @@ To build a C++ shared library with nanobind as a dependency, use the
     c-cpp#cc_shared_library>`__ rule, with all keyword arguments being directly
     forwarded to a ``cc_shared_library`` target.
 
-    *New in nanobind-bazel version 2.1.0 (unreleased).*
+    *New in nanobind-bazel version 2.1.0.*
 
 To build a C++ test target requiring nanobind, use the ``nanobind_test`` rule.
 
@@ -107,7 +139,7 @@ To build a C++ test target requiring nanobind, use the ``nanobind_test`` rule.
 Flags
 -----
 
-To customize some of nanobind's build options, nanobind-bazel exposes the 
+To customize some of nanobind's build options, nanobind-bazel exposes the
 following flag settings.
 
 .. cmake:command:: @nanobind_bazel//:minsize (boolean)

--- a/docs/bazel.rst
+++ b/docs/bazel.rst
@@ -28,7 +28,7 @@ in your MODULE.bazel file:
     # The major version of nanobind-bazel is equal to the major version
     # of the internally used nanobind.
     # In this case, we are building bindings with nanobind@v2.
-    bazel_dep(name = "nanobind_bazel", version = "2.0.0")
+    bazel_dep(name = "nanobind_bazel", version = "2.1.0")
 
 To instead use a development version from GitHub, you can declare the
 dependency as a ``git_override()`` in your MODULE.bazel:
@@ -72,7 +72,7 @@ Like all public nanobind-bazel APIs, it resides in the ``build_defs`` submodule.
 To import it into a BUILD file, use the builtin ``load`` command:
 
 .. code-block:: python
-        
+
     # In a BUILD file, e.g. my_project/BUILD
     load("@nanobind_bazel//:build_defs.bzl", "nanobind_extension")
 
@@ -101,8 +101,43 @@ version using the ``@nanobind_bazel//:py-limited-api`` flag. For example,
 to build extensions against the CPython 3.12 stable ABI, pass the option
 ``@nanobind_bazel//:py-limited-api="cp312"`` to your ``bazel build`` command.
 
-For more information about available flags, refer to the flags section in the 
+For more information about available flags, refer to the flags section in the
 :ref:`nanobind-bazel API reference <flags-bazel>`.
+
+Generating stubs for built extensions
+-------------------------------------
+
+You can also use Bazel to generate stubs for an extension directly at build
+time with the ``nanobind_stubgen`` macro. Here is an example of a nanobind
+extension with a stub file generation target declared directly alongside it:
+
+.. code-block:: python
+
+    # Same as before in a BUILD file
+    load(
+        "@nanobind_bazel//:build_defs.bzl",
+        "nanobind_extension",
+        "nanobind_stubgen",
+    )
+
+    nanobind_extension(
+        name = "my_ext",
+        srcs = ["my_ext.cpp"],
+    )
+
+    nanobind_stubgen(
+        name = "my_ext_stubgen",
+        module = ":my_ext",
+    )
+
+You can then generate stubs on an extension by invoking
+``bazel run //my_project:my_ext_stubgen``. Note that this requires actually
+running the target instead of only building it via ``bazel build``, since a
+Python script needs to be executed for stub generation.
+
+Naturally, since stub generation relies on the given shared object files, the
+actual extensions are built in the process before invocation of the stub
+generation script.
 
 nanobind-bazel and Python packaging
 -----------------------------------
@@ -115,26 +150,25 @@ To produce Python wheels containing bindings built with nanobind-bazel,
 you have various options, with two of the most prominent strategies being
 
 1. Using a wheel builder script with the facilities provided by a Bazel
-support package for Python, such as ``py_binary`` or ``py_wheel`` from 
+support package for Python, such as ``py_binary`` or ``py_wheel`` from
 `rules_python <https://github.com/bazelbuild/rules_python/>`__. This is
 a lower-level, more complex workflow, but it provides more granular
 control of how your Python wheel is built.
 
 2. Building all extensions with Bazel through a subprocess, by extending
-a Python build backend such as ``setuptools``. This allows you to stick to 
+a Python build backend such as ``setuptools``. This allows you to stick to
 those well-established build tools, like ``setuptools``, at the expense
 of more boilerplate Python code and slower build times, since Bazel is
-only invoked to build the bindings extensions (and its dependencies).
+only invoked to build the bindings extensions (and their dependencies).
 
-In general, while the latter method requires less setup and customization, 
+In general, while the latter method requires less setup and customization,
 its drawbacks weigh more severely for large projects with more extensions.
 
 .. note::
 
-    An example of packaging with the mentioned setuptools customization method 
+    An example of packaging with the mentioned setuptools customization method
     can be found in the
     `nanobind_example <https://github.com/wjakob/nanobind_example/tree/bazel>`__
-    repository, specifically, on the ``bazel`` branch. It also contains an 
+    repository, specifically, on the ``bazel`` branch. It also contains an
     example of how to customize flag names and set default build options across
     platforms with a ``.bazelrc`` file.
-


### PR DESCRIPTION
Includes stubgen with the `nanobind_stubgen()` macro, shared libraries with `nanobind_shared_library()`, and contains a small prose section on how to declare (and run) stubgen targets alongside nanobind extensions in Bazel.

Also, update all mentions of a BCR version number to v2.1.0 (current latest) to increase adoption of the latest rule version.

-------------------------------

Hi Wenzel, this is the documentation on additions made in nanobind-bazel v2.1.0, which I released to the BCR two weeks ago. Sorry for the delay, I've been in a bit of a productivity hole lately. Happy to hear your thoughts!