### PR TITLE
Support nb::init(<lambda>) as syntactic sugar for custom constructors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -73,6 +73,17 @@ Version TBD (not yet released)
   binding abstractions that "feel like" the built-in ones.
   (PR `#884 <https://github.com/wjakob/nanobind/pull/884>`__)
 
+- :cpp:struct:`nb::init() <init>` may now be written with a function argument
+  and no template parameters to express a custom constructor that doesn't exist
+  in C++. For example, you could use this to adapt Python strings to a
+  pointer-and-length argument convention:
+  ``.def(nb::init([](std::string_view sv) { return MyType(sv.data(), sv.size()); }))``.
+  This feature is syntactic sugar for writing a custom ``"__init__"`` binding
+  using placement new, which remains fully supported, and which should continue
+  to be used in cases where the custom constructor cannot be written as a
+  function that finishes by returning a prvalue (``return MyType(some, args);``).
+  (PR `#885 <https://github.com/wjakob/nanobind/pull/885>`__)
+
 Version 2.4.0 (Dec 6, 2024)
 ---------------------------
 

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -543,7 +543,8 @@ propagated to Python:
 
 To fix this behavior, you must implement a *trampoline class*. A trampoline has
 the sole purpose of capturing virtual function calls in C++ and forwarding them
-to Python.
+to Python. (If you're reading nanobind's source code, you might see references
+to an *alias class*; it's the same thing as a trampoline class.)
 
 .. code-block:: cpp
 

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -278,6 +278,8 @@ struct is_copy_constructible : std::is_copy_constructible<T> { };
 template <typename T>
 constexpr bool is_copy_constructible_v = is_copy_constructible<T>::value;
 
+struct init_using_factory_tag {};
+
 NAMESPACE_END(detail)
 
 // Low level access to nanobind type objects
@@ -364,6 +366,106 @@ private:
             extra...);
     }
 };
+
+template <typename... Args>
+struct init<detail::init_using_factory_tag, Args...> {
+    static_assert(sizeof...(Args) == 2 || sizeof...(Args) == 4,
+                  "Unexpected instantiation convention for factory init");
+    static_assert(sizeof...(Args) != 2,
+                  "Couldn't deduce function signature for factory function");
+    static_assert(sizeof...(Args) != 4,
+                  "Base factory and alias factory accept different arguments, "
+                  "or we couldn't otherwise deduce their signatures");
+};
+
+template <typename Func, typename Return, typename... Args>
+struct init<detail::init_using_factory_tag, Func, Return(Args...)>
+  : def_visitor<init<detail::init_using_factory_tag, Func, Return(Args...)>> {
+    std::remove_reference_t<Func> func;
+
+    init(Func &&f) : func((detail::forward_t<Func>) f) {}
+
+    template <typename Class, typename... Extra>
+    NB_INLINE void execute(Class &cl, const Extra&... extra) {
+        using Type = typename Class::Type;
+        using Alias = typename Class::Alias;
+        constexpr bool has_alias = !std::is_same_v<Type, Alias>;
+        if constexpr (!has_alias) {
+            static_assert(std::is_constructible_v<Type, Return>,
+                          "nb::init() factory function must return an instance "
+                          "of the type by value, or something that can "
+                          "direct-initialize it");
+        } else {
+            static_assert(std::is_constructible_v<Alias, Return>,
+                          "nb::init() factory function must return an instance "
+                          "of the alias type by value, or something that can "
+                          "direct-initialize it");
+        }
+        cl.def(
+            "__init__",
+            [func_ = (detail::forward_t<Func>) func](pointer_and_handle<Type> v, Args... args) {
+                if constexpr (has_alias && std::is_constructible_v<Type, Return>) {
+                    if (!detail::nb_inst_python_derived(v.h.ptr())) {
+                        new (v.p) Type{ func_((detail::forward_t<Args>) args...) };
+                        return;
+                    }
+                }
+                new ((void *) v.p) Alias{ func_((detail::forward_t<Args>) args...) };
+            },
+            extra...);
+    }
+};
+
+template <typename CFunc, typename CReturn, typename AFunc, typename AReturn,
+          typename... Args>
+struct init<detail::init_using_factory_tag, CFunc, CReturn(Args...),
+            AFunc, AReturn(Args...)>
+  : def_visitor<init<detail::init_using_factory_tag, CFunc, CReturn(Args...),
+                     AFunc, AReturn(Args...)>> {
+    std::remove_reference_t<CFunc> cfunc;
+    std::remove_reference_t<AFunc> afunc;
+
+    init(CFunc &&cf, AFunc &&af)
+      : cfunc((detail::forward_t<CFunc>) cf),
+        afunc((detail::forward_t<AFunc>) af) {}
+
+    template <typename Class, typename... Extra>
+    NB_INLINE void execute(Class &cl, const Extra&... extra) {
+        using Type = typename Class::Type;
+        using Alias = typename Class::Alias;
+        static_assert(!std::is_same_v<Type, Alias>,
+                      "The form of nb::init() that takes two factory functions "
+                      "doesn't make sense to use on classes that don't have an "
+                      "alias type");
+        static_assert(std::is_constructible_v<Type, CReturn>,
+                      "nb::init() first factory function must return an "
+                      "instance of the type by value, or something that can "
+                      "direct-initialize it");
+        static_assert(std::is_constructible_v<Alias, AReturn>,
+                      "nb::init() second factory function must return an "
+                      "instance of the alias type by value, or something that "
+                      "can direct-initialize it");
+        cl.def(
+            "__init__",
+            [cfunc_ = (detail::forward_t<CFunc>) cfunc,
+             afunc_ = (detail::forward_t<AFunc>) afunc](pointer_and_handle<Type> v, Args... args) {
+                if (!detail::nb_inst_python_derived(v.h.ptr()))
+                    new (v.p) Type{ cfunc_((detail::forward_t<Args>) args...) };
+                else
+                    new ((void *) v.p) Alias{ afunc_((detail::forward_t<Args>) args...) };
+            },
+            extra...);
+    }
+};
+
+template <typename Func>
+init(Func&& f) -> init<detail::init_using_factory_tag,
+                       Func, detail::function_signature_t<Func>>;
+
+template <typename CFunc, typename AFunc>
+init(CFunc&& cf, AFunc&& af) -> init<detail::init_using_factory_tag,
+                                     CFunc, detail::function_signature_t<CFunc>,
+                                     AFunc, detail::function_signature_t<AFunc>>;
 
 template <typename Arg> struct init_implicit : def_visitor<init_implicit<Arg>> {
     template <typename T, typename... Ts> friend class class_;

--- a/tests/test_classes_ext.pyi.ref
+++ b/tests/test_classes_ext.pyi.ref
@@ -5,8 +5,12 @@ class A:
     def __init__(self, arg: int, /) -> None: ...
 
 class Animal:
+    @overload
     def __init__(self) -> None:
         """A constructor"""
+
+    @overload
+    def __init__(self, arg: None | None) -> None: ...
 
     def name(self) -> str:
         """A method"""
@@ -88,7 +92,14 @@ class D:
     def value(self, arg: int, /) -> None: ...
 
 class Dog(Animal):
+    @overload
     def __init__(self, arg: str, /) -> None: ...
+
+    @overload
+    def __init__(self, arg: bytes, /) -> None: ...
+
+    @overload
+    def __init__(self, arg: int, /) -> None: ...
 
 class FinalType:
     def __init__(self) -> None: ...
@@ -199,6 +210,9 @@ class Struct:
 
     @overload
     def __init__(self, arg: int, /) -> None: ...
+
+    @overload
+    def __init__(self, arg: str, /) -> None: ...
 
     def value(self) -> int: ...
 


### PR DESCRIPTION
Unlike the corresponding pybind11 feature, the lambda must return by value, not by pointer. This simplifies the plumbing quite a bit and allows us to typically take advantage of guaranteed copy elision, producing basically the same code that we would have gotten from the previously-recommended manual `__init__` approach. Manual `__init__` is still the most appropriate method if some action needs to be taken after calling the C++ constructor.

This PR fully supports alias/trampoline classes, including the option to pass separate factory functions for constructing the bound type vs the trampoline type, except that I didn't bother providing an equivalent of pybind11's `init_alias` for forcing to always construct the trampoline type (since we don't have that for C++-provided constructors either). If this PR is judged too complex, the easiest way to simplify it would be by dropping support for trampoline classes. I'm a bit reluctant to do that though, since there is no supported API for constructing a trampoline class using the manual approach (since `detail::nb_inst_python_derived()` is internal).