### PR TITLE
stubgen: Fix generated stub filename when referencing out-of-director…

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -1369,7 +1369,13 @@ def main(args: Optional[List[str]] = None) -> None:
 
             ext_loader = importlib.machinery.ExtensionFileLoader
             if isinstance(mod_imported.__loader__, ext_loader):
-                file = file.with_name(mod_imported.__name__)
+                # Splitting on "." (module nesting qualifier) handles the case
+                # of invoking stubgen on a module that's not in the current
+                # working directory - in that case, we still only want the Python
+                # module name as the stub file name, not the whole source tree
+                # hierarchy.
+                modname = mod_imported.__name__.split(".")[-1]
+                file = file.with_name(modname)
             file = file.with_suffix(".pyi")
 
             if opt.output_dir:


### PR DESCRIPTION
…y extensions

Currently, to generate stubs for extensions not contained in the current directory, you have to invoke stubgen like so:

`python -m nanobind.stubgen -m path.to.my.module -r -O ...`

This is for example how I do it in nanobind-bazel, because Bazel invokes scripts from a hermetic "runfiles" directory, which is in general not the source directory.

In the recursive case, and possibly also the non-recursive case with an output directory specified, this leads to the creation of a file called `path.to.my.pyi`, which is not what we want (IDEs generally require that the stub file be of the same name as the generated module).

Hence, in that case, we infer the stub file name as the last part of the module name given to stubgen.

----------------------------

Before:

```
# NB: _main/src/ is a typical top-level directory layout of Bazel's Python runfiles.
$ python -m nanobind.stubgen -m _main.src.nanobind_example_ext -r -O src
Module "_main.src.nanobind_example_ext" ..
  - importing ..
  - analyzing ..
  - writing stub "src/sub_ext/__init__.pyi" ..
  - writing stub "src/_main.src.pyi" ..  # <- this path is wrong/nonsensical
```
and after:

```
$ python -m nanobind.stubgen -m _main.src.nanobind_example_ext -r -O src
Module "_main.src.nanobind_example_ext" ..
  - importing ..
  - analyzing ..
  - writing stub "src/sub_ext/__init__.pyi" ..
  - writing stub "src/nanobind_example_ext.pyi" ..
```

This is a follow-up to https://github.com/nicholasjng/nanobind-bazel/pull/44, where @cemlyn007 added recursive stubgen support to nanobind-bazel. He also kindly added a workaround for this problem there, but I would love to see it fixed upstream as well.

I would appreciate your opinion - for in-tree stub generation (i.e., the extension is contained in the current directory), this does not change anything, since then, the module name will not contain any dots.