### PR TITLE
Faster attribute lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-2022', 'macos-13']
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13.0-rc.2', 'pypy3.9-v7.3.16', 'pypy3.10-v7.3.17']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-alpha.5', 'pypy3.9-v7.3.16', 'pypy3.10-v7.3.17']
 
     name: "Python ${{ matrix.python }} / ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -49,7 +49,7 @@ jobs:
         python -m pip install pytest pytest-github-actions-annotate-failures typing_extensions
 
     - name: Install NumPy
-      if: ${{ !startsWith(matrix.python, 'pypy') && !contains(matrix.python, 'rc.2') }}
+      if: ${{ !startsWith(matrix.python, 'pypy') && !contains(matrix.python, 'alpha') }}
       run: |
         python -m pip install numpy scipy
 

--- a/cmake/darwin-ld-cpython.sym
+++ b/cmake/darwin-ld-cpython.sym
@@ -867,6 +867,7 @@
 -U __PyObject_GC_New
 -U __PyObject_GC_NewVar
 -U __PyObject_GC_Resize
+-U __PyObject_LookupAttr
 -U __PyObject_MakeTpCall
 -U __PyObject_New
 -U __PyObject_NewVar

--- a/cmake/darwin-ld-cpython.sym
+++ b/cmake/darwin-ld-cpython.sym
@@ -924,3 +924,4 @@
 -U _PyCriticalSection2_Begin
 -U _PyCriticalSection2_End
 -U _PyUnicode_AsUTF8
+-U _Py_REFCNT


### PR DESCRIPTION
When an attribute lookup fails, Python spends a significant chunk of CPU cycles formatting and then raising an exception.

The ``nb::getattr(object, key, default)`` API provides a fallback ``default`` value in the case of an error. The expense of raising an exception is therefore not wanted here.

This commit avoids this exception by

- using the new ``PyObject_GetOptionalAttr()`` function on Python 3.13+
- using an internal ``_PyObject_LookupAttr()`` API before Python 3.13.
- on the 3.12 stable API, using ``PyObject_HasAttr()`` before doing the lookup.