### PR TITLE
Don't print too many "leaked instance" messages.

### DIFF
--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -295,6 +295,9 @@ static void internals_cleanup() {
                     break;
             }
         }
+        if (ctr >= 20) {
+            fprintf(stderr, " - ... skipped remainder\n");
+        }
 #endif
     }
 


### PR DESCRIPTION
Most terminals don't have 10k line s of scrollback buffer ...