### PR TITLE
Add <cstddef> to nanobind includes.

### DIFF
--- a/include/nanobind/nanobind.h
+++ b/include/nanobind/nanobind.h
@@ -27,6 +27,7 @@
 #define NB_VERSION_DEV   1 // A value > 0 indicates a development release
 
 // Core C++ headers that nanobind depends on
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <stdexcept>


### PR DESCRIPTION
nb_types.h uses `std::ptrdiff_t`, which is defined in `cstddef`.

Fixes a build failure in Google's build environment, in which this header does not get included transitively by the existing headers.