### PR TITLE
Add partial specialization dtype_traits<const T>.

### DIFF
--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -137,9 +137,9 @@ template <> struct dtype_traits<void> {
     static constexpr auto name = descr<0>();
 };
 
-template <> struct dtype_traits<const void> {
-    static constexpr dlpack::dtype value{ 0, 0, 0 };
-    static constexpr auto name = descr<0>();
+template <typename T> struct dtype_traits<const T> {
+    static constexpr dlpack::dtype value = dtype_traits<T>::value;
+    static constexpr auto name = dtype_traits<T>::name;
 };
 
 template <ssize_t... Is> struct shape {


### PR DESCRIPTION
If a developer provides a specialization for, say, `dtype_traits<__fp16>` then this commit avoids his having also to provide a specialization for `dtype_traits<const __fp16>`.