### PR TITLE
Fix unhandled exception in set_caster

### DIFF
--- a/include/nanobind/stl/detail/nb_set.h
+++ b/include/nanobind/stl/detail/nb_set.h
@@ -24,7 +24,7 @@ template <typename Set, typename Key> struct set_caster {
     bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
         value.clear();
 
-        PyObject* iter = obj_iter(src.ptr());
+        PyObject* iter = PyObject_GetIter(src.ptr());
         if (!iter) {
             PyErr_Clear();
             return false;

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -794,3 +794,7 @@ def test71_null_input():
 @skip_on_pypy # PyPy fails this test on Windows :-(
 def test72_wstr():
     assert t.pass_wstr('🎈') == '🎈'
+
+def test73_bad_input_to_set():
+    with pytest.raises(TypeError):
+        t.set_in_value(None)


### PR DESCRIPTION
`obj_iter` throws `python_error` on failure, but type casters aren't allowed to throw! If you try to from-Python cast an object of a non-iterable type, Python will abort from the unhandled exception coming from a `noexcept` function

It looks like the intention here is to handle failure manually (a NULL return from the CPython call), so I did just that