### PR TITLE
Add leak/implicit_cast warnings getters

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -2734,6 +2734,15 @@ The documentation below refers to two per-instance flags with the following mean
 Global flags
 ------------
 
+.. cpp:function:: bool leak_warnings() noexcept
+
+   Returns whether nanobind warns if any nanobind instances, types, or
+   functions are still alive when the Python interpreter shuts down.
+
+.. cpp:function:: bool implicit_cast_warnings() noexcept
+
+   Returns whether nanobind warns if an implicit conversion was not successful.
+
 .. cpp:function:: void set_leak_warnings(bool value) noexcept
 
    By default, nanobind loudly complains when any nanobind instances, types, or

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -524,6 +524,8 @@ NB_CORE void decref_checked(PyObject *o) noexcept;
 
 // ========================================================================
 
+NB_CORE bool leak_warnings() noexcept;
+NB_CORE bool implicit_cast_warnings() noexcept;
 NB_CORE void set_leak_warnings(bool value) noexcept;
 NB_CORE void set_implicit_cast_warnings(bool value) noexcept;
 

--- a/include/nanobind/nb_misc.h
+++ b/include/nanobind/nb_misc.h
@@ -31,6 +31,14 @@ private:
     PyThreadState *state;
 };
 
+inline bool leak_warnings() noexcept {
+    return detail::leak_warnings();
+}
+
+inline bool implicit_cast_warnings() noexcept {
+    return detail::implicit_cast_warnings();
+}
+
 inline void set_leak_warnings(bool value) noexcept {
     detail::set_leak_warnings(value);
 }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1084,6 +1084,14 @@ void decref_checked(PyObject *o) noexcept {
 
 // ========================================================================
 
+bool leak_warnings() noexcept {
+    return internals->print_leak_warnings;
+}
+
+bool implicit_cast_warnings() noexcept {
+    return internals->print_implicit_cast_warnings;
+}
+
 void set_leak_warnings(bool value) noexcept {
     internals->print_leak_warnings = value;
 }


### PR DESCRIPTION
Can be useful to check the state of these internal nanobind properties if for instance you only want to temporarily disable the warnings in your project and then restore the original state.