### PR TITLE
bind_map and bind_vector: add sig to __eq__ and __ne__

### DIFF
--- a/include/nanobind/stl/bind_map.h
+++ b/include/nanobind/stl/bind_map.h
@@ -129,8 +129,8 @@ class_<Map> bind_map(handle scope, const char *name, Args &&...args) {
     }
 
     if constexpr (detail::is_equality_comparable_v<Map>) {
-        cl.def(self == self)
-          .def(self != self);
+        cl.def(self == self, sig("def __eq__(self, arg: object, /) -> bool"))
+          .def(self != self, sig("def __ne__(self, arg: object, /) -> bool"));
     }
 
     // Item, value, and key views

--- a/include/nanobind/stl/bind_vector.h
+++ b/include/nanobind/stl/bind_vector.h
@@ -192,8 +192,8 @@ class_<Vector> bind_vector(handle scope, const char *name, Args &&...args) {
     }
 
     if constexpr (detail::is_equality_comparable_v<Value>) {
-        cl.def(self == self)
-          .def(self != self)
+        cl.def(self == self, sig("def __eq__(self, arg: object, /) -> bool"))
+          .def(self != self, sig("def __ne__(self, arg: object, /) -> bool"))
 
           .def("__contains__",
                [](const Vector &v, const Value &x) {


### PR DESCRIPTION
Use the sig attribute to avoid mypy [override] error.

Following the advice from https://nanobind.readthedocs.io/en/latest/typing.html#functions