### PR TITLE
Consider adding struct names implicit_t and enum_tbl_t

### DIFF
--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -94,6 +94,18 @@ enum class type_init_flags : uint32_t {
 // See internals.h
 struct nb_alias_chain;
 
+// Implicit conversions for C++ type bindings, used in type_data below
+struct implicit_t {
+    const std::type_info **cpp;
+    bool (**py)(PyTypeObject *, PyObject *, cleanup_list *) noexcept;
+};
+
+// Forward and reverse mappings for enumerations, used in type_data below
+struct enum_tbl_t {
+    void *fwd;
+    void *rev;
+};
+
 /// Information about a type that persists throughout its lifetime
 struct type_data {
     uint32_t size;
@@ -111,17 +123,8 @@ struct type_data {
     void (*copy)(void *, const void *);
     void (*move)(void *, void *) noexcept;
     union {
-        // Implicit conversions for C++ type bindings
-        struct {
-            const std::type_info **cpp;
-            bool (**py)(PyTypeObject *, PyObject *, cleanup_list *) noexcept;
-        } implicit;
-
-        // Forward and reverse mappings for enumerations
-        struct {
-            void *fwd;
-            void *rev;
-        } enum_tbl;
+        implicit_t implicit;  // for C++ type bindings
+        enum_tbl_t enum_tbl;  // for enumerations
     };
     void (*set_self_py)(void *, PyObject *) noexcept;
     bool (*keep_shared_from_this_alive)(PyObject *) noexcept;


### PR DESCRIPTION
If compiling with clang++-19 and `-Wpedantic`, the following warning is seen:
```
warning: anonymous types declared in an anonymous union are an extension [-Wnested-anon-types]
```
Of course, this is easily silenced by adding the flag `-Wno-nested-anon-types`.

Alternatively, this PR avoids the warning by giving names to the two struct types.

Please feel free to merge or reject as you think best.

Regards,
Paul