### PR TITLE
stubgen: add `LIB_PATH` option to locate dependent shared libraries

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -618,7 +618,7 @@ endfunction()
 # ---------------------------------------------------------------------------
 
 function (nanobind_add_stub name)
-  cmake_parse_arguments(PARSE_ARGV 1 ARG "VERBOSE;INCLUDE_PRIVATE;EXCLUDE_DOCSTRINGS;EXCLUDE_VALUES;INSTALL_TIME;RECURSIVE;EXCLUDE_FROM_ALL" "MODULE;COMPONENT;PATTERN_FILE;OUTPUT_PATH" "PYTHON_PATH;DEPENDS;MARKER_FILE;OUTPUT")
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "VERBOSE;INCLUDE_PRIVATE;EXCLUDE_DOCSTRINGS;EXCLUDE_VALUES;INSTALL_TIME;RECURSIVE;EXCLUDE_FROM_ALL" "MODULE;COMPONENT;PATTERN_FILE;OUTPUT_PATH" "PYTHON_PATH;LIB_PATH;DEPENDS;MARKER_FILE;OUTPUT")
 
   if (EXISTS ${NB_DIR}/src/stubgen.py)
     set(NB_STUBGEN "${NB_DIR}/src/stubgen.py")
@@ -652,6 +652,10 @@ function (nanobind_add_stub name)
 
   foreach (PYTHON_PATH IN LISTS ARG_PYTHON_PATH)
     list(APPEND NB_STUBGEN_ARGS -i "${PYTHON_PATH}")
+  endforeach()
+
+  foreach (LIB_PATH IN LISTS ARG_LIB_PATH)
+    list(APPEND NB_STUBGEN_ARGS -L "${LIB_PATH}")
   endforeach()
 
   if (ARG_PATTERN_FILE)

--- a/docs/api_cmake.rst
+++ b/docs/api_cmake.rst
@@ -492,6 +492,17 @@ Nanobind's CMake tooling includes a convenience command to interface with the
           generation. Otherwise, generator expressions should not be used.
           Optional.
 
+      * - ``LIB_PATH``
+        - List of search paths that should be considered when searching for
+          shared libraries. This can be useful when the Python module being
+          imported depends on shared libraries that are not in the default
+          search path. On Windows, these directories are added to the DLL search
+          path using ``os.add_dll_directory()``. On Linux and macOS, dependent
+          shared libraries should generally be found through the module's rpath.
+          The paths are relative to ``CMAKE_CURRENT_BINARY_DIR`` for build-time
+          stub generation and relative to ``CMAKE_INSTALL_PREFIX`` for
+          install-time stub generation. Optional.
+
       * - ``DEPENDS``
         - Any targets listed here will be marked as a dependencies. This should
           generally be used to list the target names of one or more prior

--- a/docs/typing.rst
+++ b/docs/typing.rst
@@ -539,8 +539,9 @@ The program has the following command line options:
 
 .. code-block:: text
 
-   usage: python -m nanobind.stubgen [-h] [-o FILE] [-O PATH] [-i PATH] [-m MODULE]
-                                     [-r] [-M FILE] [-P] [-D] [--exclude-values] [-q]
+   usage: python -m nanobind.stubgen [-h] [-o FILE] [-O PATH] [-i PATH]
+                                     [-L PATH] [-m MODULE] [-r] [-M FILE] [-P]
+                                     [-D] [--exclude-values] [-q]
 
    Generate stubs for nanobind-based extensions.
 
@@ -550,6 +551,8 @@ The program has the following command line options:
      -O PATH, --output-dir PATH    write generated stubs to the specified directory
      -i PATH, --import PATH        add the directory to the Python import path (can
                                    specify multiple times)
+     -L PATH, --lib-path PATH      add directory to the DLL search path on Windows
+                                   (can specify multiple times)
      -m MODULE, --module MODULE    generate a stub for the specified module (can
                                    specify multiple times)
      -r, --recursive               recursively process submodules

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -1320,6 +1320,16 @@ def parse_options(args: List[str]) -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "-L",
+        "--lib-path",
+        action="append",
+        metavar="PATH",
+        dest="lib_paths",
+        default=[],
+        help="add directory to the DLL search path on Windows (can specify multiple times)",
+    )
+
+    parser.add_argument(
         "-m",
         "--module",
         action="append",
@@ -1460,6 +1470,7 @@ def load_pattern_file(fname: str) -> List[ReplacePattern]:
 
 def main(args: Optional[List[str]] = None) -> None:
     import sys
+    import os
 
     # Ensure that the current directory is on the path
     if "" not in sys.path and "." not in sys.path:
@@ -1479,6 +1490,11 @@ def main(args: Optional[List[str]] = None) -> None:
 
     for i in opt.imports:
         sys.path.insert(0, i)
+
+    dll_dirs = []
+    if os.name == "nt":
+        for lib_path in opt.lib_paths:
+            dll_dirs.append(os.add_dll_directory(lib_path))
 
     for i, mod in enumerate(opt.modules):
         if not opt.quiet:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,6 +154,26 @@ nanobind_add_module(test_inter_module_2_ext NB_DOMAIN mydomain test_inter_module
 target_link_libraries(test_inter_module_1_ext PRIVATE inter_module)
 target_link_libraries(test_inter_module_2_ext PRIVATE inter_module)
 
+add_library(lib_path_dep SHARED lib_path_dep.cpp)
+target_compile_definitions(lib_path_dep PRIVATE -DLIB_PATH_DEP_BUILD)
+target_include_directories(lib_path_dep PRIVATE ${NB_DIR}/include)
+set_target_properties(lib_path_dep PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib_path
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib_path
+)
+
+nanobind_add_module(test_lib_path_ext test_lib_path.cpp ${NB_EXTRA_ARGS})
+target_link_libraries(test_lib_path_ext PRIVATE lib_path_dep)
+
+nanobind_add_stub(
+  lib_path_ext_stub
+  MODULE test_lib_path_ext
+  OUTPUT ${PYI_PREFIX}test_lib_path_ext.pyi
+  PYTHON_PATH $<TARGET_FILE_DIR:test_lib_path_ext>
+  LIB_PATH $<TARGET_FILE_DIR:lib_path_dep>
+  DEPENDS test_lib_path_ext lib_path_dep
+)
+
 set(TEST_FILES
   common.py
   conftest.py
@@ -185,6 +205,7 @@ set(TEST_FILES
   # Stub reference files
   test_classes_ext.pyi.ref
   test_functions_ext.pyi.ref
+  test_lib_path_ext.pyi.ref
   test_make_iterator_ext.pyi.ref
   test_ndarray_ext.pyi.ref
   test_jax_ext.pyi.ref

--- a/tests/lib_path_dep.cpp
+++ b/tests/lib_path_dep.cpp
@@ -1,0 +1,15 @@
+#include <nanobind/nb_defs.h>
+
+#if defined(_WIN32)
+#  if defined(LIB_PATH_DEP_BUILD)
+#    define LIB_PATH_DEP_API NB_EXPORT
+#  else
+#    define LIB_PATH_DEP_API NB_IMPORT
+#  endif
+#else
+#  define LIB_PATH_DEP_API NB_EXPORT
+#endif
+
+extern "C" LIB_PATH_DEP_API int lib_path_value() {
+    return 123;
+}

--- a/tests/test_lib_path.cpp
+++ b/tests/test_lib_path.cpp
@@ -1,0 +1,9 @@
+#include <nanobind/nanobind.h>
+
+extern "C" int lib_path_value();
+
+namespace nb = nanobind;
+
+NB_MODULE(test_lib_path_ext, m) {
+    m.def("value", &lib_path_value);
+}

--- a/tests/test_lib_path_ext.pyi.ref
+++ b/tests/test_lib_path_ext.pyi.ref
@@ -1,0 +1,3 @@
+
+
+def value() -> int: ...


### PR DESCRIPTION
This PR addresses issues such as `ModuleNotFoundError` that could occur during stub generation when extension modules depend on external shared libraries (e.g., `.dll` on Windows, `.so` on Linux) located outside of the standard search paths.

### Background

On Windows, when stubgen attempts to import an extension module to generate stubs, `importlib.import_module()` may fail if the Python interpreter cannot locate the required dependent DLLs—for example, if they are not in the same directory as the `.pyd` file.

Example error:
```console
 Generating my_ext.pyi
 Traceback (most recent call last):
   File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-snyzxcow\overlay\Lib\site-packages\nanobind\stubgen.py", line 1440, in <module>
     main()
   File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-snyzxcow\overlay\Lib\site-packages\nanobind\stubgen.py", line 1367, in main
     mod_imported = importlib.import_module(mod)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ...
 ModuleNotFoundError: No module named 'my_ext'
```
In contrast, on Linux, the dynamic linker can use the extension module's embedded RPATH to find dependencies.

### Proposed Change

A new `LIB_PATH` argument has been introduced to `nanobind_add_stub`. This option allows you to specify a list of directories containing dependent shared libraries. During stub generation:

- On **Windows**, these directories are added to the DLL search path using `os.add_dll_directory()`.
- On **Linux**, the paths are prepended to the `LD_LIBRARY_PATH` environment variable (on macOS, to `DYLD_LIBRARY_PATH`).

### Example Usage

```cmake
# Suppose my_ext.pyd links against some_dynamic_lib.dll,
# and some_dynamic_lib.dll is in a separate output directory.
nanobind_add_module(my_ext my_ext.cpp)
target_link_libraries(my_ext PRIVATE some_dynamic_lib)

nanobind_add_stub(
    my_ext_stub
    MODULE my_ext
    OUTPUT my_ext.pyi
    PYTHON_PATH $<TARGET_FILE_DIR:my_ext>
    # Provide the directory containing some_dynamic_lib.dll or .so
    LIB_PATH $<TARGET_FILE_DIR:some_dynamic_lib>
    DEPENDS my_ext
)
```