### PR TITLE
Eigen: Demonstrate and fix issue with passing `scipy.sparse` matrices with unsorted indices

### DIFF
--- a/include/nanobind/eigen/sparse.h
+++ b/include/nanobind/eigen/sparse.h
@@ -86,7 +86,11 @@ template <typename T> struct type_caster<T, enable_if_t<is_eigen_sparse_matrix_v
             return false;
         }
 
-        value = SparseMap(rows, cols, nnz, outer_indices.data(), inner_indices.data(), values.data());
+        SparseMap mapped_matrix(rows, cols, nnz, outer_indices.data(), inner_indices.data(), values.data());
+#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
+        mapped_matrix.sortInnerIndices();
+#endif
+        value = mapped_matrix;
 
         return true;
     }

--- a/include/nanobind/eigen/sparse.h
+++ b/include/nanobind/eigen/sparse.h
@@ -62,11 +62,9 @@ template <typename T> struct type_caster<T, enable_if_t<is_eigen_sparse_matrix_v
             return false;
         }
 
-#if !EIGEN_VERSION_AT_LEAST(3, 4, 90)
         bool indices_sorted = cast<bool>(obj.attr("has_sorted_indices"));
         if (!indices_sorted)
             obj.attr("sort_indices")();
-#endif
 
         if (object data_o = obj.attr("data"); !data_caster.from_python(data_o, flags, cleanup))
             return false;
@@ -92,11 +90,7 @@ template <typename T> struct type_caster<T, enable_if_t<is_eigen_sparse_matrix_v
             return false;
         }
 
-        SparseMap mapped_matrix(rows, cols, nnz, outer_indices.data(), inner_indices.data(), values.data());
-#if EIGEN_VERSION_AT_LEAST(3, 4, 90)
-        mapped_matrix.sortInnerIndices();
-#endif
-        value = mapped_matrix;
+        value = SparseMap(rows, cols, nnz, outer_indices.data(), inner_indices.data(), values.data());
 
         return true;
     }

--- a/include/nanobind/eigen/sparse.h
+++ b/include/nanobind/eigen/sparse.h
@@ -62,6 +62,12 @@ template <typename T> struct type_caster<T, enable_if_t<is_eigen_sparse_matrix_v
             return false;
         }
 
+#if !EIGEN_VERSION_AT_LEAST(3, 4, 90)
+        bool indices_sorted = cast<bool>(obj.attr("has_sorted_indices"));
+        if (!indices_sorted)
+            obj.attr("sort_indices")();
+#endif
+
         if (object data_o = obj.attr("data"); !data_caster.from_python(data_o, flags, cleanup))
             return false;
         ScalarNDArray& values = data_caster.value;

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -264,9 +264,6 @@ def test08_sparse():
     assert type(t.sparse_copy_r(t.sparse_c())) is scipy.sparse.csr_matrix
     assert type(t.sparse_copy_c(t.sparse_r())) is scipy.sparse.csc_matrix
 
-    # construct scipy matrix with unsorted indices
-    assert type(t.sparse_copy_c(create_spmat_unsorted())) is scipy.sparse.csc_matrix
-
 
     def assert_sparse_equal_ref(sparse_mat):
         ref = np.array(
@@ -286,7 +283,11 @@ def test08_sparse():
     assert_sparse_equal_ref(t.sparse_copy_c(t.sparse_c()))
     assert_sparse_equal_ref(t.sparse_copy_r(t.sparse_c()))
     assert_sparse_equal_ref(t.sparse_copy_c(t.sparse_r()))
-    assert_sparse_equal_ref(t.sparse_copy_c(create_spmat_unsorted()))
+
+    # construct scipy matrix with unsorted indices
+    assert type(t.sparse_copy_c(create_spmat_unsorted())) is scipy.sparse.csc_matrix
+    mat_unsort = create_spmat_unsorted()
+    assert_array_equal(t.sparse_copy_c(mat_unsort).toarray(), create_spmat_unsorted().toarray())
 
 
 @needs_numpy_and_eigen

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -231,6 +231,26 @@ def test07_mutate_arg():
     assert_array_equal(A, 2*A2)
 
 
+def create_spmat_unsorted():
+    import scipy.sparse as sparse
+    # Create a small matrix with explicit indices and indptr
+    data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    
+    # Deliberately unsorted indices within columns
+    # For a properly sorted CSC matrix, indices should be sorted within each column
+    indices = np.array([0, 2, 1, 4, 3])  # Unsorted (should be [0, 1, 2, 3, 4])
+    
+    # indptr points to where each column starts in the indices/data arrays
+    indptr = np.array([0, 2, 3, 5])
+    
+    # Create a 5x3 matrix with unsorted indices
+    unsorted_csc = sparse.csc_matrix((data, indices, indptr), shape=(5, 3))
+    
+    # Verify that indices are unsorted
+    assert not unsorted_csc.has_sorted_indices
+    return unsorted_csc
+
+
 @needs_numpy_and_eigen
 def test08_sparse():
     pytest.importorskip("scipy")
@@ -243,6 +263,10 @@ def test08_sparse():
     assert type(t.sparse_copy_c(t.sparse_c())) is scipy.sparse.csc_matrix
     assert type(t.sparse_copy_r(t.sparse_c())) is scipy.sparse.csr_matrix
     assert type(t.sparse_copy_c(t.sparse_r())) is scipy.sparse.csc_matrix
+
+    # construct scipy matrix with unsorted indices
+    assert type(t.sparse_copy_c(create_spmat_unsorted())) is scipy.sparse.csc_matrix
+
 
     def assert_sparse_equal_ref(sparse_mat):
         ref = np.array(
@@ -262,6 +286,7 @@ def test08_sparse():
     assert_sparse_equal_ref(t.sparse_copy_c(t.sparse_c()))
     assert_sparse_equal_ref(t.sparse_copy_r(t.sparse_c()))
     assert_sparse_equal_ref(t.sparse_copy_c(t.sparse_r()))
+    assert_sparse_equal_ref(t.sparse_copy_c(create_spmat_unsorted()))
 
 
 @needs_numpy_and_eigen


### PR DESCRIPTION
Hi,

I've just encountered an issue when the user passes a scipy sparse matrix with unsorted inner indices to Eigen.
This issue manifests in two ways:
- an `eigen_assert()` is triggered when compiling in Debug,
- or you can get incorrect values in your converted sparse matrix.

It seems until [relatively recently](https://gitlab.com/libeigen/eigen/-/merge_requests/1099) it was not explicitly stated that `Eigen::Map<SparseMatrix>` objects expect the inner indices to be sorted. This issue really pops up when you try to evaluate the map into a plain sparse matrix object, like here:
https://github.com/wjakob/nanobind/blob/10eafbc528574a7045133e9751d00c8bd61ae0da/include/nanobind/eigen/sparse.h#L89

Eigen's master branch has a nice `a.sortInnerIndices()` function and some helpers to check if the indices are sorted, for compressed storage types. For Eigen's released version (3.4.0 and below), for now I've added a call to SciPy's API to sort the indices of the passed sparse matrix.

This might be relevant for #782.
Also related: https://github.com/stack-of-tasks/eigenpy/pull/538 (in Boost.Python world)