### PR TITLE
Properly install tsl::robin_map's interface sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,10 +96,9 @@ if(NB_CREATE_INSTALL_RULES AND NOT CMAKE_SKIP_INSTALL_RULES)
   )
 
   if(NB_USE_SUBMODULE_DEPS)
+    add_subdirectory(ext/robin_map)
     install(
-      FILES ext/robin_map/include/tsl/robin_map.h
-            ext/robin_map/include/tsl/robin_hash.h
-            ext/robin_map/include/tsl/robin_growth_policy.h
+      FILES  $<TARGET_PROPERTY:tsl::robin_map,INTERFACE_SOURCES>
       DESTINATION "${NB_INSTALL_EXT_DIR}/robin_map/include/tsl"
     )
   endif()


### PR DESCRIPTION
Before, the include files from `ext/robin_map/include/tsl` were installed manually. This is when I noticed that one file from `robin_map` was missing, namely `robin_set.h`.

When I found the place in which nanobind installs the headers I looked up the `CMakeLists.txt` from `robin_map`. One can safely add it with `add_subdirectory()` because it [doesn't do much](https://github.com/Tessil/robin-map/blob/188c45569cc2a5dd768077c193830b51d33a5020/CMakeLists.txt#L8-L26) when added as a subproject. The [`README.txt`](https://github.com/Tessil/robin-map/blob/188c45569cc2a5dd768077c193830b51d33a5020/README.md?plain=1#L13) from `robin_map` says:

> If you use CMake, you can also use the `tsl::robin_map` exported target
> from the `CMakeLists.txt`.

That's when I figured we might want to make this a bit more future proof and automatically get the header files from `robin_map`.