### PR TITLE
Move Bazel API defs into Python domain

### DIFF
--- a/docs/api_bazel.rst
+++ b/docs/api_bazel.rst
@@ -17,7 +17,7 @@ corresponding builtin Bazel rule producing the equivalent C++ target.
 
 The main tool to build nanobind extensions is the ``nanobind_extension`` rule.
 
-.. cmake:command:: nanobind_extension
+.. py:function:: nanobind_extension
 
     Declares a Bazel target representing a nanobind extension, which contains
     the Python bindings of your C++ code.
@@ -45,7 +45,7 @@ The main tool to build nanobind extensions is the ``nanobind_extension`` rule.
 To generate typing stubs for an extension, you can use the ``nanobind_stubgen``
 rule.
 
-.. cmake:command:: nanobind_stubgen
+.. py:function:: nanobind_stubgen
 
     Declares a Bazel target for generating a stub file from a previously
     built nanobind bindings extension.
@@ -77,7 +77,7 @@ rule.
 To build a C++ library with nanobind as a dependency, use the
 ``nanobind_library`` rule.
 
-.. cmake:command:: nanobind_library
+.. py:function:: nanobind_library
 
     Declares a Bazel target representing a C++ library depending on nanobind.
 
@@ -97,7 +97,7 @@ To build a C++ library with nanobind as a dependency, use the
 To build a C++ shared library with nanobind as a dependency, use the
 ``nanobind_shared_library`` rule.
 
-.. cmake:command:: nanobind_shared_library
+.. py:function:: nanobind_shared_library
 
     Declares a Bazel target representing a C++ shared library depending on
     nanobind.
@@ -118,7 +118,7 @@ To build a C++ shared library with nanobind as a dependency, use the
 
 To build a C++ test target requiring nanobind, use the ``nanobind_test`` rule.
 
-.. cmake:command:: nanobind_test
+.. py:function:: nanobind_test
 
     Declares a Bazel target representing a C++ test depending on nanobind.
 
@@ -142,14 +142,14 @@ Flags
 To customize some of nanobind's build options, nanobind-bazel exposes the
 following flag settings.
 
-.. cmake:command:: @nanobind_bazel//:minsize (boolean)
+.. py:function:: @nanobind_bazel//:minsize (boolean)
 
     Apply nanobind's size optimizations to the built extensions. Size
     optimizations are turned on by default, similarly to the CMake build.
     To turn off size optimizations, you can use the shorthand notation
     ``--no@nanobind_bazel//:minsize``.
 
-.. cmake:command:: @nanobind_bazel//:py-limited-api (string)
+.. py:function:: @nanobind_bazel//:py-limited-api (string)
 
     Build nanobind extensions against the stable ABI of the configured Python
     version. Allowed values are ``"cp312"``, ``"cp313"``, which target the

--- a/docs/bazel.rst
+++ b/docs/bazel.rst
@@ -66,7 +66,7 @@ Declaring and building nanobind extension targets
 -------------------------------------------------
 
 The main tool to build nanobind C++ extensions for your Python bindings is the
-:cmake:command:`nanobind_extension` rule.
+:py:func:`nanobind_extension` rule.
 
 Like all public nanobind-bazel APIs, it resides in the ``build_defs`` submodule.
 To import it into a BUILD file, use the builtin ``load`` command:


### PR DESCRIPTION
This is a hack since there is no Bazel domain provider available on PyPI, but it does seem to work since Starlark is a true subset of Python, and we do not have any classes or module structure to take care of.

Solves the unlucky collision of `nanobind_extension` between the CMake and Bazel docs that previously broke cross-referencing.

----------------------------

My Sphinx build logs on this branch no longer show a collision:

```
~/Workspaces/c++/nanobind move-bazel-apis-to-py-domain*
.venv ➜ sphinx-build docs docbuild -a
Running Sphinx v6.1.3
loading pickled environment... done
building [mo]: all of 0 po files
writing output...
building [html]: all source files
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] bazel
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] why
/Users/nicholasjunge/Workspaces/c++/nanobind/docs/changelog.rst:283: WARNING: cpp:func targets a class (nanobind::ndarray).
generating indices... genindex done
writing additional pages... search done
copying images... [100%] images/wrapper-dark.svg
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 1 warning.

The HTML pages are in docbuild.
```

Clicking through the built HTML in the browser shows me that the new nanobind_extension ref works.