### PR TITLE
Eigen caster: fix lifetime issue when casting std::optional<Eigen::Ref<const T>> with conversion

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,8 +15,15 @@ case, both modules must use the same nanobind ABI version, or they will be
 isolated from each other. Releases that don't explicitly mention an ABI version
 below inherit that of the preceding release.
 
-Version 2.7.0 (Apr 18, 2025)
+Version TBD (unreleased)
 ------------------------
+
+- Casts to ``std::optional<Eigen::Ref<const ..>>`` that require conversion
+  no longer produce a dangling reference. (PR `#1025
+  <https://github.com/wjakob/nanobind/pull/1025>`__).
+
+Version 2.7.0 (Apr 18, 2025)
+----------------------------
 
 - nanobind now provides a zero-copy type caster for
   ``Eigen::Map<Eigen::SparseMatrix>``. (PRs `#1003

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -1,4 +1,5 @@
 #include <nanobind/stl/complex.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/eigen/dense.h>
 #include <nanobind/eigen/sparse.h>
 #include <nanobind/trampoline.h>
@@ -143,6 +144,22 @@ NB_MODULE(test_eigen_ext, m) {
     m.def("updateRefV3i_nc", [](Eigen::Ref<Eigen::Vector3i> a) { a[2] = 123; }, nb::arg().noconvert());
     m.def("updateRefVXi", [](Eigen::Ref<Eigen::VectorXi> a) { a[2] = 123; });
     m.def("updateRefVXi_nc", [](Eigen::Ref<Eigen::VectorXi> a) { a[2] = 123; }, nb::arg().noconvert());
+
+    m.def("addOptRefVXi",
+          [](std::optional<Eigen::Ref<const Eigen::VectorXi>> r1,
+             std::optional<Eigen::Ref<const Eigen::VectorXi>> r2)
+                  -> std::optional<Eigen::VectorXi> {
+              if (!r1.has_value() && !r2.has_value()) {
+                  return std::nullopt;
+              }
+              if (!r1.has_value()) {
+                  return *r2;
+              }
+              if (!r2.has_value()) {
+                  return *r1;
+              }
+              return *r1 + *r2;
+          }, "r1"_a.none(), "r2"_a.none());
 
     using SparseMatrixR = Eigen::SparseMatrix<float, Eigen::RowMajor>;
     using SparseMatrixC = Eigen::SparseMatrix<float>;

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -77,6 +77,12 @@ def test02_vector_dynamic():
     # Try with a big array. This will move the result to avoid a copy
     assert_array_equal(t.addVXi(x, x), 2*x)
 
+    # Regression test for lifetime issues casting std::optional<Ref<VectorXi>>
+    assert_array_equal(t.addOptRefVXi(af, b), c)
+    assert_array_equal(t.addOptRefVXi(af, None), af)
+    assert_array_equal(t.addOptRefVXi(None, b), b)
+    assert t.addOptRefVXi(None, None) is None
+
 
 @needs_numpy_and_eigen
 def test03_update_map():


### PR DESCRIPTION
The conversion process initially produces an Eigen::Ref that owns its storage, but copying or moving it produces an Eigen::Ref that refers non-owningly to the storage owned by the first Ref. The first Ref is destroyed before the result can be used, leading to a dangling reference. Fix by having the Eigen caster return a type that encapsulates the constructor argument of Ref rather than a Ref itself, so that the owning Ref can be constructed in-place in its final location.