### PR TITLE
Allow taking optional by value in function arguments

### DIFF
--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -262,6 +262,7 @@ NB_MODULE(test_stl_ext, m) {
     m.def("identity_string_view", [](std::string_view& x) { return x; });
 
     // ----- test36-test42 ------
+    m.def("optional_int", [](std::optional<int> x) { return x; }, nb::arg("x"));
     m.def("optional_copyable", [](std::optional<Copyable> &) {}, nb::arg("x").none());
     m.def("optional_copyable_ptr", [](std::optional<Copyable *> &) {}, nb::arg("x").none());
     m.def("optional_none", [](std::optional<Copyable> &x) { if(x) fail(); }, nb::arg("x").none());

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -374,6 +374,20 @@ def test35_string_and_string_view():
     assert t.identity_string_view("🍊") == "🍊"
 
 
+
+def test36a_std_optional_int(clean):
+    v = t.optional_int(None)
+    assert v == None
+    v = t.optional_int(5)
+    assert v == None
+
+    opt_copyable = optional("test_stl_ext.Copyable")
+    assert t.optional_copyable.__doc__ == (
+        f"optional_copyable(x: {opt_copyable}) -> None"
+    )
+    assert_stats(default_constructed=1, copy_constructed=1, destructed=2)
+ 
+
 def test36_std_optional_copyable(clean):
     t.optional_copyable(t.Copyable())
     opt_copyable = optional("test_stl_ext.Copyable")


### PR DESCRIPTION
This appears to be a bug, or perhaps just an oversight?