### PR TITLE
type_caster<ndarray>: accept None only if flags say so

### DIFF
--- a/include/nanobind/eigen/dense.h
+++ b/include/nanobind/eigen/dense.h
@@ -133,7 +133,7 @@ struct type_caster<T, enable_if_t<is_eigen_plain_v<T> &&
         // We're in any case making a copy, so non-writable inputs area also okay
         using NDArrayConst = array_for_eigen_t<T, const typename T::Scalar>;
         make_caster<NDArrayConst> caster;
-        if (!caster.from_python(src, flags, cleanup))
+        if (!caster.from_python(src, flags & ~(uint8_t)cast_flags::accepts_none, cleanup))
             return false;
 
         const NDArrayConst &array = caster.value;
@@ -261,7 +261,7 @@ struct type_caster<Eigen::Map<T, Options, StrideType>,
     }
 
     bool from_python_(handle src, uint8_t flags, cleanup_list* cleanup) noexcept {
-        if (!caster.from_python(src, flags, cleanup))
+        if (!caster.from_python(src, flags & ~(uint8_t)cast_flags::accepts_none, cleanup))
             return false;
 
         // Check for memory layout compatibility of non-contiguous 'Map' types

--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -543,7 +543,7 @@ template <typename... Args> struct type_caster<ndarray<Args...>> {
                    const_name("]"))
 
     bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
-        if (src.is_none()) {
+        if (src.is_none() && flags & (uint8_t) cast_flags::accepts_none) {
             value = ndarray<Args...>();
             return true;
         }

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -223,17 +223,21 @@ NB_MODULE(test_eigen_ext, m) {
 
     struct Base {
         virtual ~Base() = default;
-        virtual void modRefData(Eigen::Ref<Eigen::VectorXd>) { };
-        virtual void modRefDataConst(Eigen::Ref<const Eigen::VectorXd>) { };
+        virtual void modRefData(Eigen::Ref<Eigen::VectorXd>) {}
+        virtual void modRefDataConst(Eigen::Ref<const Eigen::VectorXd>) {}
+        virtual Eigen::VectorXd returnVecXd() { return { 1, 2 }; }
     };
 
     struct PyBase : Base {
-        NB_TRAMPOLINE(Base, 2);
+        NB_TRAMPOLINE(Base, 3);
         void modRefData(Eigen::Ref<Eigen::VectorXd> a) override {
             NB_OVERRIDE_PURE(modRefData, a);
         }
         void modRefDataConst(Eigen::Ref<const Eigen::VectorXd> a) override {
             NB_OVERRIDE_PURE(modRefDataConst, a);
+        }
+        Eigen::VectorXd returnVecXd() override {
+            NB_OVERRIDE_PURE(returnVecXd);
         }
     };
 
@@ -251,5 +255,8 @@ NB_MODULE(test_eigen_ext, m) {
         Eigen::Vector2d input(1.0, 2.0);
         base->modRefDataConst(input);
         return input;
+    });
+    m.def("returnVecXd", [](Base* base) {
+        return base->returnVecXd();
     });
 }

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -362,12 +362,16 @@ def test13_mutate_python():
         def modRefDataConst(self, input):
             input[0] = 3.0
 
+        def returnVecXd(self):
+            pass
+
     vecRef = np.array([3.0, 2.0])
     der = Derived()
     assert_array_equal(t.modifyRef(der), vecRef)
     with pytest.raises(ValueError):
         t.modifyRefConst(der)
-
+    with pytest.raises(RuntimeError, match="bad[_ ]cast"):
+        t.returnVecXd(der)
 
 @needs_numpy_and_eigen
 def test14_single_element():


### PR DESCRIPTION
Since https://github.com/wjakob/nanobind/commit/577942c8a13c931320db89c99d35778fc99be3d6 / https://github.com/wjakob/nanobind/pull/526, `type_caster<ndarray>::from_python` accepts None as argument, yielding an invalid ndarray. It does so independently of the cast-flags. This is fine, if the caster is called by the function dispatch mechanism, which handles cast_flags::accepts_none beforehand.
However, `type_caster<Eigen::Matrix/Array>` and `type_caster<Eigen::Map>` use `type_caster<ndarray>` as a local caster. Since these Eigen types are no wrappers, their type casters must not accept None. Part of this PR is that the local caster considers cast_flags::accepts_none, and the outer casters enforce the absence of this flag.
My use case is to avoid a read access violation when casting None returned by a virtual method overridden in Python, expected to return some Eigen::Matrix - see the according test.