### PR TITLE
Fix handling of overloaded __new__ that takes no arguments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,11 @@ Version TBD (unreleased)
   ``std::variant<U, T>`` might cast a Python object wrapping a ``T`` to a ``U`` if
   there is an implicit conversion available from ``T`` to ``U``.
 
+- Restored support for constructing types with an overloaded ``__new__`` that
+  takes no arguments, which regressed with the constructor vectorcall
+  acceleration that was added in nanobind 2.2.0.
+  (issue `#786 <https://github.com/wjakob/nanobind/issues/786>`__)
+
 - Added a function annotation :cpp:class:`nb::call_policy\<Policy\>()
   <call_policy>` which supports custom function wrapping logic,
   calling ``Policy::precall()`` before the bound function and

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -59,9 +59,13 @@ enum class type_flags : uint32_t {
     is_generic               = (1 << 15),
 
     /// Does the type implement a custom __new__ operator?
-    has_new                  = (1 << 16)
+    has_new                  = (1 << 16),
 
-    // Two more bits bits available without needing a larger reorganization
+    /// Does the type implement a custom __new__ operator that can take no args
+    /// (except the type object)?
+    has_nullary_new          = (1 << 17)
+
+    // One more bit available without needing a larger reorganization
 };
 
 /// Flags about a type that are only relevant when it is being created.
@@ -430,7 +434,13 @@ struct new_<Func, Return(Args...)> {
         // replacing it; this is important for pickle support.
         // We can't do this if the user-provided __new__ takes no
         // arguments, because it would make an ambiguous overload set.
-        detail::wrap_base_new(cl, sizeof...(Args) != 0);
+        constexpr size_t num_defaults =
+            ((std::is_same_v<Extra, arg_v> ||
+              std::is_same_v<Extra, arg_locked_v>) + ... + 0);
+        constexpr size_t num_varargs =
+            ((std::is_same_v<detail::intrinsic_t<Args>, args> ||
+              std::is_same_v<detail::intrinsic_t<Args>, kwargs>) + ... + 0);
+        detail::wrap_base_new(cl, sizeof...(Args) > num_defaults + num_varargs);
 
         auto wrapper = [func = (detail::forward_t<Func>) func](handle, Args... args) {
             return func((detail::forward_t<Args>) args...);

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -453,9 +453,8 @@ PyObject *nb_func_new(const void *in_) noexcept {
                     noargs_ok = false;
                     break;
                 }
-                if (noargs_ok) {
+                if (noargs_ok)
                     td->flags |= (uint32_t) type_flags::has_nullary_new;
-                }
             }
         } else if (is_new) {
             td->init = func;

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -968,12 +968,15 @@ static PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
         self = inst_new_int(tp, nullptr, nullptr);
         if (!self)
             return nullptr;
-    } else if (nargs == 0 && !kwargs_in && nb_func_data(func)->nargs != 0) {
+    } else if (nargs == 0 && !kwargs_in &&
+               !(td->flags & (uint32_t) type_flags::has_nullary_new)) {
         // When the bindings define a custom __new__ operator, nanobind always
         // provides a no-argument dummy __new__ constructor to handle unpickling
         // via __setstate__. This is an implementation detail that should not be
         // exposed. Therefore, only allow argument-less calls if there is an
-        // actual __new__ overload with a compatible signature.
+        // actual __new__ overload with a compatible signature. This is
+        // detected in nb_func.cpp based on whether any __init__ overload can
+        // accept no arguments.
 
         return func->vectorcall((PyObject *) func, nullptr, 0, nullptr);
     }

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -6,6 +6,7 @@
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/unique_ptr.h>
 #include <map>
 #include <memory>
 #include <cstring>
@@ -657,6 +658,23 @@ NB_MODULE(test_classes_ext, m) {
         }), "s"_a)
         .def("value", &UniqueInt::value)
         .def("lookups", &UniqueInt::lookups);
+
+    // issue #786
+    struct NewNone {};
+    struct NewDflt { int value; };
+    struct NewStar { size_t value; };
+    nb::class_<NewNone>(m, "NewNone")
+        .def(nb::new_([]() { return NewNone(); }));
+    nb::class_<NewDflt>(m, "NewDflt")
+        .def(nb::new_([](int value) { return NewDflt{value}; }),
+             "value"_a = 42)
+        .def_ro("value", &NewDflt::value);
+    nb::class_<NewStar>(m, "NewStar")
+        .def(nb::new_([](nb::args a, int value, nb::kwargs k) {
+            return NewStar{nb::len(a) + value + 10 * nb::len(k)};
+        }),
+            "args"_a, "value"_a = 42, "kwargs"_a)
+        .def_ro("value", &NewStar::value);
 
     // issue #750
     PyCFunctionWithKeywords dummy_init = [](PyObject *, PyObject *,

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -888,6 +888,17 @@ def test46_custom_new():
     with pytest.raises(RuntimeError):
         t.UniqueInt.__new__(int)
 
+    # Make sure we do allow no-args construction for types that declare
+    # such a __new__
+    t.NewNone()
+    assert t.NewDflt().value == 42
+    assert t.NewDflt(10).value == 10
+    assert t.NewStar().value == 42
+    assert t.NewStar("hi").value == 43
+    assert t.NewStar(value=10).value == 10
+    assert t.NewStar("hi", "lo", value=10).value == 12
+    assert t.NewStar(value=10, other="blah").value == 20
+
 def test47_inconstructible():
     with pytest.raises(TypeError, match="no constructor defined"):
         t.Foo()

--- a/tests/test_classes_ext.pyi.ref
+++ b/tests/test_classes_ext.pyi.ref
@@ -130,6 +130,21 @@ class MyClass:
 
     def f(self) -> None: ...
 
+class NewDflt:
+    def __init__(self, value: int = 42) -> None: ...
+
+    @property
+    def value(self) -> int: ...
+
+class NewNone:
+    def __init__(self) -> None: ...
+
+class NewStar:
+    def __init__(self, *args, value: int = 42, **kwargs) -> None: ...
+
+    @property
+    def value(self) -> int: ...
+
 class NonCopyableVec:
     pass
 


### PR DESCRIPTION
Fixes #786. We now consider whether it's possible to invoke the overload with no arguments, rather than just whether it is declared with no parameters; the difference is relevant in the presence of `nb::args`/`nb::kwargs` and default values. The previous logic didn't work anyway - it checked whether there was an overload with zero args, but (a) this couldn't distinguish the auto-added wrapper overload from a user-specified one and (b) neither would have zero args, because new always takes at least the type arg.