### PR TITLE
Include stdio.h for vsnprintf in buffer.h

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -2,6 +2,7 @@
 
 #include <string.h>
 #include <stdarg.h>
+#include <stdio.h> // vsnprintf
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)


### PR DESCRIPTION
`vsnprintf` is defined in `stdio.h`:
https://github.com/bminor/glibc/blob/734e7f91e752f44984fe42c2384c23a0290b6e56/libio/stdio.h#L389

All the examples include both `stdio.h` and `stdarg.h` when using `vsnprintf`. For whatever reason, on the emscripten target there is an error due to missing `vsnprintf` but on other targets there is no error.