### PR TITLE
ndarray: use clone to copy return pytorch tensors

### DIFF
--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -803,8 +803,12 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
     }
 
     if (copy) {
+        const char* copy_str = "copy";
+        if (framework == pytorch::value)
+            copy_str = "clone";
+        
         try {
-            o = o.attr("copy")();
+            o = o.attr(copy_str)();
         } catch (std::exception &e) {
             PyErr_Format(PyExc_RuntimeError,
                          "nanobind::detail::ndarray_export(): copy failed: %s",


### PR DESCRIPTION
Using `rv_policy::copy` for torch tensors is currently broken. Produces the following error:
```
RuntimeError: nanobind::detail::ndarray_export(): copy failed: AttributeError: 'Tensor' object has no attribute 'copy'
```

The error message is correct, torch tensors don't have an out-of-place `copy` attribute, they have `clone()`.

I added a simple if statement to change out the attribute name in the ndarray export function. If other frameworks have similar issues, could be expanded to a switch case or so.
