### PR TITLE
Fix race condition in free-threaded Python (fixes issue #867)

### DIFF
--- a/docs/free_threaded.rst
+++ b/docs/free_threaded.rst
@@ -103,6 +103,11 @@ supplemental locking. The :ref:`next section <free-threaded-locks>` explains a
 Python-specific locking primitive that can be used in binding code besides
 the solutions mentioned above.
 
+Multi-threaded code that concurrently returns the same C++ instance via the
+:cpp:enumerator:`nb::rv_policy::reference` policy may observe situations, where
+multiple Python objects are created that all wrap the same C++ instance
+(however, this is harmless aside from the duplication).
+
 .. _free-threaded-locks:
 
 Python locks

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -16,6 +16,23 @@ struct GlobalData {} global_data;
 
 nb::ft_mutex mutex;
 
+struct ClassWithProperty {
+public:
+    ClassWithProperty(int value): value_(value) {}
+    int get_prop() const { return value_; }
+private:
+    int value_;
+};
+
+class ClassWithClassProperty {
+public:
+    ClassWithClassProperty(ClassWithProperty value) : value_(std::move(value)) {};
+    const ClassWithProperty& get_prop() const { return value_; }
+private:
+    ClassWithProperty value_;
+};
+
+
 NB_MODULE(test_thread_ext, m) {
     nb::class_<Counter>(m, "Counter")
         .def(nb::init<>())
@@ -39,4 +56,16 @@ NB_MODULE(test_thread_ext, m) {
 
     nb::class_<GlobalData>(m, "GlobalData")
         .def_static("get", [] { return &global_data; }, nb::rv_policy::reference);
+
+    nb::class_<ClassWithProperty>(m, "ClassWithProperty")
+        .def(nb::init<int>(), nb::arg("value"))
+        .def_prop_ro("prop2", &ClassWithProperty::get_prop);
+
+    nb::class_<ClassWithClassProperty>(m, "ClassWithClassProperty")
+        .def(
+          "__init__",
+          [](ClassWithClassProperty* self, ClassWithProperty value) {
+            new (self) ClassWithClassProperty(std::move(value));
+          }, nb::arg("value"))
+        .def_prop_ro("prop1", &ClassWithClassProperty::get_prop);
 }

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -29,7 +29,7 @@ def test02_global_lock(n_threads=8):
     n = 100000
     c = Counter()
     def f():
-        for i in range(n):
+        for _ in range(n):
             t.inc_global(c)
 
     parallelize(f, n_threads=n_threads)
@@ -53,7 +53,7 @@ def test04_locked_function(n_threads=8):
     n = 100000
     c = Counter()
     def f():
-        for i in range(n):
+        for _ in range(n):
             t.inc_safe(c)
 
     parallelize(f, n_threads=n_threads)
@@ -77,11 +77,11 @@ def test05_locked_twoargs(n_threads=8):
     assert c.value == n * n_threads
 
 
-def test_06_global_wrapper(n_threads=8):
+def test06_global_wrapper(n_threads=8):
     # Check wrapper lookup racing with wrapper deallocation
     n = 10000
     def f():
-        for i in range(n):
+        for _ in range(n):
             GlobalData.get()
             GlobalData.get()
             GlobalData.get()

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -1,5 +1,5 @@
 import test_thread_ext as t
-from test_thread_ext import Counter, GlobalData
+from test_thread_ext import Counter, GlobalData, ClassWithProperty, ClassWithClassProperty
 from common import parallelize
 
 def test01_object_creation(n_threads=8):
@@ -86,5 +86,17 @@ def test06_global_wrapper(n_threads=8):
             GlobalData.get()
             GlobalData.get()
             GlobalData.get()
+
+    parallelize(f, n_threads=n_threads)
+
+
+def test07_access_attributes(n_threads=8):
+    n = 1000
+    c1 = ClassWithProperty(123)
+    c2 = ClassWithClassProperty(c1)
+
+    def f():
+        for i in range(n):
+            _ = c2.prop1.prop2
 
     parallelize(f, n_threads=n_threads)


### PR DESCRIPTION
This commit addresses an issue arising when multiple threads want to access the Python object associated with the same C++ instance, which does not exist yet and therefore must be created. @vfdev-5 reported that TSAN detects a race condition in code that uses this pattern, caused by concurrent unprotected reads/writes of internal ``nb_inst`` fields.

To fix this issue, we split instance creation and registration into a two-step process. The registration is only done when the object is fully constructed.