### PR TITLE
Fix [-Wcast-qual] warnings on GCC 14.2

### DIFF
--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -179,8 +179,8 @@ public:
     handle &operator=(handle &&) noexcept = default;
     NB_INLINE handle(std::nullptr_t, detail::steal_t) : m_ptr(nullptr) { }
     NB_INLINE handle(std::nullptr_t) : m_ptr(nullptr) { }
-    NB_INLINE handle(const PyObject *ptr) : m_ptr((PyObject *) ptr) { }
-    NB_INLINE handle(const PyTypeObject *ptr) : m_ptr((PyObject *) ptr) { }
+    NB_INLINE handle(const PyObject *ptr) : m_ptr(const_cast<PyObject *>(ptr)) { }
+    NB_INLINE handle(const PyTypeObject *ptr) : m_ptr((PyObject *)const_cast<PyTypeObject *>(ptr)) { }
 
     const handle& inc_ref() const & noexcept {
 #if defined(NDEBUG) && !defined(Py_LIMITED_API)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -87,7 +87,7 @@ PyObject *capsule_new(const void *ptr, const char *name,
             cleanup_2(PyCapsule_GetPointer(o, PyCapsule_GetName(o)));
     };
 
-    PyObject *c = PyCapsule_New((void *) ptr, name, capsule_cleanup);
+    PyObject *c = PyCapsule_New(const_cast<void *>(ptr), name, capsule_cleanup);
 
     check(c, "nanobind::detail::capsule_new(): allocation failed!");
 

--- a/src/implicit.cpp
+++ b/src/implicit.cpp
@@ -36,7 +36,7 @@ void implicitly_convertible(const std::type_info *src,
 
     if (size)
         memcpy(data, t->implicit.cpp, size * sizeof(void *));
-    data[size] = (void *) src;
+    data[size] = (void *)const_cast<std::type_info *>(src);
     data[size + 1] = nullptr;
     PyMem_Free(t->implicit.cpp);
     t->implicit.cpp = (decltype(t->implicit.cpp)) data;

--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -102,7 +102,7 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
         delete (enum_map *) t->enum_tbl.fwd;
         delete (enum_map *) t->enum_tbl.rev;
         nb_type_unregister(t);
-        free((char*) t->name);
+        free(const_cast<char*>(t->name));
         delete t;
     });
 

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -102,7 +102,7 @@ static int nd_ndarray_tpbuffer(PyObject *exporter, Py_buffer *view, int) {
         return -1;
     }
 
-    view->format = (char *) format;
+    view->format = const_cast<char *>(format);
     view->itemsize = t.dtype.bits / 8;
     view->buf = (void *) ((uintptr_t) t.data + t.byte_offset);
     view->obj = exporter;

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -433,7 +433,7 @@ static void nb_type_dealloc(PyObject *o) {
         PyMem_Free(t->implicit.py);
     }
 
-    free((char *) t->name);
+    free(const_cast<char *>(t->name));
     NB_SLOT(PyType_Type, tp_dealloc)(o);
 }
 
@@ -988,7 +988,7 @@ static PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
     bool alloc = false;
 
     if (NB_LIKELY(nargsf & NB_VECTORCALL_ARGUMENTS_OFFSET)) {
-        args = (PyObject **) (args_in - 1);
+        args = const_cast<PyObject **>(args_in - 1);
         temp = args[0];
     } else {
         size_t size = nargs + 1;
@@ -1074,7 +1074,7 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
             PyObject *tp = (PyObject *) it->second->type_py;
             Py_INCREF(tp);
             if (has_signature)
-                free((char *) t_name);
+                free(const_cast<char *>(t_name));
             return tp;
         }
     }
@@ -1183,7 +1183,7 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
     *s++ = { Py_tp_dealloc, (void *) inst_dealloc };
 
     if (has_doc)
-        *s++ = { Py_tp_doc, (void *) t->doc };
+        *s++ = { Py_tp_doc, (void *)const_cast<char *>(t->doc) };
 
     vectorcallfunc type_vectorcall = nb_type_vectorcall;
 
@@ -1355,7 +1355,7 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
 
     if (has_signature) {
         setattr(result, "__nb_signature__", str(t->name));
-        free((char *) t_name);
+        free(const_cast<char *>(t_name));
     }
 
 #if PY_VERSION_HEX >= 0x03090000
@@ -2137,7 +2137,7 @@ void nb_inst_copy(PyObject *dst, const PyObject *src) noexcept {
     if (src == dst)
         return;
 
-    PyTypeObject *tp = Py_TYPE((PyObject *) src);
+    PyTypeObject *tp = Py_TYPE(const_cast<PyObject *>(src));
     type_data *t = nb_type_data(tp);
 
     check(tp == Py_TYPE(dst) &&
@@ -2145,7 +2145,7 @@ void nb_inst_copy(PyObject *dst, const PyObject *src) noexcept {
           "nanobind::detail::nb_inst_copy(): invalid arguments!");
 
     nb_inst *nbi = (nb_inst *) dst;
-    const void *src_data = inst_ptr((nb_inst *) src);
+    const void *src_data = inst_ptr((nb_inst *)const_cast<PyObject *>(src));
     void *dst_data = inst_ptr(nbi);
 
     if (t->flags & (uint32_t) type_flags::has_copy)
@@ -2161,7 +2161,7 @@ void nb_inst_move(PyObject *dst, const PyObject *src) noexcept {
     if (src == dst)
         return;
 
-    PyTypeObject *tp = Py_TYPE((PyObject *) src);
+    PyTypeObject *tp = Py_TYPE(const_cast<PyObject *>(src));
     type_data *t = nb_type_data(tp);
 
     check(tp == Py_TYPE(dst) &&
@@ -2169,7 +2169,7 @@ void nb_inst_move(PyObject *dst, const PyObject *src) noexcept {
           "nanobind::detail::nb_inst_move(): invalid arguments!");
 
     nb_inst *nbi = (nb_inst *) dst;
-    void *src_data = inst_ptr((nb_inst *) src);
+    void *src_data = inst_ptr((nb_inst *)const_cast<PyObject *>(src));
     void *dst_data = inst_ptr(nbi);
 
     if (t->flags & (uint32_t) type_flags::has_move) {

--- a/src/trampoline.cpp
+++ b/src/trampoline.cpp
@@ -133,7 +133,7 @@ static void trampoline_enter_internal(void **data, size_t size,
         key = Py_None;
     }
 
-    data[2 * offset + 1] = (void *) name;
+    data[2 * offset + 1] = (void *)const_cast<char *>(name);
     data[2 * offset + 2] = key;
 
     if (key != None) {


### PR DESCRIPTION
GCC's C++ with -Wcast-qual enabled wants C++17's `const_cast`.