### PR TITLE
fix(cmake): Handle empty SKBUILD_SABI_VERSION

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -28,8 +28,9 @@ endif()
 
 
 # Error if scikit-build-core is trying to build Stable ABI < 3.12 wheels
-if(DEFINED SKBUILD_SABI_VERSION AND SKBUILD_SABI_VERSION VERSION_LESS "3.12")
-  message(FATAL_ERROR "You must set tool.scikit-build.wheel.py-api to 'cp312' or later when using scikit-build-core with nanobind.")
+if(DEFINED SKBUILD_SABI_VERSION AND SKBUILD_ABI_VERSION AND SKBUILD_SABI_VERSION VERSION_LESS "3.12")
+  message(FATAL_ERROR "You must set tool.scikit-build.wheel.py-api to 'cp312' or later when "
+                      "using scikit-build-core with nanobind, '${SKBUILD_SABI_VERSION}' is too old.")
 endif()
 
 # PyPy sets an invalid SOABI (platform missing), causing older FindPythons to


### PR DESCRIPTION
This is an empty string when it's not building for the Stable ABI.

I chose to check if it's defined and check if it's empty in two steps, though if you'd prefer, the empty check also is False if it's not defined. The form I used is slightly clearer, and might work a little better if someone passes `--warn-uninitialized` (maybe the second one passes that too, not sure).

Fix for regression in #978.