### PR TITLE
Simplify how to default CMAKE_BUILD_TYPE to Release.

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -44,8 +44,7 @@ addition, binding code may run slowly and produce large binaries.
 .. code-block:: cmake
 
    if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-     set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
-     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE Release)
    endif()
 
 Finding nanobind

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -45,6 +45,7 @@ addition, binding code may run slowly and produce large binaries.
 
    if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
      set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE Release)
+     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
    endif()
 
 Finding nanobind


### PR DESCRIPTION
It is simpler to set the VALUE of the existing property to Release.

Note that this cannot be done so easily in nanobind's `CMakeLists.txt` because the `project()` specifies `LANGUAGES NONE`.
Probably, it could be done later in the file, after `enable_language(CXX)`.

See:  https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html

