### PR TITLE
Use Py_XINCREF,Py_XDECREF also with Py_LIMITED_API

### DIFF
--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -183,7 +183,7 @@ public:
     NB_INLINE handle(const PyTypeObject *ptr) : m_ptr((PyObject *) ptr) { }
 
     const handle& inc_ref() const & noexcept {
-#if defined(NDEBUG) && !defined(Py_LIMITED_API)
+#if defined(NDEBUG)
         Py_XINCREF(m_ptr);
 #else
         detail::incref_checked(m_ptr);
@@ -192,7 +192,7 @@ public:
     }
 
     const handle& dec_ref() const & noexcept {
-#if defined(NDEBUG) && !defined(Py_LIMITED_API)
+#if defined(NDEBUG)
         Py_XDECREF(m_ptr);
 #else
         detail::decref_checked(m_ptr);


### PR DESCRIPTION
My understanding is that #500 concluded that it is fine to use `Py_XINCREF` and `Py_XDECREF` with `Py_LIMITED_API`.
If so, it seems preferable from a performance point of view.

Please review this PR carefully and correct me if I'm wrong.   I'm not a Python expert.