### PR TITLE
Have type_caster for Eigen::Map create its own temp array

### DIFF
--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -1,4 +1,6 @@
+#include <iostream>
 #include <nanobind/stl/complex.h>
+#include <nanobind/stl/vector.h>
 #include <nanobind/eigen/dense.h>
 #include <nanobind/eigen/sparse.h>
 #include <nanobind/trampoline.h>
@@ -251,5 +253,20 @@ NB_MODULE(test_eigen_ext, m) {
         Eigen::Vector2d input(1.0, 2.0);
         base->modRefDataConst(input);
         return input;
+    });
+
+    using MatXdR = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    using MatRefXdR = Eigen::Ref<const MatXdR>;
+    using Vec_MatRefXdR = std::vector<MatRefXdR>;
+    m.def("printRefs", [](const Vec_MatRefXdR& ms) {
+        std::cout << "[cpp] got matrices:\n";
+        std::cout << ms[0] << "\n----" << std::endl;
+        std::cout << ms[1] << std::endl;
+        // passthrough
+        std::vector<MatXdR> out(ms.size());
+        for (size_t i = 0; i < ms.size(); i++) {
+            out[i] = ms[i];
+        }
+        return out;
     });
 }

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -378,17 +378,19 @@ def test14_single_element():
 
 @needs_numpy_and_eigen
 @pytest.mark.parametrize(("n1", "n2"), [(4, 2), (6, 3), (8, 2)])
-def test15_vec_ref(n1, n2):
-    np.set_printoptions(precision=4, linewidth=200)
+@pytest.mark.parametrize("colMajor", (False, True))
+def test15_vec_ref(n1, n2, colMajor):
+    np.set_printoptions(precision=5, linewidth=200)
     np.random.seed(42)
     a = np.random.randn(n1, 8)
-    a = np.asfortranarray(a)  # column-major
+    if colMajor:
+        a = np.asfortranarray(a)  # column-major
     s1 = a[:n2]
     s2 = a[n2:]
     print("INPUT VALUES AND STRIDES:")
     print(s1, s1.strides)
     print(s2, s2.strides)
     r1, r2 = t.printRefs([s1, s2])
-    np.allclose(s1, r1)
-    np.allclose(s2, r2)
+    assert np.allclose(s1, r1)
+    assert np.allclose(s2, r2)
     

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -374,3 +374,21 @@ def test14_single_element():
     a = np.array([[1]], dtype=np.uint32)
     assert a.ndim == 2 and a.shape == (1, 1)
     t.addMXuCC(a, a)
+
+
+@needs_numpy_and_eigen
+@pytest.mark.parametrize(("n1", "n2"), [(4, 2), (6, 3), (8, 2)])
+def test15_vec_ref(n1, n2):
+    np.set_printoptions(precision=4, linewidth=200)
+    np.random.seed(42)
+    a = np.random.randn(n1, 8)
+    a = np.asfortranarray(a)  # column-major
+    s1 = a[:n2]
+    s2 = a[n2:]
+    print("INPUT VALUES AND STRIDES:")
+    print(s1, s1.strides)
+    print(s2, s2.strides)
+    r1, r2 = t.printRefs([s1, s2])
+    np.allclose(s1, r1)
+    np.allclose(s2, r2)
+    


### PR DESCRIPTION
This PR:
- Has `type_caster<Eigen::Map<...>>` create its own copy of the input `NDArray`
  - with appropriate strides,
  - pointing to data with same lifetime as the function (using the `cleanup_list *cleanup` arg in `from_python`).
  - This will only happen when the inner stride is 1 (maybe we can handle other strides later?), otherwise the caster will return false (`Eigen::Ref` will then dispatch to the `Map` type caster with dynamic strides and rely on its constructor creating an internal copy `Ref::m_object`, which was the previous behaviour)
- adds a test to `test_eigen.cpp|test_eigen.py` which tests a function with argument `std::vector<Eigen::Ref<const VectorXd>>`, which creates a temp copy when an array with the wrong order is given.

Fixes #682 