### PR TITLE
Introducing option NB_SUPPRESS_WARNINGS to nanobind_add_module

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -236,7 +236,7 @@ function (nanobind_build_library TARGET_NAME)
       ${NB_DIR}/ext/robin_map/include)
   endif()
 
-  target_include_directories(${TARGET_NAME} PUBLIC
+  target_include_directories(${TARGET_NAME} SYSTEM PUBLIC
     ${Python_INCLUDE_DIRS}
     ${NB_DIR}/include)
 

--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -104,6 +104,9 @@ endfunction()
 # ---------------------------------------------------------------------------
 
 function (nanobind_build_library TARGET_NAME)
+  cmake_parse_arguments(PARSE_ARGV 1 ARG
+    "AS_SYSINCLUDE" "" "")
+
   if (TARGET ${TARGET_NAME})
     return()
   endif()
@@ -112,6 +115,10 @@ function (nanobind_build_library TARGET_NAME)
     set (TARGET_TYPE STATIC)
   else()
     set (TARGET_TYPE SHARED)
+  endif()
+
+  if (${ARG_AS_SYSINCLUDE})
+    set (AS_SYSINCLUDE SYSTEM)
   endif()
 
   add_library(${TARGET_NAME} ${TARGET_TYPE}
@@ -236,7 +243,7 @@ function (nanobind_build_library TARGET_NAME)
       ${NB_DIR}/ext/robin_map/include)
   endif()
 
-  target_include_directories(${TARGET_NAME} SYSTEM PUBLIC
+  target_include_directories(${TARGET_NAME} ${AS_SYSINCLUDE} PUBLIC
     ${Python_INCLUDE_DIRS}
     ${NB_DIR}/include)
 
@@ -310,7 +317,7 @@ endfunction()
 
 function(nanobind_add_module name)
   cmake_parse_arguments(PARSE_ARGV 1 ARG
-    "STABLE_ABI;FREE_THREADED;NB_STATIC;NB_SHARED;PROTECT_STACK;LTO;NOMINSIZE;NOSTRIP;MUSL_DYNAMIC_LIBCPP"
+    "STABLE_ABI;FREE_THREADED;NB_STATIC;NB_SHARED;PROTECT_STACK;LTO;NOMINSIZE;NOSTRIP;MUSL_DYNAMIC_LIBCPP;NB_SUPPRESS_WARNINGS"
     "NB_DOMAIN" "")
 
   add_library(${name} MODULE ${ARG_UNPARSED_ARGUMENTS})
@@ -355,7 +362,11 @@ function(nanobind_add_module name)
     set(libname ${libname}-${ARG_NB_DOMAIN})
   endif()
 
-  nanobind_build_library(${libname})
+  if (ARG_NB_SUPPRESS_WARNINGS)
+    set(EXTRA_LIBRARY_PARAMS AS_SYSINCLUDE)
+  endif()
+
+  nanobind_build_library(${libname} ${EXTRA_LIBRARY_PARAMS})
 
   if (ARG_NB_DOMAIN)
     target_compile_definitions(${name} PRIVATE NB_DOMAIN=${ARG_NB_DOMAIN})

--- a/docs/api_cmake.rst
+++ b/docs/api_cmake.rst
@@ -84,8 +84,12 @@ The high-level interface consists of just one CMake command:
           as a shared library for use in projects that consist of multiple
           extensions.
       * - ``NB_SUPPRESS_WARNINGS``
-        - Mark nanobind's include directories as system includes, suppressing
-          warnings generated from nanobind's and Python's header files.
+        - Mark the include directories of nanobind and Python as
+          [SYSTEM](https://cmake.org/cmake/help/latest/command/include_directories.html)
+          include directories, which suppresses any potential warning messages
+          originating there. This is mainly of relevance if your project artificially
+          raises the warning level via flags like `-pedantic`, ``-Wcast-qual``,
+          ``-Wsign-conversion``.
       * - ``PROTECT_STACK``
         - Don't remove stack smashing-related protections.
       * - ``LTO``

--- a/docs/api_cmake.rst
+++ b/docs/api_cmake.rst
@@ -83,6 +83,9 @@ The high-level interface consists of just one CMake command:
         - The opposite of ``NB_STATIC``: compile the core nanobind library
           as a shared library for use in projects that consist of multiple
           extensions.
+      * - ``NB_SUPPRESS_WARNINGS``
+        - Mark nanobind's include directories as system includes, suppressing
+          warnings generated from nanobind's and Python's header files.
       * - ``PROTECT_STACK``
         - Don't remove stack smashing-related protections.
       * - ``LTO``


### PR DESCRIPTION
With this change compile commands generated by cmake for targets consuming nanobind use `-isystem` instead of `-I` for defining nanobind's header locations, which makes modern analysis tools (e.g. clang-analyzer) ignore them.