### PR TITLE
Add a non-const overload of bytearray::data

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1081,6 +1081,10 @@ Wrapper classes
 
       Return the size in bytes.
 
+   .. cpp:function:: void * data()
+
+      Convert a Python ``bytearray`` object into a byte buffer of length :cpp:func:`bytearray::size()` bytes.
+
    .. cpp:function:: const void * data() const
 
       Convert a Python ``bytearray`` object into a byte buffer of length :cpp:func:`bytearray::size()` bytes.

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -462,7 +462,8 @@ class bytearray : public object {
 
     const char *c_str() const { return PyByteArray_AsString(m_ptr); }
 
-    const void *data() const { return (const void *) PyByteArray_AsString(m_ptr); }
+    const void *data() const { return PyByteArray_AsString(m_ptr); }
+    void *data() { return PyByteArray_AsString(m_ptr); }
 
     size_t size() const { return (size_t) PyByteArray_Size(m_ptr); }
 


### PR DESCRIPTION
Unlike `bytes`, a `bytearray` is mutable. You are allowed to write to it, and the underlying API function returns a `char*`