### PR TITLE
Custom dtype improvements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -56,7 +56,7 @@ Version 2.2.0 (TBA)
   `#732 <https://github.com/wjakob/nanobind/pull/732>`__)
 
 * A refactor of :cpp:class:`nb::ndarray\<...\> <ndarray>` was an opportunity to
-  realize two usability improvements:
+  realize three usability improvements:
 
   1. The constructor used to return new nd-arrays from C++ now considers
      all template arguments:
@@ -95,6 +95,12 @@ Version 2.2.0 (TBA)
      and return value policy, while preserving the type signature in return
      values. This is useful to :ref:`return temporaries (e.g. stack-allocated
      memory) <ndarray-temporaries>` from functions.
+
+  3. Added a new and more general mechanism ``nanobind::detail::dtype_traits<T>``
+     to declare custom ndarray data types like ``float16`` or ``bfloat16``. The old
+     interface (``nanobind::ndarray_traits<T>``) still exists but is deprecated
+     and will be removed in the next major release. See the :ref:`documentation
+     <ndarray-nonstandard>` for details.
 
   There are two minor but potentially breaking changes:
 

--- a/docs/ndarray.rst
+++ b/docs/ndarray.rst
@@ -519,22 +519,29 @@ Nonstandard arithmetic types
 ----------------------------
 
 Low or extended-precision arithmetic types (e.g., ``int128``, ``float16``,
-``bfloat``) are sometimes used but don't have standardized C++ equivalents. If
-you wish to exchange arrays based on such types, you must register a partial
-overload of ``nanobind::ndarray_traits`` to inform nanobind about it.
+``bfloat16``) are sometimes used but don't have standardized C++ equivalents.
+If you wish to exchange arrays based on such types, you must register a partial
+overload of ``nanobind::detail::dtype_traits`` to inform nanobind about it.
+
+You are expressively allowed to create partial overloads of this class despite
+it being in the ``nanobind::detail`` namespace.
 
 For example, the following snippet makes ``__fp16`` (half-precision type on
-``aarch64``) available:
+``aarch64``) available by  providing
+
+1. ``value``, a DLPack ``nanobind::dlpack::dtype`` type descriptor, and
+2. ``name``, a type name for use in docstrings and error messages.
 
 .. code-block:: cpp
 
-   namespace nanobind {
-       template <> struct ndarray_traits<__fp16> {
-           static constexpr bool is_complex = false;
-           static constexpr bool is_float   = true;
-           static constexpr bool is_bool    = false;
-           static constexpr bool is_int     = false;
-           static constexpr bool is_signed  = true;
+   namespace nanobind::detail {
+       template <> struct dtype_traits<__fp16> {
+           static constexpr dlpack::dtype value {
+               (uint8_t) dlpack::dtype_code::Float, // type code
+               16, // size in bits
+               1   // lanes (simd), usually set to 1
+           };
+           static constexpr auto name = const_name("float16");
        };
    }
 

--- a/tests/test_ndarray.cpp
+++ b/tests/test_ndarray.cpp
@@ -13,14 +13,15 @@ static float f_global[] { 1, 2, 3, 4, 5, 6, 7, 8 };
 static int i_global[] { 1, 2, 3, 4, 5, 6, 7, 8 };
 
 #if defined(__aarch64__)
-namespace nanobind {
-   template <> struct ndarray_traits<__fp16> {
-       static constexpr bool is_complex = false;
-       static constexpr bool is_float   = true;
-       static constexpr bool is_bool    = false;
-       static constexpr bool is_int     = false;
-       static constexpr bool is_signed  = true;
-   };
+namespace nanobind::detail {
+    template <> struct dtype_traits<__fp16> {
+        static constexpr dlpack::dtype value {
+            (uint8_t) dlpack::dtype_code::Float, // type code
+            16, // size in bits
+            1   // lanes (simd)
+        };
+        static constexpr auto name = const_name("float16");
+    };
 }
 #endif
 


### PR DESCRIPTION
This commit generalizes the interface for registering custom dtypes with the ``nb::ndarray`` class. In particular, the previous version had hardcoded members like ``is_float``, ``is_int``, etc., which is not general enough to express nuances like ``bfloat16`` or 8-bit FP types with different numbers of exponent and mantissa bits.

The new interface just lets the developer populate a ``nb::dlpack::dtype`` record manually and provide a type name for use in docstrings and error messages.