### PR TITLE
Up to 2x faster instance construction using type vector calls

### DIFF
--- a/cmake/darwin-ld-cpython.sym
+++ b/cmake/darwin-ld-cpython.sym
@@ -899,3 +899,4 @@
 -U __Py_SwappedOp
 -U __Py_TrueStruct
 -U __Py_VaBuildValue_SizeT
+-U _Py_Version

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,11 +15,25 @@ case, both modules must use the same nanobind ABI version, or they will be
 isolated from each other. Releases that don't explicitly mention an ABI version
 below inherit that of the preceding release.
 
-Version 2.1.1 (TBA)
+Version 2.2.0 (TBA)
 -------------------
+
+- nanobind has always used `PEP 590 vector calls
+  <https://www.python.org/dev/peps/pep-0590>`__ to efficiently dispatch calls
+  to function and method bindings, but it lacked the ability to do so for
+  constructors (e.g., ``MyType(arg1, arg2, ...)``).
+
+  Version 2.2.0 adds this missing part, which accelerates object construction
+  by up to a factor of 2×. The difference is especially pronounced when passing
+  keyword arguments to constructors. Note that this feature is only supported
+  on Python 3.9+ and when building non-stable ABI extensions. If CPython PR
+  #123332 <https://github.com/python/cpython/pull/123332>`__ is accepted, this
+  fast path might also become available in the stable ABI on Python 3.14+.
 
 * Added the :cpp:class:`bytearray` wrapper type. (PR `#654
   <https://github.com/wjakob/nanobind/pull/654>`__)
+
+* ABI version 15.
 
 
 Version 2.1.0 (Aug 11, 2024)

--- a/docs/meson.rst
+++ b/docs/meson.rst
@@ -34,7 +34,7 @@ pyproject.toml file:
    requires = ['meson-python']
 
    build-backend = 'mesonpy'
-   
+
 In your project root, you will also want to create the subprojects folder
 that Meson can install into. Then you will need to install the wrap packages
 for both nanobind and robin-map:

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -58,16 +58,10 @@ enum class type_flags : uint32_t {
     /// The class implements __class_getitem__ similar to typing.Generic
     is_generic               = (1 << 15),
 
-    /// Is this an arithmetic enumeration?
-    is_arithmetic            = (1 << 16),
-
-    /// Is the number type underlying the enumeration signed?
-    is_signed                = (1 << 17),
-
     /// Does the type implement a custom __new__ operator?
-    has_new                  = (1 << 18)
+    has_new                  = (1 << 16)
 
-    // No more bits bits available without needing a larger reorganization
+    // Two more bits bits available without needing a larger reorganization
 };
 
 /// Flags about a type that are only relevant when it is being created.
@@ -192,6 +186,14 @@ NB_INLINE void type_extra_apply(type_init_data &t, supplement<T>) {
     t.supplement = sizeof(T);
 }
 
+enum class enum_flags : uint32_t {
+    /// Is this an arithmetic enumeration?
+    is_arithmetic            = (1 << 1),
+
+    /// Is the number type underlying the enumeration signed?
+    is_signed                = (1 << 2)
+};
+
 struct enum_init_data {
     const std::type_info *type;
     PyObject *scope;
@@ -201,7 +203,7 @@ struct enum_init_data {
 };
 
 NB_INLINE void enum_extra_apply(enum_init_data &e, is_arithmetic) {
-    e.flags |= (uint32_t) type_flags::is_arithmetic;
+    e.flags |= (uint32_t) enum_flags::is_arithmetic;
 }
 
 NB_INLINE void enum_extra_apply(enum_init_data &e, const char *doc) {
@@ -719,7 +721,7 @@ public:
         ed.scope = scope.ptr();
         ed.name = name;
         ed.flags = std::is_signed_v<Underlying>
-                       ? (uint32_t) detail::type_flags::is_signed
+                       ? (uint32_t) detail::enum_flags::is_signed
                        : 0;
         (detail::enum_extra_apply(ed, extra), ...);
         m_ptr = detail::enum_create(&ed);

--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -27,7 +27,7 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
 
     handle scope(ed->scope);
 
-    bool is_arithmetic = ed->flags & (uint32_t) type_flags::is_arithmetic;
+    bool is_arithmetic = ed->flags & (uint32_t) enum_flags::is_arithmetic;
 
     str name(ed->name), qualname = name;
     object modname;
@@ -99,7 +99,7 @@ void enum_append(PyObject *tp_, const char *name_, int64_t value_,
     type_data *t = enum_get_type_data(tp);
 
     object val;
-    if (t->flags & (uint32_t) type_flags::is_signed)
+    if (t->flags & (uint32_t) enum_flags::is_signed)
         val = steal(PyLong_FromLongLong((long long) value_));
     else
         val = steal(PyLong_FromUnsignedLongLong((unsigned long long) value_));
@@ -161,7 +161,7 @@ bool enum_from_python(const std::type_info *tp, PyObject *o, int64_t *out, uint8
     if (flags & (uint8_t) cast_flags::convert) {
         enum_map *fwd = (enum_map *) t->enum_tbl.fwd;
 
-        if (t->flags & (uint32_t) type_flags::is_signed) {
+        if (t->flags & (uint32_t) enum_flags::is_signed) {
             long long value = PyLong_AsLongLong(o);
             if (value == -1 && PyErr_Occurred()) {
                 PyErr_Clear();
@@ -204,7 +204,7 @@ PyObject *enum_from_cpp(const std::type_info *tp, int64_t key) noexcept {
         return value;
     }
 
-    if (t->flags & (uint32_t) type_flags::is_signed)
+    if (t->flags & (uint32_t) enum_flags::is_signed)
         PyErr_Format(PyExc_ValueError, "%lli is not a valid %s.",
                      (long long) key, t->name);
     else

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -17,7 +17,7 @@
 
 /// Tracks the ABI of nanobind
 #ifndef NB_INTERNALS_VERSION
-#  define NB_INTERNALS_VERSION 14
+#  define NB_INTERNALS_VERSION 15
 #endif
 
 /// On MSVC, debug and release builds are not ABI-compatible!

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -887,3 +887,7 @@ def test46_custom_new():
 
     with pytest.raises(RuntimeError):
         t.UniqueInt.__new__(int)
+
+def test47_inconstructible():
+    with pytest.raises(TypeError, match="no constructor defined"):
+        t.Foo()


### PR DESCRIPTION
nanobind has always used [PEP 590 vector calls](https://www.python.org/dev/peps/pep-0590) to efficiently dispatch calls to function and method bindings, but it lacked the ability to do so for instance constructors (e.g., ``MyType(arg1, arg2, ...)``).

Version 2.2.0 adds this missing part, which accelerates object construction by up to a factor of 2×. The difference is especially pronounced when passing keyword arguments to constructors. Note that this feature is only supported on Python 3.9+ and when building non-stable ABI extensions. If CPython PR [#123332](https://github.com/python/cpython/pull/123332) is accepted, this fast path might also become available in the stable ABI on Python 3.14+.
