### PR TITLE
Add missing #pragma once

### DIFF
--- a/include/nanobind/typing.h
+++ b/include/nanobind/typing.h
@@ -7,6 +7,8 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
+#pragma once
+
 #include <nanobind/nanobind.h>
 
 NAMESPACE_BEGIN(NB_NAMESPACE)

--- a/src/nb_ft.h
+++ b/src/nb_ft.h
@@ -7,6 +7,8 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
+#pragma once
+
 #if !defined(Py_GIL_DISABLED)
 /// Trivial implementations for non-free-threaded Python
 inline void make_immortal(PyObject *) noexcept { }


### PR DESCRIPTION
This adds `#pragma once` to the following headers:

- The public header `<nanobind/typing.h>`, which would result in an error if included twice.

- The private header `src/nb_ft.h`, which _is_ included twice by `nb_combined.cpp`, resulting in an error (at least in my environment).

(There are additional private headers that lack `#pragma once`; I'm leaving those alone here.)