### PR TITLE
Bypass python bug that causes compilation targeting stable ABI of python 3.12 not to work on python 3.12 when compiled with python 3.13+

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -463,13 +463,21 @@ void setattr(PyObject *obj, PyObject *key, PyObject *value) {
 }
 
 void delattr(PyObject *obj, const char *key) {
+    #if (defined(Py_LIMITED_API) && PY_LIMITED_API < 0x030d0000)
+    int rv = PyObject_SetAttrString(obj, key, nullptr);
+    #else
     int rv = PyObject_DelAttrString(obj, key);
+    #endif
     if (rv)
         raise_python_error();
 }
 
 void delattr(PyObject *obj, PyObject *key) {
+    #if (defined(Py_LIMITED_API) && PY_LIMITED_API < 0x030d0000)
+    int rv = PyObject_SetAttr(obj, key, nullptr);
+    #else
     int rv = PyObject_DelAttr(obj, key);
+    #endif
     if (rv)
         raise_python_error();
 }


### PR DESCRIPTION
To be more specific:
Python 3.12 uses macros defined in abstract.h to rewrite PyObject_DelAttr (and PyObject_DelAttrString) to PyObject_SetAttr (PyObject_SetAttrString).
Python 3.13 defines new symbols PyObject_DelAttr and PyObject_DelAttrString and removes the macro.

This change is however not guarded by PY_LIMITED_API check.
Library compiled on 3.13 will therefore search for PyObject_DelAttr, regardless of PY_LIMITED_API. This causes the library to be unloadble in Python 3.12. 

I added simple macro check, that mimics the macro rewrite of Python 3.12 when limited API for 3.12 is requested.

I have observed this bug on windows and linux.
Fix tested on windows as well as linux.