### PR TITLE
Fix extraction of class name with new parameter syntax

### DIFF
--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -810,11 +810,16 @@ NB_NOINLINE char *extract_name(const char *cmd, const char *prefix, const char *
           cmd, s, prefix);
     p += prefix_len;
 
-    // Find the opening parenthesis
+    // Find the opening parenthesis or bracket
     const char *p2 = strchr(p, '(');
+    const char *p3 = strchr(p, '[');
+    if (p2 == nullptr)
+        p2 = p3;
+    else if (p3 != nullptr)
+        p2 = p2 < p3 ? p2 : p3;
     check(p2 != nullptr,
           "%s(): last line of custom signature \"%s\" must contain an opening "
-          "parenthesis (\"(\")!", cmd, s);
+          "parenthesis (\"(\") or bracket (\"[\")!", cmd, s);
 
     // A few sanity checks
     size_t len = strlen(p);

--- a/tests/test_typing.cpp
+++ b/tests/test_typing.cpp
@@ -104,6 +104,13 @@ NB_MODULE(test_typing_ext, m) {
     nb::class_<WrapperFoo>(m, "WrapperFoo", wrapper[nb::type<Foo>()]);
 #endif
 
+    // Type parameter syntax for Python 3.12+
+    struct WrapperTypeParam { };
+    nb::class_<WrapperTypeParam>(m, "WrapperTypeParam",
+                                 nb::sig("class WrapperTypeParam[T]"));
+    m.def("list_front", [](nb::list l) { return l[0]; },
+          nb::sig("def list_front[T](arg: list[T], /) -> T"));
+
     // Some statements that will be modified by the pattern file
     m.def("remove_me", []{});
     m.def("tweak_me", [](nb::object o) { return o; }, "prior docstring\nremains preserved");

--- a/tests/test_typing_ext.pyi.ref
+++ b/tests/test_typing_ext.pyi.ref
@@ -46,9 +46,14 @@ class Wrapper(Generic[T]):
 class WrapperFoo(Wrapper[Foo]):
     pass
 
+class WrapperTypeParam[T]:
+    pass
+
 def f() -> None: ...
 
 f_alias = f
+
+def list_front[T](arg: list[T], /) -> T: ...
 
 def makeNestedClass() -> py_stub_test.AClass.NestedClass: ...
 


### PR DESCRIPTION
I found that a compilation error occurs when the [new parameter syntax for generics](https://docs.python.org/3.12/reference/compound_stmts.html#type-params) is used as a signature. 
 
This fix adds the searching for `[` to the `extract_name` function.