### PR TITLE
Two small doc fixes

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1032,7 +1032,7 @@ Wrapper classes
 
 .. cpp:class:: bytes: public object
 
-   This wrapper class represents Python unicode ``bytes`` instances.
+   This wrapper class represents Python ``bytes`` instances.
 
    .. cpp:function:: bytes(handle h)
 

--- a/docs/free_threaded.rst
+++ b/docs/free_threaded.rst
@@ -236,7 +236,7 @@ The following API specific to free-threading has been added:
 API stability
 _____________
 
-The interface explained in this is excluded from the project's semantic
+The interface explained in this section is excluded from nanobind's semantic
 versioning policy. Free-threading is still experimental, and API breaks may be
 necessary based on future experience and changes in Python itself.
 


### PR DESCRIPTION
* Bytes are not unicode
* the word "section" was missing from a sentence in the free-threading section
* replaced "the project" with "nanobind" in the same sentence,
   'cause that's somewhat more clear prose to this reader