### PR TITLE
Fix underalignment of nanobind-bound classes.

### DIFF
--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1189,6 +1189,9 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
     bool base_intrusive_ptr =
         tb && (tb->flags & (uint32_t) type_flags::intrusive_ptr);
 
+    // tp_basicsize must satisfy pointer alignment.
+    basicsize = (basicsize + ptr_size - 1) / ptr_size * ptr_size;
+
     char *name_copy = strdup_check(name.c_str());
 
     constexpr size_t nb_type_max_slots = 11,


### PR DESCRIPTION
See https://github.com/python/cpython/issues/129675#issuecomment-2638095421
`tp_basicsize` needs to be a multiple of the alignment of `PyObject`, which is in effect pointer aligned.

This fixes a SIGBUS alignment crash found when testing free-threaded nanobind-using code on aarch64.