### PR TITLE
Overload chains with empty strings

### DIFF
--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -352,7 +352,7 @@ PyObject *nb_func_new(const void *in_) noexcept {
         if (fc->doc[0] == '\0') {
             fc->doc = nullptr;
             fc->flags &= ~(uint32_t) func_flags::has_doc;
-            has_doc = true;
+            has_doc = false;
         } else {
             fc->doc = strdup_check(fc->doc);
         }

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -49,6 +49,10 @@ NB_MODULE(test_functions_ext, m) {
     m.def("test_05b", [](int) -> int { return 1; }, "doc_1");
     m.def("test_05b", [](float) -> int { return 2; }, "doc_1");
 
+    // Test an overload chain with an empty docstring
+    m.def("test_05c", [](int) -> int { return 1; }, "doc_1");
+    m.def("test_05c", [](float) -> int { return 2; }, "");
+
     /// Function raising an exception
     m.def("test_06", []() { throw std::runtime_error("oops!"); });
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -75,6 +75,19 @@ def test05_signature():
         "doc_1"
     )
 
+    assert t.test_05c.__doc__ == (
+        "test_05c(arg: int, /) -> int\n"
+        "test_05c(arg: float, /) -> int\n"
+        "\n"
+        "Overloaded function.\n"
+        "\n"
+        "1. ``test_05c(arg: int, /) -> int``\n"
+        "\n"
+        "doc_1\n"
+        "\n"
+        "2. ``test_05c(arg: float, /) -> int``\n"
+    )
+
     assert t.test_07.__doc__ == (
         f"test_07(arg0: int, arg1: int, /, *args, **kwargs) -> {TYPING_TUPLE}[int, int]\n"
         f"test_07(a: int, b: int, *myargs, **mykwargs) -> {TYPING_TUPLE}[int, int]"

--- a/tests/test_functions_ext.pyi.ref
+++ b/tests/test_functions_ext.pyi.ref
@@ -59,6 +59,13 @@ def test_05b(arg: int, /) -> int:
 @overload
 def test_05b(arg: float, /) -> int: ...
 
+@overload
+def test_05c(arg: int, /) -> int:
+    """doc_1"""
+
+@overload
+def test_05c(arg: float, /) -> int: ...
+
 def test_06() -> None: ...
 
 @overload


### PR DESCRIPTION
Small fix for when a docstring is an empty string and is part of an overload chain.