### PR TITLE
generalize type_caster<std::optional<T>>

### DIFF
--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -238,19 +238,21 @@ template <> struct type_caster<void> {
     }
 };
 
-template <> struct type_caster<std::nullptr_t> {
+template <typename T> struct none_caster {
     bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
         if (src.is_none())
             return true;
         return false;
     }
 
-    static handle from_cpp(std::nullptr_t, rv_policy, cleanup_list *) noexcept {
+    static handle from_cpp(T, rv_policy, cleanup_list *) noexcept {
         return none().release();
     }
 
-    NB_TYPE_CASTER(std::nullptr_t, const_name("None"))
+    NB_TYPE_CASTER(T, const_name("None"))
 };
+
+template <> struct type_caster<std::nullptr_t> : none_caster<std::nullptr_t> { };
 
 template <> struct type_caster<bool> {
     bool from_python(handle src, uint8_t, cleanup_list *) noexcept {

--- a/include/nanobind/stl/detail/nb_optional.h
+++ b/include/nanobind/stl/detail/nb_optional.h
@@ -1,0 +1,48 @@
+/*
+    nanobind/stl/optional.h: type caster for std::optional<...>
+
+    Copyright (c) 2022 Yoshiki Matsuda and Wenzel Jakob
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename Optional, typename T = typename Optional::value_type>
+struct optional_caster {
+    using Caster = make_caster<T>;
+
+    NB_TYPE_CASTER(Optional, optional_name(Caster::Name))
+
+    bool from_python(handle src, uint8_t flags, cleanup_list* cleanup) noexcept {
+        if (src.is_none())
+            // default-constructed value is already empty
+            return true;
+
+        Caster caster;
+        if (!caster.from_python(src, flags_for_local_caster<T>(flags), cleanup) ||
+            !caster.template can_cast<T>())
+            return false;
+
+        value.emplace(caster.operator cast_t<T>());
+
+        return true;
+    }
+
+    template <typename T_>
+    static handle from_cpp(T_ &&value, rv_policy policy, cleanup_list *cleanup) noexcept {
+        if (!value)
+            return none().release();
+
+        return Caster::from_cpp(forward_like_<T_>(*value), policy, cleanup);
+    }
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/optional.h
+++ b/include/nanobind/stl/optional.h
@@ -21,19 +21,7 @@ template <typename T> struct remove_opt_mono<std::optional<T>>
 template <typename T>
 struct type_caster<std::optional<T>> : optional_caster<std::optional<T>> {};
 
-template <> struct type_caster<std::nullopt_t> {
-    bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
-        if (src.is_none())
-            return true;
-        return false;
-    }
-
-    static handle from_cpp(std::nullopt_t, rv_policy, cleanup_list *) noexcept {
-        return none().release();
-    }
-
-    NB_TYPE_CASTER(std::nullopt_t, const_name("None"))
-};
+template <> struct type_caster<std::nullopt_t> : none_caster<std::nullopt_t> { };
 
 NAMESPACE_END(detail)
 NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/stl/optional.h
+++ b/include/nanobind/stl/optional.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <nanobind/nanobind.h>
+#include "detail/nb_optional.h"
 #include <optional>
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
@@ -17,36 +17,6 @@ NAMESPACE_BEGIN(detail)
 
 template <typename T> struct remove_opt_mono<std::optional<T>>
     : remove_opt_mono<T> { };
-
-template <typename Optional, typename T = typename Optional::value_type>
-struct optional_caster {
-    using Caster = make_caster<T>;
-
-    NB_TYPE_CASTER(Optional, optional_name(Caster::Name))
-
-    bool from_python(handle src, uint8_t flags, cleanup_list* cleanup) noexcept {
-        if (src.is_none())
-            // default-constructed value is already empty
-            return true;
-
-        Caster caster;
-        if (!caster.from_python(src, flags_for_local_caster<T>(flags), cleanup) ||
-            !caster.template can_cast<T>())
-            return false;
-
-        value.emplace(caster.operator cast_t<T>());
-
-        return true;
-    }
-
-    template <typename T_>
-    static handle from_cpp(T_ &&value, rv_policy policy, cleanup_list *cleanup) noexcept {
-        if (!value)
-            return none().release();
-
-        return Caster::from_cpp(forward_like_<T_>(*value), policy, cleanup);
-    }
-};
 
 template <typename T>
 struct type_caster<std::optional<T>> : optional_caster<std::optional<T>> {};

--- a/include/nanobind/stl/variant.h
+++ b/include/nanobind/stl/variant.h
@@ -24,18 +24,7 @@ struct concat_variant<std::variant<Ts1...>, std::variant<Ts2...>, Ts3...>
 template <typename... Ts> struct remove_opt_mono<std::variant<Ts...>>
     : concat_variant<std::conditional_t<std::is_same_v<std::monostate, Ts>, std::variant<>, std::variant<remove_opt_mono_t<Ts>>>...> {};
 
-template <> struct type_caster<std::monostate> {
-    NB_TYPE_CASTER(std::monostate, const_name("None"))
-
-    bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
-        return src.is_none();
-    }
-
-    static handle from_cpp(const std::monostate &, rv_policy,
-                           cleanup_list *) noexcept {
-        return none().release();
-    }
-};
+template <> struct type_caster<std::monostate> : none_caster<std::monostate> { };
 
 template <typename... Ts> struct type_caster<std::variant<Ts...>> {
     NB_TYPE_CASTER(std::variant<Ts...>, union_name(make_caster<Ts>::Name...))


### PR DESCRIPTION
Add `optional_caster<>` that works like in pybind11.
It can be used for type casting optional types other than std::optional:
boost::optional, absl::optional, nonstd::optional, llvm::Optional, etc.

I guess these types are mostly obsolete in C++17, but there still might be a reason to use other such types. In one project I use a custom OptionalInt that has 4 bytes instead of 8 (at the cost of not using INT_MIN).