### PR TITLE
Use atomic reads and writes in code that uses double-checked locking.

### DIFF
--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -175,11 +175,11 @@ static PyMethodDef nb_ndarray_members[] = {
 
 static PyTypeObject *nd_ndarray_tp() noexcept {
     nb_internals *internals_ = internals;
-    PyTypeObject *tp = internals_->nb_ndarray;
+    PyTypeObject *tp = internals_->nb_ndarray.load_acquire();
 
     if (NB_UNLIKELY(!tp)) {
         lock_internals guard(internals_);
-        tp = internals_->nb_ndarray;
+        tp = internals_->nb_ndarray.load_relaxed();
         if (tp)
             return tp;
 
@@ -209,7 +209,7 @@ static PyTypeObject *nd_ndarray_tp() noexcept {
         tp->tp_as_buffer->bf_releasebuffer = nb_ndarray_releasebuffer;
 #endif
 
-        internals_->nb_ndarray = tp;
+        internals_->nb_ndarray.store_release(tp);
     }
 
     return tp;

--- a/src/nb_static_property.cpp
+++ b/src/nb_static_property.cpp
@@ -30,12 +30,12 @@ static int nb_static_property_descr_set(PyObject *self, PyObject *obj, PyObject 
 
 PyTypeObject *nb_static_property_tp() noexcept {
     nb_internals *internals_ = internals;
-    PyTypeObject *tp = internals_->nb_static_property;
+    PyTypeObject *tp = internals_->nb_static_property.load_acquire();
 
     if (NB_UNLIKELY(!tp)) {
         lock_internals guard(internals_);
 
-        tp = internals_->nb_static_property;
+        tp = internals_->nb_static_property.load_relaxed();
         if (tp)
             return tp;
 
@@ -65,8 +65,8 @@ PyTypeObject *nb_static_property_tp() noexcept {
         tp = (PyTypeObject *) PyType_FromSpec(&spec);
         check(tp, "nb_static_property type creation failed!");
 
-        internals_->nb_static_property = tp;
         internals_->nb_static_property_descr_set = nb_static_property_descr_set;
+        internals_->nb_static_property.store_release(tp);
     }
 
     return tp;

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -512,7 +512,7 @@ int nb_type_setattro(PyObject* obj, PyObject* name, PyObject* value) {
 #endif
 
     if (cur) {
-        PyTypeObject *tp = int_p->nb_static_property;
+        PyTypeObject *tp = int_p->nb_static_property.load_acquire();
         // For type.static_prop = value, call the setter.
         // For type.static_prop = another_static_prop, replace the descriptor.
         if (Py_TYPE(cur) == tp && Py_TYPE(value) != tp) {


### PR DESCRIPTION
In a couple of places in nanobind we see this idiom:
```
nb_internals *internals_ = internals;
PyTypeObject *tp = internals_->nb_ndarray;

if (NB_UNLIKELY(!tp)) {
    lock_internals guard(internals_);
    tp = internals_->nb_ndarray;
    if (tp)
        return tp;

    // ... build tp
    internals_->nb_ndarray = tp;
}
```

This is the classic double-checked locking idiom, which on architectures that don't have total store ordering is racy (e.g. ARM, not x86). To use this pattern correctly, we need to use an atomic acquire load for the read outside the lock, and to use an atomic store release for the store inside the lock. These add the necessary fences to ensure that, for example, the contents of `tp` do not appear populated to the reader before the writer has stored them to memory.

This PR adds an include of `<atomic>` to nb_internals.h if free-threading is enabled. I was unable to think of a good way to avoid this, bar using intrinsics. The use of atomics seemed appropriate to me in the presence of free threading.