### PR TITLE
Default to rv_policy::move when binding in-place operators

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,12 @@ Version TBD (unreleased)
   of storing a dangling C++ iterator reference in the returned Python
   iterator object. (PR `#788 <https://github.com/wjakob/nanobind/pull/788>`__)
 
+- Bindings for augmented assignment operators (as generated, for example, by
+  ``.def(nb::self += nb::self)``) now return the same object in Python in the
+  typical case where the C++ operator returns a reference to ``*this``.
+  Previously, after ``a += b``, ``a`` would be replaced with a copy.
+  (PR `#803 <https://github.com/wjakob/nanobind/pull/803>`__)
+
 Version 2.2.0 (October 3, 2024)
 -------------------------------
 

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -325,7 +325,9 @@ def test14_operators():
         assert repr(a - b) == "3"
     assert "unsupported operand type" in str(excinfo.value)
     assert repr(a - 2) == "-1"
+    a_before = id(a)
     a += b
+    assert id(a) == a_before
     assert repr(a) == "3"
     assert repr(b) == "2"
 


### PR DESCRIPTION
The idiomatic return type for `T::operator+=` in C++ is `T&`, because the idiomatic return value is `*this`. When binding `nb::self += nb::self`, or any other augmented-assignment operator, for a class that follows this convention, nanobind currently applies `rv_policy::automatic` to the `T&` return value and makes a copy of the referenced `T`. I think this is counter to users' expectations: a C++ type that defines these augmented assignment operators is mutable, so it should behave like mutable objects do in Python, and let `+=` preserve object identity. The problem is demonstrated by the test in this PR, which fails on current master.

Fix this issue by defaulting to `rv_policy::move` for the return value of augmented assignment operators. This will work as it does today if the operator returns by value, but be able to reuse the same Python object if the operator returns `*this` by reference. Users can still override the default by passing an rvp as an additional argument to `.def()`.

Footnote: This issue suggests a potential wider problem when binding "generative methods" like `Foo& Foo::withBar(int bar) { myBar = bar; return *this; }`; using those in Python will make a copy too, because `rv_policy::copy` prevents reusing an existing pyobject on nanobind. (This is a difference from pybind and maybe should be mentioned in the porting section?) However, I don't think we can conclude that all methods returning reference-to-self-type return `*this`; it's a much more robust assumption for augmented assignment operators.