### PR TITLE
Add `nanobind.source_dir()` API to obtain the source path

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,6 +4,10 @@ import os
 if sys.version_info < (3, 8):
     raise ImportError("nanobind does not support Python < 3.8.")
 
+def source_dir() -> str:
+    "Return the path to the nanobind source directory."
+    return os.path.join(os.path.abspath(os.path.dirname(__file__)), "src")
+
 def include_dir() -> str:
     "Return the path to the nanobind include directory"
     return os.path.join(os.path.abspath(os.path.dirname(__file__)), "include")
@@ -16,6 +20,7 @@ __version__ = "2.5.0dev1"
 
 __all__ = (
     "__version__",
+    "source_dir",
     "include_dir",
     "cmake_dir",
 )


### PR DESCRIPTION
This is useful when building with other tools or build systems, like `setuptools` in my case.

-------------

Right now, to obtain the source path, I am using `Path(nanobind.include_dir()).with_name("src")`, but I felt that this was a worthy addition for anyone needing the sources path when building nanobind from source themselves as part of a package / wheel build by means other than scikit-build-core.