### PR TITLE
Fix type in put_nb_static_property stubgen

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -462,7 +462,7 @@ class StubGen:
     def put_nb_static_property(self, name: Optional[str], prop: NbStaticProperty):
         """Append a 'nb_static_property' object"""
         getter_sig = prop.fget.__nb_signature__[0][0]
-        getter_sig = getter_sig[getter_sig.find("/) -> ") + 6 :]
+        getter_sig = getter_sig[getter_sig.find("() -> ") + 6 :]
         self.write_ln(f"{name}: {getter_sig} = ...")
         if prop.__doc__ and self.include_docstrings:
             self.put_docstr(prop.__doc__)


### PR DESCRIPTION
This was generating invalid `.pyi` files with code like this:

```cpp
nb::class_<NbDatabase>(m, "Database")
	.def_prop_ro_static("current", &NbDatabase::get_current, "Get the current database")
```