### PR TITLE
Fix backslash at the end of file

### DIFF
--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -232,4 +232,4 @@
     extern "C" PyObject *PyInit_##name(void) {                                 \
         return PyModuleDef_Init(&nanobind_##name##_module);                    \
     }                                                                          \
-    void nanobind_##name##_exec_impl(nanobind::module_ variable)               \
+    void nanobind_##name##_exec_impl(nanobind::module_ variable)


### PR DESCRIPTION
Otherwise GCC complains:

```
include/nanobind/nb_defs.h:205:80: warning: backslash-newline at end of file
  205 | #define NB_MODULE(name, variable)                                              \
```