### PR TITLE
Fix py_stub_test dependency in out-of-source builds

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,14 +85,6 @@ foreach (NAME functions classes ndarray stl enum typing make_iterator)
     ${EXTRA})
 endforeach()
 
-nanobind_add_stub(
-  py_stub
-  MODULE py_stub_test
-  OUTPUT ${PYI_PREFIX}py_stub_test.pyi
-  PYTHON_PATH $<TARGET_FILE_DIR:test_stl_ext>
-  DEPENDS py_stub_test.py
-)
-
 find_package (Eigen3 3.3.1 NO_MODULE)
 if (TARGET Eigen3::Eigen)
   nanobind_add_module(test_eigen_ext test_eigen.cpp ${NB_EXTRA_ARGS})
@@ -147,6 +139,7 @@ set(TEST_FILES
   py_stub_test.pyi.ref
 )
 
+set (PY_STUB_TEST py_stub_test.py)
 if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR) OR MSVC)
   if (CMAKE_CONFIGURATION_TYPES)
     set(OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
@@ -164,4 +157,13 @@ if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR) OR MSVC)
   endforeach()
 
   add_custom_target(copy-tests ALL DEPENDS ${TEST_FILES_OUT})
+  set(PY_STUB_TEST ${OUT_DIR}/py_stub_test.py)
 endif()
+
+nanobind_add_stub(
+  py_stub
+  MODULE py_stub_test
+  OUTPUT ${PYI_PREFIX}py_stub_test.pyi
+  PYTHON_PATH $<TARGET_FILE_DIR:test_stl_ext>
+  DEPENDS ${PY_STUB_TEST}
+)


### PR DESCRIPTION
Fix the dependency between py_stub stubgen invocation and `py_stub_test.py` source file when building out of source. Previously, the dependency would be on the original file in the source directory rather than the one copied to build directory, which could lead to stubgen being invoked prior to it being copied and therefore failing to import it.