### PR TITLE
Vector calls for type objects (now even in the limited API!)

### DIFF
--- a/cmake/darwin-ld-cpython.sym
+++ b/cmake/darwin-ld-cpython.sym
@@ -676,6 +676,7 @@
 -U _PyType_Modified
 -U _PyType_Ready
 -U _PyType_Type
+-U _PyType_GetTypeDataSize
 -U _PyUnicodeDecodeError_Create
 -U _PyUnicodeDecodeError_GetEncoding
 -U _PyUnicodeDecodeError_GetEnd

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,9 +26,7 @@ Version 2.2.0 (TBA)
   Version 2.2.0 adds this missing part, which accelerates object construction
   by up to a factor of 2×. The difference is especially pronounced when passing
   keyword arguments to constructors. Note that this feature is only supported
-  on Python 3.9+ and when building non-stable ABI extensions. If CPython PR
-  #123332 <https://github.com/python/cpython/pull/123332>`__ is accepted, this
-  fast path might also become available in the stable ABI on Python 3.14+.
+  on Python 3.9+.
 
 * Added the :cpp:class:`bytearray` wrapper type. (PR `#654
   <https://github.com/wjakob/nanobind/pull/654>`__)

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -99,6 +99,9 @@ struct type_data {
     const std::type_info *type;
     PyTypeObject *type_py;
     nb_alias_chain *alias_chain;
+#if defined(Py_LIMITED_API)
+    PyObject* (*vectorcall)(PyObject *, PyObject * const*, size_t, PyObject *);
+#endif
     void *init; // Constructor nb_func
     void (*destruct)(void *);
     void (*copy)(void *, const void *);

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -406,6 +406,26 @@ NB_NOINLINE void init(const char *name) {
         (descrgetfunc) PyType_GetSlot(&PyProperty_Type, Py_tp_descr_get);
     p->PyProperty_Type_tp_descr_set =
         (descrsetfunc) PyType_GetSlot(&PyProperty_Type, Py_tp_descr_set);
+
+    PyType_Slot dummy_slots[] = {
+        { Py_tp_base, &PyType_Type },
+        { 0, nullptr }
+    };
+
+    PyType_Spec dummy_spec = {
+        /* .name = */ "nanobind.dummy",
+        /* .basicsize = */ - (int) sizeof(void*),
+        /* .itemsize = */ 0,
+        /* .flags = */ Py_TPFLAGS_DEFAULT,
+        /* .slots = */ dummy_slots
+    };
+
+    // Determine the offset, at which types defined by nanobind begin
+    PyObject *dummy = PyType_FromMetaclass(
+        p->nb_meta, p->nb_module, &dummy_spec, nullptr);
+    p->type_data_offset =
+        (uint8_t *) PyObject_GetTypeData(dummy, p->nb_meta) - (uint8_t *) dummy;
+    Py_DECREF(dummy);
 #endif
 
     p->translators = { default_exception_translator, nullptr, nullptr };

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -268,6 +268,7 @@ struct nb_internals {
     setattrofunc PyType_Type_tp_setattro;
     descrgetfunc PyProperty_Type_tp_descr_get;
     descrsetfunc PyProperty_Type_tp_descr_set;
+    size_t type_data_offset;
 #endif
 };
 


### PR DESCRIPTION
Commit 7225e070 introduced the ability to construct types using vector calls, which can significantly improve performance. Unfortunately, the original implementation did not work in the limited API / stable ABI since it does not expose the ``tp_vectorcall`` member of ``PyTypeObject``. This commit fixes the issue by installing the vector call capability one level higher up at the metaclass level.