### PR TITLE
Decide whether to lock function arguments at compile time

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1616,7 +1616,9 @@ parameter of :cpp:func:`module_::def`, :cpp:func:`class_::def`,
 
    .. cpp:function:: template <typename T> arg_v operator=(T &&value) const
 
-      Assign a default value to the argument.
+      Return an argument annotation that is like this one but also assigns a
+      default value to the argument. The default will be converted into a Python
+      object immediately, so its bindings must have already been defined.
 
    .. cpp:function:: arg &none(bool value = true)
 
@@ -1638,14 +1640,11 @@ parameter of :cpp:func:`module_::def`, :cpp:func:`class_::def`,
       explain it in docstrings and stubs (``str(value)``) does not produce
       acceptable output.
 
-   .. cpp:function:: arg_locked &lock()
+   .. cpp:function:: arg_locked lock()
 
-      Set a flag noting that this argument must be locked when dispatching a
-      function call in free-threaded Python extensions. It does nothing in
-      regular GIL-protected extensions. In order to allow nanobind to detect
-      statically whether any arguments are being locked, this method does not
-      take a parameter, so it is not possible to decide at runtime whether an
-      argument should be locked or not.
+      Return an argument annotation that is like this one but also requests that
+      this argument be locked when dispatching a function call in free-threaded
+      Python extensions. It does nothing in regular GIL-protected extensions.
 
 .. cpp:struct:: is_method
 

--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1638,11 +1638,14 @@ parameter of :cpp:func:`module_::def`, :cpp:func:`class_::def`,
       explain it in docstrings and stubs (``str(value)``) does not produce
       acceptable output.
 
-   .. cpp:function:: arg &lock(bool value = true)
+   .. cpp:function:: arg_locked &lock()
 
       Set a flag noting that this argument must be locked when dispatching a
       function call in free-threaded Python extensions. It does nothing in
-      regular GIL-protected extensions.
+      regular GIL-protected extensions. In order to allow nanobind to detect
+      statically whether any arguments are being locked, this method does not
+      take a parameter, so it is not possible to decide at runtime whether an
+      argument should be locked or not.
 
 .. cpp:struct:: is_method
 

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -390,6 +390,7 @@ NB_INLINE void func_extra_apply(F &f, nanobind::keep_alive<Nurse, Patient>, size
 template <typename... Ts> struct func_extra_info {
     using call_guard = void;
     static constexpr bool keep_alive = false;
+    static constexpr size_t nargs_locked = 0;
 };
 
 template <typename T, typename... Ts> struct func_extra_info<T, Ts...>
@@ -405,6 +406,16 @@ struct func_extra_info<nanobind::call_guard<Cs...>, Ts...> : func_extra_info<Ts.
 template <size_t Nurse, size_t Patient, typename... Ts>
 struct func_extra_info<nanobind::keep_alive<Nurse, Patient>, Ts...> : func_extra_info<Ts...> {
     static constexpr bool keep_alive = true;
+};
+
+template <typename... Ts>
+struct func_extra_info<nanobind::arg_locked, Ts...> : func_extra_info<Ts...> {
+    static constexpr size_t nargs_locked = 1 + func_extra_info<Ts...>::nargs_locked;
+};
+
+template <typename... Ts>
+struct func_extra_info<nanobind::lock_self, Ts...> : func_extra_info<Ts...> {
+    static constexpr size_t nargs_locked = 1 + func_extra_info<Ts...>::nargs_locked;
 };
 
 template <typename T>

--- a/include/nanobind/nb_call.h
+++ b/include/nanobind/nb_call.h
@@ -35,6 +35,9 @@ args_proxy api<Derived>::operator*() const {
 template <typename T>
 NB_INLINE void call_analyze(size_t &nargs, size_t &nkwargs, const T &value) {
     using D = std::decay_t<T>;
+    static_assert(!std::is_base_of_v<arg_locked, D>,
+                  "nb::arg().lock() may be used only when defining functions, "
+                  "not when calling them");
 
     if constexpr (std::is_same_v<D, arg_v>)
         nkwargs++;

--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -633,6 +633,9 @@ tuple make_tuple(Args &&...args) {
 template <typename T> arg_v arg::operator=(T &&value) const {
     return arg_v(*this, cast((detail::forward_t<T>) value));
 }
+template <typename T> arg_locked_v arg_locked::operator=(T &&value) const {
+    return arg_locked_v(*this, cast((detail::forward_t<T>) value));
+}
 
 template <typename Impl> template <typename T>
 detail::accessor<Impl>& detail::accessor<Impl>::operator=(T &&value) {

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -111,9 +111,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
     // Determine the number of potentially-locked function arguments
     constexpr bool lock_self_det =
         (std::is_same_v<lock_self, Extra> + ... + 0) != 0;
-    constexpr size_t nargs_locked =
-        (std::is_base_of_v<arg_locked, Extra> + ... + 0) + lock_self_det;
-    static_assert(nargs_locked <= 2,
+    static_assert(Info::nargs_locked <= 2,
         "At most two function arguments can be locked");
     static_assert(!(lock_self_det && !is_method_det),
         "The nb::lock_self() annotation only applies to methods");
@@ -232,7 +230,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
         tuple<make_caster<Args>...> in;
         (void) in;
 
-        ft_args_guard<nargs_locked != 0> guard;
+        ft_args_guard<Info::nargs_locked != 0> guard;
         if constexpr (decltype(guard)::enabled) {
             ft_args_collector collector{args};
             if constexpr (is_method_det) {

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -112,8 +112,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
     constexpr bool lock_self_det =
         (std::is_same_v<lock_self, Extra> + ... + 0) != 0;
     constexpr size_t nargs_locked =
-        ((std::is_base_of_v<arg_locked, Extra> +
-          std::is_same_v<lock_self, Extra>) + ... + 0);
+        (std::is_base_of_v<arg_locked, Extra> + ... + 0) + lock_self_det;
     static_assert(nargs_locked <= 2,
         "At most two function arguments can be locked");
     static_assert(!(lock_self_det && !is_method_det),

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -187,50 +187,6 @@ char *strdup_check(const char *s) {
     return result;
 }
 
-#if defined(NB_FREE_THREADED)
-// Locked function wrapper for free-threaded Python
-struct locked_func {
-    void *capture[3];
-    size_t nargs;
-    PyObject *(*impl)(void *, PyObject **, uint8_t *, rv_policy,
-                      cleanup_list *);
-    void (*free_capture)(void *);
-};
-
-static void locked_func_free(void *p) {
-    locked_func *f = (locked_func *) ((void **) p)[0];
-    if (f->free_capture)
-        f->free_capture(f->capture);
-    PyMem_Free(f);
-}
-
-static PyObject *locked_func_impl(void *p, PyObject **args, uint8_t *args_flags,
-                                  rv_policy policy, cleanup_list *cleanup) {
-    handle h1, h2;
-    size_t ctr = 0;
-
-    locked_func *f = (locked_func *) ((void **) p)[0];
-
-    for (size_t i = 0; i < f->nargs; ++i) {
-        if (args_flags[i] & (uint8_t) cast_flags::lock) {
-            if (ctr == 0)
-                h1 = args[i];
-            h2 = args[i];
-            ctr++;
-        }
-    }
-
-#if !defined(NDEBUG)
-    // nb_func_new ensured that at most two arguments are locked, but
-    // can't hurt to check once more in debug builds
-    check(ctr == 1 || ctr == 2, "locked_call: expected 1 or 2 locked arguments!");
-#endif
-
-    ft_object2_guard guard(h1, h2);
-    return f->impl(f->capture, args, args_flags, policy, cleanup);
-}
-#endif
-
 /**
  * \brief Wrap a C++ function into a Python function object
  *
@@ -249,7 +205,6 @@ PyObject *nb_func_new(const void *in_) noexcept {
          is_implicit    = f->flags & (uint32_t) func_flags::is_implicit,
          is_method      = f->flags & (uint32_t) func_flags::is_method,
          return_ref     = f->flags & (uint32_t) func_flags::return_ref,
-         lock_self      = f->flags & (uint32_t) func_flags::lock_self,
          is_constructor = false,
          is_init        = false,
          is_new         = false,
@@ -423,7 +378,6 @@ PyObject *nb_func_new(const void *in_) noexcept {
         }
     }
 
-    size_t lock_count = 0;
     if (has_args) {
         fc->args = (arg_data *) malloc_check(sizeof(arg_data) * f->nargs);
 
@@ -442,54 +396,10 @@ PyObject *nb_func_new(const void *in_) noexcept {
             }
             if (a.value == Py_None)
                 a.flag |= (uint8_t) cast_flags::accepts_none;
-            if (a.flag & (uint8_t) cast_flags::lock)
-                lock_count++;
             a.signature = a.signature ? strdup_check(a.signature) : nullptr;
             Py_XINCREF(a.value);
         }
     }
-
-    if (lock_self) {
-        check(is_method && !is_init,
-              "nb::detail::nb_func_new(\"%s\"): the nb::lock_self annotation only "
-              "applies to regular methods.", name_cstr);
-
-#if defined(NB_FREE_THREADED)
-        // Must potentially allocate dummy 'args' if 'lock_self' is set
-        if (!has_args) {
-            fc->args = (arg_data *) malloc_check(sizeof(arg_data) * f->nargs);
-            memset(fc->args, 0, sizeof(arg_data) * f->nargs);
-            for (uint32_t i = 1; i < f->nargs; ++i)
-                fc->args[i].flag &= (uint8_t) cast_flags::convert;
-            func->vectorcall = nb_func_vectorcall_complex;
-            fc->flags |= (uint32_t) func_flags::has_args;
-            has_args = true;
-        }
-
-        fc->args[0].flag |= (uint8_t) cast_flags::lock;
-#endif
-
-        lock_count++;
-    }
-
-    check(lock_count <= 2,
-          "nb::detail::nb_func_new(\"%s\"): at most two function arguments can "
-          "be locked.", name_cstr);
-
-#if defined(NB_FREE_THREADED)
-    if (lock_count) {
-        locked_func *lf = (locked_func *) PyMem_Malloc(sizeof(locked_func));
-        check(lf, "nb::detail::nb_func_new(\"%s\"): locked function alloc. failed.", name_cstr);
-        memcpy(lf->capture, fc->capture, sizeof(func_data::capture));
-        lf->nargs = fc->nargs;
-        lf->impl = fc->impl;
-        lf->free_capture = (fc->flags & (uint32_t) func_flags::has_free) ? fc->free_capture : nullptr;
-        fc->impl = locked_func_impl;
-        fc->free_capture = locked_func_free;
-        fc->flags |= (uint32_t) func_flags::has_free;
-        fc->capture[0] = lf;
-    }
-#endif
 
     // Fast path for vector call object construction
     if (((is_init && is_method) || (is_new && !is_method)) &&


### PR DESCRIPTION
An attempt at the static locking determination that I suggested in https://github.com/wjakob/nanobind/pull/695#discussion_r1752419034. Note this PR is against the free-threaded branch.

Behavior differences from the free-threaded branch without this change:
* it is no longer possible to do `nb::arg().lock(false)` or `.lock(runtime_determined_value)`; this could be re-added by restoring `cast_flags::lock` and checking the `arg_flags` at runtime, but I didn't think it was worth the complexity
* we no longer prohibit locking self in `__init__`; changing this would also require restoring `cast_flags::lock`, and it's not clear what benefit it would have (sure the lock is somewhat superfluous but do we really care?)