### PR TITLE
docs: Add resources for nanobind-bazel v2.5.0 changes

### DIFF
--- a/docs/api_bazel.rst
+++ b/docs/api_bazel.rst
@@ -56,23 +56,28 @@ rule.
             name,
             module,
             output_file = None,
+            output_directory = None,
             imports = [],
             pattern_file = None,
             marker_file = None,
             include_private_members = False,
-            exclude_docstrings = False):
+            exclude_docstrings = False,
+            recursive = False):
 
     It generates a `py_binary <https://bazel.build/reference/be/
     python#py_binary>`__ rule with a corresponding runfiles distribution,
     which invokes nanobind's builtin stubgen script, outputs a stub file and,
-    optionally, a typing marker file into the build
-    output directory (commonly called "bindir" in Bazel terms).
+    optionally, a typing marker file into ``output_directory`` (defaults to
+    the build output directory, commonly called "bindir" in Bazel terms).
 
     All arguments (except the name, which is used only to refer to the target
     in Bazel) correspond directly to nanobind's stubgen command line interface,
     which is described in more detail in the :ref:`typing documentation <stubs>`.
 
     *New in nanobind-bazel version 2.1.0.*
+
+    *New in nanobind-bazel v2.5.0: Added the "output_directory" and "recursive"
+    keyword arguments.*
 
 To build a C++ library with nanobind as a dependency, use the
 ``nanobind_library`` rule.

--- a/docs/bazel.rst
+++ b/docs/bazel.rst
@@ -27,8 +27,8 @@ in your MODULE.bazel file:
     # Place this in your MODULE.bazel file.
     # The major version of nanobind-bazel is equal to the version
     # of the internally used nanobind.
-    # In this case, we are building bindings with nanobind v2.4.0.
-    bazel_dep(name = "nanobind_bazel", version = "2.4.0")
+    # In this case, we are building bindings with nanobind v2.5.0.
+    bazel_dep(name = "nanobind_bazel", version = "2.5.0")
 
 To instead use a development version from GitHub, you can declare the
 dependency as a ``git_override()`` in your MODULE.bazel:


### PR DESCRIPTION
Bumps the version number in MODULE.bazel, and mentions the additional keyword arguments supported in `nanobind_stubgen`.