### PR TITLE
Fix stub generation for imported methods

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -388,7 +388,12 @@ class StubGen:
 
         # Check if this function is an alias from *another* module
         if name and fn_module and fn_module != self.module.__name__:
-            self.put_value(fn, name)
+            if parent is None:
+                self.put_value(fn, name)
+            else:
+                import_name = self.import_object(fn_module, fn.__name__)
+                self.write_ln(f"{name} = {import_name}\n")
+                
             return
 
         # Check if this function is an alias from the *same* module


### PR DESCRIPTION
Currently, stub generation mishandles the case where a method is actually a function imported from a different module. (It simply imports the name as the name of the method and calls it a day. A name never gets added to the class namespace.)

This can arise, for example, if one adds methods to nanobind-generated classes via monkeypatching.

Full disclosure: this is a bit of a drive-by PR. I did not investigate if/how type stubs are tested. If you'd like me to add testing or make other revisions, I would be happy to.