### PR TITLE
Introduce def_visitor abstraction for objects that provide custom binding logic when passed to def()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -65,6 +65,14 @@ Version TBD (not yet released)
   not be an instance of the alias/trampoline type.
   (PR `#859 <https://github.com/wjakob/nanobind/pull/859>`__)
 
+- Added :cpp:class:`nb::def_visitor\<..\> <def_visitor>`, which can be used to
+  define your own binding logic that operates on a :cpp:class:`nb::class_\<..\>
+  <class_>` when an instance of the visitor object is passed to
+  :cpp:func:`class_::def()`. This generalizes the mechanism used by
+  :cpp:class:`init`, :cpp:class:`new_`, etc, so that you can create
+  binding abstractions that "feel like" the built-in ones.
+  (PR `#884 <https://github.com/wjakob/nanobind/pull/884>`__)
+
 Version 2.4.0 (Dec 6, 2024)
 ---------------------------
 


### PR DESCRIPTION
This has two purposes:
* I'm planning to contribute some `class_` extensions (for pickling and buffer protocol support) that I would like to be able to put in their own headers so they don't slow down compilation for those that don't use them. This PR allows `class_::def()` to perform an operation that was not foreseen by the code inside `class_`.
* I've found it quite ergonomically useful (and am carrying a local patch) to be able to add customizations by chaining `.def(my_thing())` to a class binding, rather than the existing supported alternative of giving the binding a name and calling a helper function on it (`auto someCls = nb::class_<...>(...); my_thing(someCls);`).

Previously `class_filler`, renamed to `def_visitor` per feedback.