### PR TITLE
stubgen: Fix module search of nested modules

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -676,7 +676,7 @@ class StubGen:
                         cls_name = search_cls_name
                         break
                     search_mod_name, _, symbol = search_mod_name.rpartition(".")
-                    search_cls_name = f"{search_cls_name}.{symbol}"
+                    search_cls_name = f"{symbol}.{search_cls_name}"
 
                 # Import the module and reference the contained class by name
                 self.import_object(mod_name, None)


### PR DESCRIPTION
This PR fixes the logic that tries to find which dot (`.`) separates the module from the class in a nested type name in `simplify_types`. The current logic flipped the components, creating invalid type names.