### PR TITLE
Fix object construction when some construction signatures would select a nontrivial __new__ and others a nontrivial __init__

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -56,6 +56,10 @@ Version TBD (not yet released)
   <https://github.com/wjakob/nanobind/pull/847>`__, commit `b95eb7
   <https://github.com/wjakob/nanobind/commit/b95eb755b5a651a40562002be9ca8a4c6bf0acb9>`__).
 
+- Fixed constructor overload resolution for types where some constructor
+  signatures select a nontrivial ``__new__`` while others select a nontrivial
+  ``__init__``. (PR `#860 <https://github.com/wjakob/nanobind/pull/860>`__)
+
 Version 2.4.0 (Dec 6, 2024)
 ---------------------------
 

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -439,6 +439,10 @@ extern PyTypeObject *nb_static_property_tp() noexcept;
 extern type_data *nb_type_c2p(nb_internals *internals,
                               const std::type_info *type);
 extern void nb_type_unregister(type_data *t) noexcept;
+extern PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
+                                    size_t nargsf,
+                                    PyObject *kwargs_in) noexcept;
+
 
 extern PyObject *call_one_arg(PyObject *fn, PyObject *arg) noexcept;
 

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -952,9 +952,9 @@ static PyMethodDef class_getitem_method[] = {
 
 // Implements the vector call protocol directly on type objects to construct
 // instances more efficiently.
-static PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
-                                    size_t nargsf,
-                                    PyObject *kwargs_in) noexcept {
+PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
+                             size_t nargsf,
+                             PyObject *kwargs_in) noexcept {
     PyTypeObject *tp = (PyTypeObject *) self;
     type_data *td = nb_type_data(tp);
     nb_func *func = (nb_func *) td->init;

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -659,6 +659,18 @@ NB_MODULE(test_classes_ext, m) {
         .def("value", &UniqueInt::value)
         .def("lookups", &UniqueInt::lookups);
 
+    struct NewOrInit {
+        NewOrInit() : value(-1) {}
+        NewOrInit(int v) : value(v) {}
+        int value;
+    };
+    // construction with no args uses __init__, while with an arg uses __new__
+    nb::class_<NewOrInit>(m, "NewOrInit")
+        .def_static("__new__", [](nb::handle ty) { return nb::inst_alloc(ty); })
+        .def(nb::new_([](int val) { return NewOrInit(val); }))
+        .def(nb::init<>())
+        .def_rw("value", &NewOrInit::value);
+
     // issue #786
     struct NewNone {};
     struct NewDflt { int value; };

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -901,6 +901,23 @@ def test46_custom_new():
     assert t.NewStar("hi", "lo", value=10).value == 12
     assert t.NewStar(value=10, other="blah").value == 20
 
+    # Make sure we do overload resolution correctly when some signatures
+    # use a nontrivial __new__ and others use a nontrivial __init__
+    assert t.NewOrInit().value == -1
+    assert t.NewOrInit(5).value == 5
+
+    uses_new = t.NewOrInit.__new__(t.NewOrInit, 10)
+    assert uses_new.value == 10
+    uses_new.__init__(10)
+    assert uses_new.value == 10
+
+    uses_init = t.NewOrInit.__new__(t.NewOrInit)
+    with pytest.warns(RuntimeWarning, match="access an uninitialized instance"):
+        with pytest.raises(TypeError):
+            uses_init.value
+    uses_init.__init__()
+    assert uses_init.value == -1
+
 def test47_inconstructible():
     with pytest.raises(TypeError, match="no constructor defined"):
         t.Foo()

--- a/tests/test_classes_ext.pyi.ref
+++ b/tests/test_classes_ext.pyi.ref
@@ -139,6 +139,19 @@ class NewDflt:
 class NewNone:
     def __init__(self) -> None: ...
 
+class NewOrInit:
+    @overload
+    def __init__(self, arg: int, /) -> None: ...
+
+    @overload
+    def __init__(self) -> None: ...
+
+    @property
+    def value(self) -> int: ...
+
+    @value.setter
+    def value(self, arg: int, /) -> None: ...
+
 class NewStar:
     def __init__(self, *args, value: int = 42, **kwargs) -> None: ...
 


### PR DESCRIPTION
This previously fooled the vectorcall shortcut constructor; now we detect the conflict and disable vectorcall construction.

While we're here, update the complex call dispatcher to consider the constructor-ness of each overload independently, and make "overloads differ in constructor-ness" a reason to use the complex dispatcher. An actual object constructor that takes a `T*` self argument would have `is_constructor = true`, while a stub constructor that takes a `nb::handle` self argument (such as the one emitted by `nb::new_`) has `is_constructor = false`; these can be in the same overload set.