### PR TITLE
Fix bugs in tp_traverse examples and documentation.

### DIFF
--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -69,14 +69,18 @@ struct FuncWrapper {
 };
 
 int funcwrapper_tp_traverse(PyObject *self, visitproc visit, void *arg) {
+    #if PY_VERSION_HEX >= 0x03090000
+        Py_VISIT(Py_TYPE(self));
+    #endif
+
+    if (!nb::inst_ready(self)) {
+        return 0;
+    }
+
     FuncWrapper *w = nb::inst_ptr<FuncWrapper>(self);
 
     nb::handle f = nb::cast(w->f, nb::rv_policy::none);
     Py_VISIT(f.ptr());
-
-    #if PY_VERSION_HEX >= 0x03090000
-        Py_VISIT(Py_TYPE(self));
-    #endif
 
     return 0;
 }


### PR DESCRIPTION
* In wrapper_tp_traverse in test_classes.cpp, make sure to visit the type.
* In both the tp_traverse docs and tests, do not visit the contents of the C++ object if the instance is not ready. A nanobind object is tracked for GC at the end of PyType_GenericAlloc, but that is before the constructor is called. If a GC occurs between the two, we may end up trying to traverse an unconstructed C++ object. We found this to happen in practice in JAX.
* Update the Wrapper type in the docs to use a std::shared_ptr<Wrapper>. It makes no sense to use nb::find if the type is an nb::object.