### PR TITLE
Set singles mask only if already present on the enum

### DIFF
--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -126,7 +126,7 @@ void enum_append(PyObject *tp_, const char *name_, int64_t value_,
         setattr(tp, "_flag_mask_", tp.attr("_flag_mask_") | val);
 
         bool is_single_bit = (value_ != 0) && (value_ & (value_ - 1)) == 0;
-        if (is_single_bit)
+        if (is_single_bit && hasattr(tp, "_singles_mask_"))
             setattr(tp, "_singles_mask_", tp.attr("_singles_mask_") | val);
 
         int_ bit_length = int_(tp.attr("_flag_mask_").attr("bit_length")());


### PR DESCRIPTION
The singles mask attribute was added for the STRICT boundary default, but only starting at Python 3.11.4. This means that for any Python 3.11 before that, we need to avoid updating it (accessing it in the process), which would result in an attribute error.