### PR TITLE
Doc: add info about litgen binding generator

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -398,6 +398,19 @@ build system compatible with another tool that is sufficiently
 feature-complete, then please file an issue and I am happy to reference it in
 the documentation.
 
+Are there tools to generate nanobind bindings automatically?
+------------------------------------------------------------
+
+`litgen <https://pthom.github.io/litgen>`__ is an automatic Python bindings 
+generator compatible with both pybind11 and nanobind, designed to create 
+documented and easily discoverable bindings. 
+It reproduces header documentation directly in the bindings, making the 
+generated API intuitive and well-documented for Python users. 
+Powered by srcML (srcml.org), a high-performance, multi-language parsing tool, 
+litgen takes a developer-centric approach. 
+The C++ API to be exposed to Python must be C++14 compatible, although the 
+implementation can leverage more modern C++ features.
+
 How to cite this project?
 -------------------------
 


### PR DESCRIPTION
Hi,

I am the creator of [litgen](https://pthom.github.io/litgen), an automatic binding generator for pybind11 which generates documented C++ binding code together with python stubs.

Recently it was updated to also support nanobind (with help from @davidlatwe)

This PR proposes to mention litgen in the nanobind documentation, in two parts:

- 9454073: In the building.rst page, I added a section called "Generating binding code automatically," similar to what’s in the pybind11 documentation, to explain litgen’s role in generating documented, discoverable bindings for both pybind11 and nanobind.
- 63f3386: In the porting.rst page, I included a link to the litgen documentation, highlighting examples that compare pybind11 and nanobind binding code side by side. This should be helpful for users looking to understand key differences.

Feel free to discard the part in the porting.rst page if you feel it does not bring enough value.

Thanks!

Pascal Thomet