### PR TITLE
Added empty() method to tuple/list/dict/set

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -676,6 +676,10 @@ Wrapper classes
 
       Return the number of tuple elements.
 
+   .. cpp:function:: bool empty() const
+
+      Check whether the tuple is empty.
+
    .. cpp:function:: detail::fast_iterator begin() const
 
       Return a forward iterator analogous to ``iter()`` in Python. The function
@@ -718,6 +722,10 @@ Wrapper classes
    .. cpp:function:: size_t size() const
 
       Return the number of list elements.
+
+   .. cpp:function:: bool empty() const
+
+      Check whether the list is empty.
 
    .. cpp:function:: template <typename T> void append(T&& value)
 
@@ -784,6 +792,10 @@ Wrapper classes
 
       Return the number of dictionary elements.
 
+   .. cpp:function:: bool empty() const
+
+      Check whether the dictionary is empty.
+
    .. cpp:function:: template <typename T> bool contains(T&& key) const
 
       Check whether the dictionary contains a particular key. When `T` does not
@@ -838,6 +850,10 @@ Wrapper classes
    .. cpp:function:: size_t size() const
 
       Return the number of set elements.
+
+   .. cpp:function:: bool empty() const
+
+      Check whether the set is empty.
 
    .. cpp:function:: template <typename T> void add(T&& key)
 
@@ -1121,6 +1137,10 @@ Wrapper classes
 
       Check whether the map contains a particular key. When `T` does not
       already represent a wrapped Python object, the function performs a cast.
+
+   .. cpp:function:: bool empty() const
+
+      Check whether the map is empty.
 
    .. cpp:function:: list keys() const
 

--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1138,10 +1138,6 @@ Wrapper classes
       Check whether the map contains a particular key. When `T` does not
       already represent a wrapped Python object, the function performs a cast.
 
-   .. cpp:function:: bool empty() const
-
-      Check whether the map is empty.
-
    .. cpp:function:: list keys() const
 
       Return a list containing all of the map's keys.

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -488,6 +488,7 @@ class tuple : public object {
     detail::fast_iterator begin() const;
     detail::fast_iterator end() const;
 #endif
+    bool empty() const { return size() == 0; }
 };
 
 class type_object : public object {
@@ -531,6 +532,7 @@ class list : public object {
     detail::fast_iterator begin() const;
     detail::fast_iterator end() const;
 #endif
+    bool empty() const { return size() == 0; }
 };
 
 class dict : public object {
@@ -548,6 +550,7 @@ class dict : public object {
         if (PyDict_Update(m_ptr, h.ptr()))
             raise_python_error();
     }
+    bool empty() const { return size() == 0; }
 };
 
 class set : public object {
@@ -563,6 +566,7 @@ class set : public object {
             raise_python_error();
     }
     template <typename T> bool discard(T &&value);
+    bool empty() const { return size() == 0; }
 };
 
 class sequence : public object {
@@ -575,6 +579,7 @@ class mapping : public object {
     list values() const { return steal<list>(detail::obj_op_1(m_ptr, PyMapping_Values)); }
     list items() const { return steal<list>(detail::obj_op_1(m_ptr, PyMapping_Items)); }
     template <typename T> bool contains(T&& key) const;
+    bool empty() const { return size() == 0; }
 };
 
 class args : public tuple {

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -585,7 +585,6 @@ class mapping : public object {
     list values() const { return steal<list>(detail::obj_op_1(m_ptr, PyMapping_Values)); }
     list items() const { return steal<list>(detail::obj_op_1(m_ptr, PyMapping_Items)); }
     template <typename T> bool contains(T&& key) const;
-    bool empty() const { return size() == 0; }
 };
 
 class args : public tuple {


### PR DESCRIPTION
Description:
- Added empty() methdo to tuple/list/dict/setfor a certain level of parity with pybind11
  - pybind11 has size and empty methods on sequence, but nanobind seems not to expose these methods   

Context: when ported pybind11 code to nanobind was expecting to have the same method in nanobind.

Related to https://github.com/wjakob/nanobind/discussions/1026#discussioncomment-13200460

cc @wjakob 