### PR TITLE
Update nanobind-bazel version in Bazel document

### DIFF
--- a/docs/api_bazel.rst
+++ b/docs/api_bazel.rst
@@ -155,3 +155,15 @@ following flag settings.
     version. Allowed values are ``"cp312"``, ``"cp313"``, which target the
     stable ABI starting from Python 3.12 or 3.13, respectively. By default, all
     extensions are built without any ABI limitations.
+
+.. py:function:: @nanobind_bazel//:free_threading (boolean)
+
+    Build nanobind extensions with a Python toolchain in free-threaded mode.
+    If given, the currently configured Python toolchain must support free-threading,
+    otherwise, the build will result in a compilation error.
+    Only relevant for CPython 3.13+, since support for free-threaded Python was
+    introduced in CPython 3.13.
+    For more information on free-threaded extension support in nanobind, refer to the
+    relevant :ref:`documentation section <free-threaded>`.
+
+    *New in nanobind-bazel version 2.2.0.*

--- a/docs/bazel.rst
+++ b/docs/bazel.rst
@@ -25,10 +25,10 @@ in your MODULE.bazel file:
 .. code-block:: python
 
     # Place this in your MODULE.bazel file.
-    # The major version of nanobind-bazel is equal to the major version
+    # The major version of nanobind-bazel is equal to the version
     # of the internally used nanobind.
-    # In this case, we are building bindings with nanobind@v2.
-    bazel_dep(name = "nanobind_bazel", version = "2.1.0")
+    # In this case, we are building bindings with nanobind v2.2.0.
+    bazel_dep(name = "nanobind_bazel", version = "2.2.0")
 
 To instead use a development version from GitHub, you can declare the
 dependency as a ``git_override()`` in your MODULE.bazel:


### PR DESCRIPTION
The code comment above the bzlmod usage was updated to reflect the change back to match nanobind SemVer exactly, starting from v2.2.0.

------------------

Hi Wenzel, this is the nanobind-bazel release for free-threading. I included a small cosmetic update of the Bazel doc, since I decided to make the change of following nanobind SemVer exactly with the newest release. More details can be found on the [release page](https://github.com/nicholasjng/nanobind-bazel/releases/tag/v2.2.0).