### PR TITLE
Support overriding static properties defined via def_prop_ro_static.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,6 +49,10 @@ Version TBD (unreleased)
   Previously, after ``a += b``, ``a`` would be replaced with a copy.
   (PR `#803 <https://github.com/wjakob/nanobind/pull/803>`__)
 
+- Added support for overriding static properties, such as those defined using
+  ``def_prop_ro_static``, in subclasses. Previously this would fail with an
+  error.
+
 Version 2.2.0 (October 3, 2024)
 -------------------------------
 

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -513,7 +513,9 @@ int nb_type_setattro(PyObject* obj, PyObject* name, PyObject* value) {
 
     if (cur) {
         PyTypeObject *tp = int_p->nb_static_property;
-        if (Py_TYPE(cur) == tp) {
+        // For type.static_prop = value, call the setter.
+        // For type.static_prop = another_static_prop, replace the descriptor.
+        if (Py_TYPE(cur) == tp && Py_TYPE(value) != tp) {
             int rv = int_p->nb_static_property_descr_set(cur, obj, value);
             Py_DECREF(cur);
             return rv;

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -705,4 +705,12 @@ NB_MODULE(test_classes_ext, m) {
             nb::inst_mark_ready(h);
         })
         .def_rw("value", &MonkeyPatchable::value);
+
+    struct StaticPropertyOverride {};
+    struct StaticPropertyOverride2 : public StaticPropertyOverride {};
+
+    nb::class_<StaticPropertyOverride>(m, "StaticPropertyOverride")
+        .def_prop_ro_static("x", [](nb::handle /*unused*/) { return 42; });
+    nb::class_<StaticPropertyOverride2, StaticPropertyOverride>(m, "StaticPropertyOverride2")
+        .def_prop_ro_static("x", [](nb::handle /*unused*/) { return 43; });
 }

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -916,3 +916,7 @@ def test48_monekypatchable():
     t.MonkeyPatchable.__init__ = my_init
     q = t.MonkeyPatchable()
     assert q.value == 456
+
+def test49_static_property_override():
+    assert t.StaticPropertyOverride.x == 42
+    assert t.StaticPropertyOverride2.x == 43

--- a/tests/test_classes_ext.pyi.ref
+++ b/tests/test_classes_ext.pyi.ref
@@ -180,6 +180,14 @@ class StaticProperties:
 class StaticProperties2(StaticProperties):
     pass
 
+class StaticPropertyOverride:
+    x: int = ...
+    """(arg: object, /) -> int"""
+
+class StaticPropertyOverride2(StaticPropertyOverride):
+    x: int = ...
+    """(arg: object, /) -> int"""
+
 class Struct:
     """Some documentation"""
 


### PR DESCRIPTION
See
https://github.com/pybind/pybind11/commit/e0e2ea33788e29ff5efca5842e92c6b179ca9378 for the analogous change to pybind11.