### PR TITLE
Fix -Wsign-compare gcc warning

### DIFF
--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -445,7 +445,8 @@ PyObject *nb_func_new(const void *in_) noexcept {
                 // skips Python's usual logic where __init__ is always called
                 // if __new__ returns an instance of the type.
                 bool noargs_ok = true;
-                for (size_t i = 1; i < fc->nargs - has_var_kwargs; ++i) {
+                for (size_t i = 1;
+                     i < fc->nargs - static_cast<size_t>(has_var_kwargs); ++i) {
                     if (has_var_args && i == fc->nargs_pos)
                         continue; // skip `nb::args` since it can be empty
                     if (has_args && fc->args[i].value != nullptr)


### PR DESCRIPTION
gcc warns about this code:
`warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'int' [-Wsign-compare]`

From what I can tell, this is a difference between clang and gcc, as explored [on godbolt](https://godbolt.org/z/T3TKsdvTr)