### PR TITLE
Enable subclassing `nb_type`

### DIFF
--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -876,7 +876,7 @@ static PyTypeObject *nb_type_tp(size_t supplement) noexcept {
             /* .name = */ name,
             /* .basicsize = */ basicsize,
             /* .itemsize = */ itemsize,
-            /* .flags = */ Py_TPFLAGS_DEFAULT,
+            /* .flags = */ Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
             /* .slots = */ slots
         };
 


### PR DESCRIPTION
I would like to be able to subclass `nb_type`. Currently this is possible in `pybind` and I use this feature to perform some "magic" when a pybind class pops out from C++ (see [here](https://github.com/makslevental/mlir-python-extras/blob/af8bd5fd628d9ed61a516acc7133019ac8fa92f5/mlir_utils/dialects/ext/arith.py#L75)). The upstream project (MLIR) recently switched `pybind -> nanobind` so I'd like to restore this functionality.

Let me know if you'd like me to add a test case.