### PR TITLE
Add a CI workflow for building against Eigen from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,16 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'windows-2022', 'macos-13']
         python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13.0-rc.2', 'pypy3.9-v7.3.16', 'pypy3.10-v7.3.17']
+        eigen-from-source: [false]
+        include:
+        - os: 'macos-13'
+          python: '3.12'
+          eigen-from-source: true
+        - os: 'ubuntu-latest'
+          python: '3.12'
+          eigen-from-source: true
 
-    name: "Python ${{ matrix.python }} / ${{ matrix.os }}"
+    name: "Python ${{ matrix.python }} / ${{ matrix.os }} ${{ (matrix.eigen-from-source && '(eigen from source)') || '' }}"
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -41,8 +49,17 @@ jobs:
       uses: lukka/get-cmake@latest
 
     - name: Install Eigen
-      if: matrix.os == 'ubuntu-latest'
+      if: ${{ matrix.os == 'ubuntu-latest'  && !matrix.eigen-from-source }}
       run: sudo apt-get -y install libeigen3-dev
+
+    - name: Install Eigen from source
+      if: matrix.eigen-from-source
+      run: |
+        git clone --depth 1 https://gitlab.com/libeigen/eigen.git
+        mkdir eigen/build
+        cd eigen/build
+        cmake ..
+        sudo make install
 
     - name: Install PyTest
       run: |


### PR DESCRIPTION
This isn't really meant to be merged, but it's a follow up from https://github.com/wjakob/nanobind/issues/746 demonstrating the test failure with the current master branch of Eigen. This workflow seems to fail when run on macOS (but not on Ubuntu), and (as @hawkinsp suggested) I expect the issue is related to using clang instead of gcc.

One way to "fix" this test failure is to update this function:

https://github.com/wjakob/nanobind/blob/bff96e268749e788b69153221c1546b8904a9b53/tests/test_eigen.cpp#L172-L179

as follows

```diff
-             "default_arg", [](Matrix1d a, Matrix1d b) { return a + b; },
+             "default_arg", [](Matrix1d a, Matrix1d b) -> Matrix1d { return a + b; },
```

but I think there's probably something more complicated happening here.