### PR TITLE
Disable clang-tidy on nanobind library

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -212,6 +212,11 @@ function (nanobind_build_library TARGET_NAME)
   set_target_properties(${TARGET_NAME} PROPERTIES
     POSITION_INDEPENDENT_CODE ON)
 
+  if (${ARG_AS_SYSINCLUDE})
+    set_target_properties(${TARGET_NAME} PROPERTIES
+      CXX_CLANG_TIDY "")
+  endif()
+
   if (MSVC)
     # Do not complain about vsnprintf
     target_compile_definitions(${TARGET_NAME} PRIVATE -D_CRT_SECURE_NO_WARNINGS)


### PR DESCRIPTION
Pull request for #994 as requested. Not disabling this could lead to build failures in projects where clang-tidy is globally enabled if one included the project as a submodule.