### PR TITLE
fix(cmake): error if SKBUILD_SABI_VERSION set and too low

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -26,6 +26,12 @@ elseif(DEFINED Python_SOSABI)
   set(NB_SOSABI "${Python_SOSABI}")
 endif()
 
+
+# Error if scikit-build-core is trying to build Stable ABI < 3.12 wheels
+if(DEFINED SKBUILD_SABI_VERSION AND SKBUILD_SABI_VERSION VERSION_LESS "3.12")
+  message(FATAL_ERROR "You must set 'tool.scikit-build.wheel.py-api to cp312 or later when using scikit-build-core with nanobind.")
+endif()
+
 # PyPy sets an invalid SOABI (platform missing), causing older FindPythons to
 # report an incorrect value. Only use it if it looks correct (X-X-X form).
 if(DEFINED NB_SOABI AND "${NB_SOABI}" MATCHES ".+-.+-.+")


### PR DESCRIPTION
This was confusing a user in https://github.com/scikit-build/scikit-build-core/issues/1017 and https://github.com/wjakob/nanobind/issues/976. I think this would really help, since it would have been a clear, readable error instead of a wheel that worked on the CPython it was built on but claimed it was Stable ABI.
