### PR TITLE
Add input types to chrono type casters

### DIFF
--- a/include/nanobind/stl/chrono.h
+++ b/include/nanobind/stl/chrono.h
@@ -99,7 +99,13 @@ public:
         return pack_timedelta(dd.count(), ss.count(), us.count());
     }
 
-    NB_TYPE_CASTER(type, const_name("datetime.timedelta"))
+    #if PY_VERSION_HEX < 0x03090000
+        NB_TYPE_CASTER(type, io_name("typing.Union[datetime.timedelta, float]",
+                                     "datetime.timedelta"))
+    #else
+        NB_TYPE_CASTER(type, io_name("datetime.timedelta | float",
+                                     "datetime.timedelta"))
+    #endif
 };
 
 template <class... Args>
@@ -208,7 +214,13 @@ public:
                              localtime.tm_sec,
                              (int) us.count());
     }
-    NB_TYPE_CASTER(type, const_name("datetime.datetime"))
+    #if PY_VERSION_HEX < 0x03090000
+        NB_TYPE_CASTER(type, io_name("typing.Union[datetime.datetime, datetime.date, datetime.time]",
+                                     "datetime.datetime"))
+    #else
+        NB_TYPE_CASTER(type, io_name("datetime.datetime | datetime.date | datetime.time",
+                                     "datetime.datetime"))
+    #endif
 };
 
 // Other clocks that are not the system clock are not measured as


### PR DESCRIPTION
The type casters in `stl/chrono.h` accept various types in their
`from_python` calls, but they currently just use a name for their
output type.

This uses `io_name` to differentiate, adding the various acceptable
types that the casters permit at runtime

This also includes type stub testing for the `test_chrono_ext` module. The
first commit in this PR contains the stubs only.