### PR TITLE
Create a metaclass for each supplemental data type

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -2059,9 +2059,20 @@ declarations in generated :ref:`stubs <stubs>`,
 
 .. cpp:struct:: template <typename T> supplement
 
-   Indicate that ``sizeof(T)`` bytes of memory should be set aside to
-   store supplemental data in the type object. See :ref:`Supplemental
-   type data <supplement>` for more information.
+   Indicate that the type being created (not its instances) should contain
+   a subobject of type ``T``, which can later be accessed using
+   :cpp:func:`nb::type_supplement\<T\>() <type_supplement>`. nanobind will
+   create a separate metaclass per type ``T``. See
+   :ref:`Supplemental type data <supplement>` for more information.
+
+   .. cpp::function:: supplement&& inheritable() &&
+
+      By default, specifying a supplement for a type prevents that type from
+      being inherited, since there would be no general way to initialize the
+      supplemental data for the derived type. If you instead pass the binding
+      annotation ``nb::supplement<T>().inheritable()``, inheritance will be
+      allowed. Any derived type gets a new default-constructed copy of the
+      supplemental data, not a copy of the data stored in the base type.
 
 .. cpp:struct:: type_slots
 
@@ -2865,6 +2876,13 @@ Type objects
    creating the type; no type check is performed, and invalid supplement
    accesses may crash the interpreter. Also refer to
    :cpp:class:`nb::supplement\<T\> <supplement>`.
+
+.. cpp:function:: template <typename T> bool type_has_supplement(handle h)
+
+   Assuming that `h` represents a bound type (see :cpp:func:`type_check`),
+   check whether it stores supplemental data of type ``T``. If this function
+   returns true, then it is valid to call :cpp:func:`nb::type_supplement\<T\>(h)
+   <type_supplement>`.
 
 .. cpp:function:: str type_name(handle h)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,20 @@ Upcoming version (TBA)
   long-standing inconvenience. (PR `#778
   <https://github.com/wjakob/nanobind/pull/778>`__).
 
-* ABI version 16.
+- nanobind now creates a separate metaclass for each supplemental data type
+  named in a :cpp:class:`nb::supplement\<T\>() <supplement>` class
+  binding annotation. (Previously, it created a separate metaclass for each
+  **size** of supplemental data.) This enables the use of supplemental data
+  types with non-trivial construction and destruction. You can also now query
+  whether a nanobind type uses a particular supplement type via the new
+  function :cpp:func:`nb::type_has_supplement\<T\>() <type_has_supplement>`,
+  and can implement certain metaclass customizations by defining a method
+  ``static void T::init_metaclass(PyTypeObject *metatype)``. Review the
+  documentation of :ref:`supplemental type data <supplement>` for more
+  information about the new capabilities. (PR `#972
+  <https://github.com/wjakob/nanobind/pull/972>`__).
+
+- ABI version 16.
 
 
 Version 2.5.0 (Feb 2, 2025)

--- a/docs/porting.rst
+++ b/docs/porting.rst
@@ -338,7 +338,12 @@ Removed features include:
   annotation was removed. However, the same behavior can be achieved by
   creating unnamed arguments; see the discussion in the section on
   :ref:`keyword-only arguments <kw_only>`.
-- ○ **Metaclasses**: creating types with custom metaclasses is unsupported.
+- ○ **Metaclasses**: Creating types with arbitrary custom metaclasses is
+  unsupported. However, many of the things you might want a metaclass for can
+  be accomplished using :ref:`supplemental type data <supplement>`. Each
+  supplement type is associated with its own metaclass, so you can add some
+  customizations after the metaclass has been created, but nanobind does not
+  allow customizing the metaclass's type, bases, or slots.
 - ○ **Module-local bindings**: support was removed (both for types and exceptions).
 - ○ **Custom allocation**: C++ classes with an overloaded or deleted ``operator
   new`` / ``operator delete`` are not supported.

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -125,7 +125,14 @@ struct kw_only {};
 struct lock_self {};
 
 template <size_t /* Nurse */, size_t /* Patient */> struct keep_alive {};
-template <typename T> struct supplement {};
+template <typename T> struct supplement {
+    bool is_inheritable = false;
+
+    supplement&& inheritable() && {
+        is_inheritable = true;
+        return std::move(*this);
+    }
+};
 template <typename T> struct intrusive_ptr {
     intrusive_ptr(void (*set_self_py)(T *, PyObject *) noexcept)
         : set_self_py(set_self_py) { }

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -143,17 +143,6 @@ struct supplement_data {
     constructor_t construct; // nullptr if trivial
     destructor_t destruct; // nullptr if trivial
     init_metaclass_t init_metaclass; // nullptr if not defined
-
-    // Cache the metaclass object that nanobind has created to serve as
-    // the type of all nanobind types that use this supplement type.
-    // Due to this cache, the cost of looking up a given supplement type is
-    // paid once per module rather than once per nanobind type that uses it.
-    mutable PyTypeObject *metaclass_cache = nullptr;
-
-    // Link together all the supplement_data structures for the same type
-    // in different extension modules, so that all of their metaclass_cache
-    // members can be cleared when the metaclass is destroyed.
-    mutable const supplement_data *next_in_chain = nullptr;
 };
 
 template <typename T, typename = void>

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -131,6 +131,57 @@ struct type_data {
 #endif
 };
 
+/// Information about a type T used as nb::supplement<T>()
+struct supplement_data {
+    // These aliases are required to work around a MSVC bug
+    using constructor_t = void (*)(void *supp, PyTypeObject *tp);
+    using destructor_t = void (*)(void *supp);
+    using init_metaclass_t = void (*)(PyTypeObject *metatype);
+
+    const std::type_info *type;
+    size_t size;
+    constructor_t construct; // nullptr if trivial
+    destructor_t destruct; // nullptr if trivial
+    init_metaclass_t init_metaclass; // nullptr if not defined
+
+    // Cache the metaclass object that nanobind has created to serve as
+    // the type of all nanobind types that use this supplement type.
+    // Due to this cache, the cost of looking up a given supplement type is
+    // paid once per module rather than once per nanobind type that uses it.
+    mutable PyTypeObject *metaclass_cache = nullptr;
+
+    // Link together all the supplement_data structures for the same type
+    // in different extension modules, so that all of their metaclass_cache
+    // members can be cleared when the metaclass is destroyed.
+    mutable const supplement_data *next_in_chain = nullptr;
+};
+
+template <typename T, typename = void>
+inline supplement_data::init_metaclass_t init_metaclass_for = nullptr;
+
+template <typename T>
+inline supplement_data::init_metaclass_t init_metaclass_for<
+        T, std::void_t<decltype(&T::init_metaclass)>> = &T::init_metaclass;
+
+template <typename T, typename = int>
+inline supplement_data::constructor_t construct_supplement_for =
+        std::is_trivially_default_constructible_v<T> ? nullptr :
+                +[](void *p, PyTypeObject *) { new (p) T{}; };
+
+template <typename T>
+inline supplement_data::constructor_t construct_supplement_for<
+        T, enable_if_t<std::is_constructible_v<T, PyTypeObject *>>> =
+                +[](void *p, PyTypeObject *tp) { new (p) T{tp}; };
+
+template <typename T>
+inline const supplement_data supplement_data_for = {
+        &typeid(T), sizeof(T),
+        construct_supplement_for<T>,
+        std::is_trivially_destructible_v<T> ? nullptr :
+                +[](void *p) { ((T *) p)->~T(); },
+        init_metaclass_for<T>,
+};
+
 /// Information about a type that is only relevant when it is being created
 struct type_init_data : type_data {
     PyObject *scope;
@@ -138,7 +189,7 @@ struct type_init_data : type_data {
     PyTypeObject *base_py;
     const char *doc;
     const PyType_Slot *type_slots;
-    size_t supplement;
+    const supplement_data *supplement;
 };
 
 NB_INLINE void type_extra_apply(type_init_data &t, const handle &h) {
@@ -184,13 +235,13 @@ NB_INLINE void type_extra_apply(type_init_data & t, const sig &s) {
 }
 
 template <typename T>
-NB_INLINE void type_extra_apply(type_init_data &t, supplement<T>) {
-    static_assert(std::is_trivially_default_constructible_v<T>,
-                  "The supplement must be a POD (plain old data) type");
+NB_INLINE void type_extra_apply(type_init_data &t, supplement<T> supp) {
     static_assert(alignof(T) <= alignof(void *),
                   "The alignment requirement of the supplement is too high.");
-    t.flags |= (uint32_t) type_init_flags::has_supplement | (uint32_t) type_flags::is_final;
-    t.supplement = sizeof(T);
+    t.flags |= (uint32_t) type_init_flags::has_supplement;
+    if (!supp.is_inheritable)
+        t.flags |= (uint32_t) type_flags::is_final;
+    t.supplement = &supplement_data_for<T>;
 }
 
 enum class enum_flags : uint32_t {
@@ -287,6 +338,8 @@ inline size_t type_align(handle h) { return detail::nb_type_align(h.ptr()); }
 inline const std::type_info& type_info(handle h) { return *detail::nb_type_info(h.ptr()); }
 template <typename T>
 inline T &type_supplement(handle h) { return *(T *) detail::nb_type_supplement(h.ptr()); }
+template <typename T>
+inline bool type_has_supplement(handle h) { return detail::nb_type_has_supplement(h.ptr(), &typeid(T)); }
 inline str type_name(handle h) { return steal<str>(detail::nb_type_name(h.ptr())); }
 
 // Low level access to nanobind instance objects

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -316,6 +316,10 @@ NB_CORE void nb_type_restore_ownership(PyObject *o, bool cpp_delete) noexcept;
 /// Get a pointer to a user-defined 'extra' value associated with the nb_type t.
 NB_CORE void *nb_type_supplement(PyObject *t) noexcept;
 
+/// Determine whether the nb_type t has a supplement whose type matches supp_type.
+NB_CORE bool nb_type_has_supplement(PyObject *t,
+                                    const std::type_info *supp_type) noexcept;
+
 /// Check if the given python object represents a nanobind type
 NB_CORE bool nb_type_check(PyObject *t) noexcept;
 

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -436,8 +436,17 @@ void nb_type_unregister(type_data *t) noexcept {
           "find type!", t->name);
 }
 
-static void nb_type_dealloc(PyObject *o) {
+NB_INLINE const supplement_data *&nb_meta_supplement_data(PyTypeObject *o) noexcept {
+    return *(const supplement_data **)nb_type_data(o);
+}
+
+static void nb_type_dealloc(PyObject *o) noexcept {
     type_data *t = nb_type_data((PyTypeObject *) o);
+    PyTypeObject *metatype = Py_TYPE(o);
+    const supplement_data *s = nb_meta_supplement_data(metatype);
+
+    if (s && s->destruct)
+        s->destruct(t + 1);
 
     if (t->type && (t->flags & (uint32_t) type_flags::is_python_type) == 0)
         nb_type_unregister(t);
@@ -449,6 +458,7 @@ static void nb_type_dealloc(PyObject *o) {
 
     free((char *) t->name);
     NB_SLOT(PyType_Type, tp_dealloc)(o);
+    Py_DECREF(metatype);
 }
 
 /// Called when a C++ type is extended from within Python
@@ -502,6 +512,10 @@ static int nb_type_init(PyObject *self, PyObject *args, PyObject *kwds) {
 #else
     ((PyTypeObject *) self)->tp_vectorcall = nullptr;
 #endif
+
+    const supplement_data *s = nb_meta_supplement_data(Py_TYPE(self));
+    if (s && s->construct)
+        s->construct(t + 1, t->type_py);
 
     return 0;
 }
@@ -839,78 +853,117 @@ static PyObject *nb_type_from_metaclass(PyTypeObject *meta, PyObject *mod,
 
 extern int nb_type_setattro(PyObject* obj, PyObject* name, PyObject* value);
 
-static PyTypeObject *nb_type_tp(size_t supplement) noexcept {
-    object key = steal(PyLong_FromSize_t(supplement));
-    nb_internals *internals_ = internals;
-
-    PyTypeObject *tp =
-        (PyTypeObject *) dict_get_item_ref_or_fail(internals_->nb_type_dict, key.ptr());
-
-    if (NB_UNLIKELY(!tp)) {
-        // Retry in critical section to avoid races that create the same nb_type
-        lock_internals guard(internals_);
-
-        tp = (PyTypeObject *) dict_get_item_ref_or_fail(internals_->nb_type_dict, key.ptr());
-        if (tp)
-            return tp;
-
+// Create and return a new metaclass type that is appropriate for use with
+// the given supplement type, or for classes without a supplement if
+// supplement is nullptr. Must not be called concurrently from multiple threads.
+PyTypeObject *nb_meta_new(nb_internals *internals_,
+                          const supplement_data *supplement) noexcept {
 #if defined(Py_LIMITED_API)
-        PyMemberDef members[] = {
-            { "__vectorcalloffset__", Py_T_PYSSIZET, 0, Py_READONLY, nullptr },
-            { nullptr, 0, 0, 0, nullptr }
-        };
+    PyMemberDef members[] = {
+        { "__vectorcalloffset__", Py_T_PYSSIZET, 0, Py_READONLY, nullptr },
+        { nullptr, 0, 0, 0, nullptr }
+    };
 
-        // Workaround because __vectorcalloffset__ does not support Py_RELATIVE_OFFSET
-        members[0].offset = internals_->type_data_offset + offsetof(type_data, vectorcall);
+    // Workaround because __vectorcalloffset__ does not support Py_RELATIVE_OFFSET
+    members[0].offset = internals_->type_data_offset + offsetof(type_data, vectorcall);
 #endif
 
-        PyType_Slot slots[] = {
-            { Py_tp_base, &PyType_Type },
-            { Py_tp_dealloc, (void *) nb_type_dealloc },
-            { Py_tp_setattro, (void *) nb_type_setattro },
-            { Py_tp_init, (void *) nb_type_init },
+    PyType_Slot slots[] = {
+        { Py_tp_base, &PyType_Type },
+        { Py_tp_dealloc, (void *) nb_type_dealloc },
+        { Py_tp_setattro, (void *) nb_type_setattro },
+        { Py_tp_init, (void *) nb_type_init },
 #if defined(Py_LIMITED_API)
-            { Py_tp_members, (void *) members },
+        { Py_tp_members, (void *) members },
 #endif
-            { 0, nullptr }
-        };
+        { 0, nullptr }
+    };
+
+    size_t supplement_size = supplement ? supplement->size : 0;
 
 #if PY_VERSION_HEX >= 0x030C0000
-        int basicsize = -(int) (sizeof(type_data) + supplement),
-            itemsize = 0;
+    int basicsize = -(int) (sizeof(type_data) + supplement_size),
+        itemsize = 0;
 #else
-        int basicsize = (int) (PyType_Type.tp_basicsize + (sizeof(type_data) + supplement)),
-            itemsize = (int) PyType_Type.tp_itemsize;
+    int basicsize = (int) (PyType_Type.tp_basicsize + (sizeof(type_data) + supplement_size)),
+        itemsize = (int) PyType_Type.tp_itemsize;
 #endif
 
-        char name[17 + 20 + 1];
-        snprintf(name, sizeof(name), "nanobind.nb_type_%zu", supplement);
+    const char *cpp_name = supplement ? supplement->type->name() : "0";
+    size_t py_namelen = strlen("nanobind.nb_type_") + strlen(cpp_name) + 1;
+    char *py_name = (char *) alloca(py_namelen);
+    snprintf(py_name, py_namelen, "nanobind.nb_type_%s", cpp_name);
 
-        PyType_Spec spec = {
-            /* .name = */ name,
-            /* .basicsize = */ basicsize,
-            /* .itemsize = */ itemsize,
-            /* .flags = */ Py_TPFLAGS_DEFAULT,
-            /* .slots = */ slots
-        };
+    PyType_Spec spec = {
+        /* .name = */ py_name,
+        /* .basicsize = */ basicsize,
+        /* .itemsize = */ itemsize,
+        /* .flags = */ Py_TPFLAGS_DEFAULT,
+        /* .slots = */ slots
+    };
 
 #if defined(Py_LIMITED_API)
-        spec.flags |= Py_TPFLAGS_HAVE_VECTORCALL;
+    spec.flags |= Py_TPFLAGS_HAVE_VECTORCALL;
 #endif
 
-        tp = (PyTypeObject *) nb_type_from_metaclass(
-            internals_->nb_meta, internals_->nb_module, &spec);
+    PyTypeObject *tp = (PyTypeObject *) nb_type_from_metaclass(
+        internals_->nb_meta, internals_->nb_module, &spec);
+    check(tp, "%s type creation failed!", py_name);
+    nb_meta_supplement_data(tp) = supplement;
 
-        make_immortal((PyObject *) tp);
+    make_immortal((PyObject *) tp);
 
-        handle(tp).attr("__module__") = "nanobind";
+    handle(tp).attr("__module__") = "nanobind";
 
-        int rv = 1;
-        if (tp)
-            rv = PyDict_SetItem(internals_->nb_type_dict, key.ptr(), (PyObject *) tp);
-        check(rv == 0, "nb_type type creation failed!");
+    if (supplement && supplement->init_metaclass) {
+        supplement->init_metaclass(tp);
     }
 
+    return tp;
+}
+
+void nb_meta_dealloc(PyObject *o) {
+    const supplement_data *s = nb_meta_supplement_data((PyTypeObject *) o);
+    if (s) {
+        nb_internals *internals_ = internals;
+        lock_internals guard(internals_);
+        internals_->nb_type_for_supplement.erase(s->type);
+        while (s) {
+            s->metaclass_cache = nullptr;
+            auto *next = s->next_in_chain;
+            s->next_in_chain = nullptr;
+            s = next;
+        }
+    }
+}
+
+// Return a new reference to the metaclass type that is appropriate for use
+// with the given supplement type, creating it if necessary. supplement must
+// not be nullptr. Must not be called concurrently from multiple threads.
+static PyTypeObject *nb_meta_lookup(const supplement_data *supplement) noexcept {
+    // First, try the cache. This will succeed for any metaclass that has been
+    // used in this module.
+    if (NB_LIKELY(supplement->metaclass_cache)) {
+        Py_INCREF((PyObject *) supplement->metaclass_cache);
+        return supplement->metaclass_cache;
+    }
+
+    // Next, try the nb_types map. This will succeed for any metaclass that
+    // has been used in any other nanobind module in this domain.
+    nb_internals *internals_ = internals;
+    auto [it, inserted] = internals_->nb_type_for_supplement.try_emplace(
+            supplement->type);
+    if (inserted) {
+        // If it's not in the dict either, then we need to create a new nb_type.
+        it.value() = (type_data *) nb_meta_new(internals_, supplement);
+    } else {
+        auto *head = nb_meta_supplement_data((PyTypeObject *) it->second);
+        supplement->next_in_chain = head->next_in_chain;
+        head->next_in_chain = supplement;
+        Py_INCREF((PyObject *) it->second);
+    }
+    PyTypeObject *tp = (PyTypeObject *) it->second;
+    supplement->metaclass_cache = tp;
     return tp;
 }
 
@@ -1073,25 +1126,7 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
     object modname;
     PyObject *mod = nullptr;
 
-    // Update hash table that maps from std::type_info to Python type
-    nb_type_map_slow::iterator it;
-    bool success;
     nb_internals *internals_ = internals;
-
-    {
-        lock_internals guard(internals_);
-        std::tie(it, success) = internals_->type_c2p_slow.try_emplace(t->type, nullptr);
-        if (!success) {
-            PyErr_WarnFormat(PyExc_RuntimeWarning, 1,
-                             "nanobind: type '%s' was already registered!\n",
-                             t_name);
-            PyObject *tp = (PyObject *) it->second->type_py;
-            Py_INCREF(tp);
-            if (has_signature)
-                free((char *) t_name);
-            return tp;
-        }
-    }
 
     if (t->scope != nullptr) {
         if (PyModule_Check(t->scope)) {
@@ -1191,6 +1226,48 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
 
     // tp_basicsize must satisfy pointer alignment.
     basicsize = (basicsize + ptr_size - 1) / ptr_size * ptr_size;
+
+    const supplement_data *supplement = t->supplement;
+    if (tb) {
+        const supplement_data *base_supplement =
+                nb_meta_supplement_data(Py_TYPE(base));
+        if (base_supplement) {
+            check(!has_supplement || std_typeinfo_eq{}(supplement->type,
+                                                       base_supplement->type),
+                  "nanobind::detail::nb_type_new(\"%s\"): supplement type %s "
+                  "conflict with %s from base %s!",
+                  t_name, type_name(supplement->type),
+                  type_name(base_supplement->type), tb->name);
+            has_supplement = true;
+            supplement = base_supplement;
+        }
+    }
+
+    PyTypeObject *metaclass;
+    {
+        lock_internals guard(internals_);
+
+        // Update hash table that maps from std::type_info to Python type
+        auto [it, success] = internals_->type_c2p_slow.try_emplace(t->type, nullptr);
+        if (!success) {
+            PyErr_WarnFormat(PyExc_RuntimeWarning, 1,
+                             "nanobind: type '%s' was already registered!\n",
+                             t_name);
+            PyObject *tp = (PyObject *) it->second->type_py;
+            Py_INCREF(tp);
+            if (has_signature)
+                free((char *) t_name);
+            return tp;
+        }
+
+        // Determine metaclass to use, creating it if needed
+        if (has_supplement)
+            metaclass = nb_meta_lookup(supplement);
+        else {
+            metaclass = (PyTypeObject *) internals_->nb_type_0;
+            Py_INCREF((PyObject *) metaclass);
+        }
+    }
 
     char *name_copy = strdup_check(name.c_str());
 
@@ -1316,8 +1393,6 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
 
     *s++ = { 0, nullptr };
 
-    PyTypeObject *metaclass = nb_type_tp(has_supplement ? t->supplement : 0);
-
     PyObject *result = nb_type_from_metaclass(metaclass, mod, &spec);
     if (!result) {
         python_error err;
@@ -1377,6 +1452,9 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
 
     if (modname.is_valid())
         setattr(result, "__module__", modname.ptr());
+
+    if (has_supplement && supplement->construct)
+        supplement->construct(to + 1, to->type_py);
 
     {
         lock_internals guard(internals_);
@@ -2081,6 +2159,12 @@ const std::type_info *nb_type_info(PyObject *t) noexcept {
 
 void *nb_type_supplement(PyObject *t) noexcept {
     return nb_type_data((PyTypeObject *) t) + 1;
+}
+
+bool nb_type_has_supplement(PyObject *t,
+                            const std::type_info *supp_type) noexcept {
+    const supplement_data *supp = nb_meta_supplement_data(Py_TYPE(t));
+    return supp && std_typeinfo_eq{}(supp->type, supp_type);
 }
 
 PyObject *nb_inst_alloc(PyTypeObject *t) {

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -487,6 +487,20 @@ def test20_supplement():
     assert t.check_supplement(c)
     assert not t.check_supplement(t.Struct())
 
+    class Set:
+        pass
+
+    class List:
+        pass
+
+    t.Collection.register(Set)
+    t.Sequence.register(List)
+
+    assert isinstance(Set(), t.Collection)
+    assert not isinstance(Set(), t.Sequence)
+    assert isinstance(List(), t.Collection)
+    assert isinstance(List(), t.Sequence)
+
 
 def test21_type_callback():
     o = t.ClassWithLen()

--- a/tests/test_classes_ext.pyi.ref
+++ b/tests/test_classes_ext.pyi.ref
@@ -68,6 +68,9 @@ class ClassWithLen:
 class ClassWithSupplement:
     def __init__(self) -> None: ...
 
+class Collection:
+    __subclasses: set = ...
+
 class D:
     @overload
     def __init__(self, arg: A, /) -> None: ...
@@ -169,6 +172,11 @@ class PolymorphicBase:
 
 class PolymorphicSubclass:
     pass
+
+class Sequence(Collection):
+    def __init__(self) -> None: ...
+
+    __subclasses: set = ...
 
 class SiameseCat(Cat):
     pass


### PR DESCRIPTION
This allows many metaclass customizations without incurring the performance cost of allowing arbitrary metaclasses. As a side benefit, we get nontrivial construction and destruction of supplement types, and can check whether a particular nanobind type uses a particular supplement type. There are no additional per-instance performance or storage costs, no additional per-type storage costs, and negligible per-type performance costs.

The information about a particular supplement type is stored in a new `nb::detail::supplement_data` structure. An inline variable template is used to automatically create one of these in static data for each supplement type used in a particular extension module. Instances of `nb_meta` (i.e., metaclass types) gain a pointer to their `supplement_data`, which is null for the default metaclass `nb_type_0`. The non-default metaclass types `nb_type_xyz` are now stored in a `nb_type_map_slow` rather than a Python dictionary, and (except on free-threaded builds where everything is immortal) they are properly reference-counted so that they will be destroyed once all their instances are. This avoids leak warnings when assigning nanobind functions as their attributes.

Size cost:
* On my laptop this adds 781 bytes to a release build of libnanobind-static.a.
* One pointer per nanobind metatype, including the default one.
* One `nb::detail::supplement_data` structure (five pointers) stored in static data per supplement type used in an extension module.

I originally added some caching in static data to limit lookups by supplement type to one per supplement type per extension module. I removed this because it was a bit complex and I don't think it's necessary (we already do two type_map_slow lookups per nb_type_new, avoiding a third doesn't save all that much) but it would be easy to re-add. See commit 34739e3. The additional cost from that caching would be 104 bytes of code and two more pointers in `supplement_data`.