### PR TITLE
enum: __repr__ != __str__

### DIFF
--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -72,8 +72,8 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
     scope.attr(name) = result;
     result.attr("__doc__") = ed->docstr ? str(ed->docstr) : none();
 
-    result.attr("__str__") = enum_mod.attr(is_flag ? factory_name : "Enum").attr("__str__");
-    result.attr("__repr__") = result.attr("__str__");
+    result.attr("__str__") = factory.attr("__str__");
+    result.attr("__repr__") = factory.attr("__repr__");
 
     type_init_data *t = new type_init_data();
     memset(t, 0, sizeof(type_data));

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -61,7 +61,7 @@ NB_MODULE(test_enum_ext, m) {
 
     m.def("from_enum_default_0", [](Flag value) { return (uint32_t) value; }, nb::arg("value") = Enum::A);
 
-    m.def("from_enum_default_1", [](SEnum value) { return (uint32_t) value; }, nb::arg("value") = SEnum::A);
+    m.def("from_enum_default_1", [](SEnum value) { return (uint32_t) value; }, nb::arg("value").sig("SEnum.A") = SEnum::A);
 
     // test for issue #39
     nb::class_<EnumProperty>(m, "EnumProperty")

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -2,11 +2,11 @@ import test_enum_ext as t
 import pytest
 
 def test01_unsigned_enum():
-    assert repr(t.Enum.A) == 'Enum.A'
+    assert repr(t.Enum.A) == '<Enum.A: 0>'
     assert str(t.Enum.A) == 'Enum.A'
-    assert repr(t.Enum.B) == 'Enum.B'
+    assert repr(t.Enum.B) == '<Enum.B: 1>'
     assert str(t.Enum.B) == 'Enum.B'
-    assert repr(t.Enum.C) == 'Enum.C'
+    assert repr(t.Enum.C) == '<Enum.C: 4294967295>'
     assert str(t.Enum.C) == 'Enum.C'
     assert t.Enum.A.name == 'A'
     assert t.Enum.B.name == 'B'
@@ -52,12 +52,12 @@ def test01_unsigned_enum():
 
 
 def test02_signed_enum():
-    assert repr(t.SEnum.A) == 'SEnum.A'
-    assert repr(t.SEnum.B) == 'SEnum.B'
-    assert repr(t.SEnum.C) == 'SEnum.C'
-    assert str(t.SEnum.A) == 'SEnum.A'
-    assert str(t.SEnum.B) == 'SEnum.B'
-    assert str(t.SEnum.C) == 'SEnum.C'
+    assert repr(t.SEnum.A) == '<SEnum.A: 0>'
+    assert repr(t.SEnum.B) == '<SEnum.B: 1>'
+    assert repr(t.SEnum.C) == '<SEnum.C: -1>'
+    assert str(t.SEnum.A) == '0'
+    assert str(t.SEnum.B) == '1'
+    assert str(t.SEnum.C) == '-1'
     assert int(t.SEnum.A) == 0
     assert int(t.SEnum.B) == 1
     assert int(t.SEnum.C) == -1
@@ -138,15 +138,15 @@ def test08_enum_comparisons():
 
 def test06_enum_flag():
     # repr / str tests
-    assert repr(t.Flag.A) == 'Flag.A'
+    assert repr(t.Flag.A) == '<Flag.A: 1>'
     assert str(t.Flag.A) == 'Flag.A'
-    assert repr(t.Flag.B) == 'Flag.B'
+    assert repr(t.Flag.B) == '<Flag.B: 2>'
     assert str(t.Flag.B) == 'Flag.B'
-    assert repr(t.Flag.C) == 'Flag.C'
+    assert repr(t.Flag.C) == '<Flag.C: 4>'
     assert str(t.Flag.C) == 'Flag.C'
-    assert repr(t.Flag.A | t.Flag.B) in ['Flag.A|B', 'Flag.B|A']
+    assert repr(t.Flag.A | t.Flag.B) in ['<Flag.A|B: 3>', '<Flag.B|A: 3>']
     assert str(t.Flag.A | t.Flag.B) in ['Flag.A|B', 'Flag.B|A']
-    assert repr(t.Flag.A | t.Flag.B | t.Flag.C) in ['Flag.A|B|C', 'Flag.C|B|A']
+    assert repr(t.Flag.A | t.Flag.B | t.Flag.C) in ['<Flag.A|B|C: 7>', '<Flag.C|B|A: 7>']
     assert str(t.Flag.A | t.Flag.B | t.Flag.C) in ['Flag.A|B|C', 'Flag.C|B|A']
 
     # Flag membership tests

--- a/tests/test_enum_ext.pyi.ref
+++ b/tests/test_enum_ext.pyi.ref
@@ -43,6 +43,8 @@ class UnsignedFlag(enum.Flag):
     """All values"""
 
 class SEnum(enum.IntEnum):
+    __str__ = __repr__
+
     A = 0
 
     B = 1


### PR DESCRIPTION
For Python enums, repr() differs from str()
for example:

Enum
str(): Color.RED
repr(): <Color.RED: 1>

Flag
str(): Permissions.READ|WRITE
repr(): <Permissions.READ|WRITE: 3>

IntFlag
str(): 3
repr(): <Colors.YELLOW: 3>

in nanobind, `__repr__` was set to `PythonEnumType.__str__`

This change sets it to `PythonEnumType.__repr__` instead

ping @skallweitNV @nicholasjng

