### PR TITLE
Switch to integer data type in Eigen test for default arguments

### DIFF
--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -169,7 +169,7 @@ NB_MODULE(test_eigen_ext, m) {
     m.def("sparse_complex", []() -> Eigen::SparseMatrix<std::complex<double>> { return {}; });
 
     /// issue #166
-    using Matrix1d = Eigen::Matrix<double,1,1>;
+    using Matrix1d = Eigen::Matrix<int,1,1>;
     try {
         m.def(
             "default_arg", [](Matrix1d a, Matrix1d b) { return a + b; },


### PR DESCRIPTION
The `test10_eigen_scalar_default` test in `test_eigen.py` relies unnecessarily on exact equality of floating point numbers. In my environment, with a recent commit of Eigen, the addition in the test is causing the equality check to fail. There might be other upstream issues to consider here, but the specific test failure here seems to be a false positive! This PR switches that test to use integer zeros to be less sensitive to numerics. Let me know what you think - thanks!