### PR TITLE
Added a comment about GIL acquisition vs. multithreading vs. program exit.

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -2737,6 +2737,12 @@ running it in parallel from multiple Python threads.
 
       Reacquire the GIL
 
+If you use nanobind in a multi-threaded program, you **must** ensure that
+all threads have terminated **before** the interpreter exits. Otherwise any
+code that re-acquires the GIL (e.g. for running destructors) will throw a
+cancellation exception. This will result in a hard crash because C++ does
+not support exceptions in destructors, nor ignoring a cancellation.
+
 Free-threading
 --------------
 


### PR DESCRIPTION
I added a paragraph warning about this problem. Maybe it saves somebody else a few hours of work.

Cf. #890 where one of my problems was exactly this …