### PR TITLE
Add IWYU export pragmas to protect internal headers

### DIFF
--- a/include/nanobind/nanobind.h
+++ b/include/nanobind/nanobind.h
@@ -36,6 +36,7 @@
 #include <new>
 
 // Implementation. The nb_*.h files should only be included through nanobind.h
+// IWYU pragma: begin_exports
 #include "nb_python.h"
 #include "nb_defs.h"
 #include "nb_enums.h"
@@ -52,6 +53,7 @@
 #include "nb_call.h"
 #include "nb_func.h"
 #include "nb_class.h"
+// IWYU pragma: end_exports
 
 #if defined(_MSC_VER)
 #  pragma warning(pop)


### PR DESCRIPTION
We use [Include What You Use](https://github.com/include-what-you-use/include-what-you-use) to manage `#include`s across a large codebase. IWYU automatically adds and removes `#include` statements in each source file to match what symbols are being used in that file. By default it tries to directly include internal nanobind headers when it detects symbols from those files.

This PR adds [`export` pragmas](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-export) to tell IWYU basically the same thing as the comment on line 38 tells humans: that `nanobind.h` itself exports all of the internal symbols, and that the transitive headers should not be directly included.

We've been carrying this patch for a while and it's been working great for us.

Thanks for making nanobind!