### PR TITLE
docs: Add frozenset to available wrapper list

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -882,7 +882,7 @@ Wrapper classes
 
    .. cpp:function:: frozenset()
 
-      Create an empty frozenset
+      Create an empty frozenset.
 
    .. cpp:function:: frozenset(handle h)
 

--- a/docs/exchanging.rst
+++ b/docs/exchanging.rst
@@ -393,7 +393,7 @@ directives:
 :cpp:class:`dict`, :cpp:class:`ellipsis`, :cpp:class:`handle`,
 :cpp:class:`handle_t\<T\> <handle_t>`,
 :cpp:class:`bool_`, :cpp:class:`int_`, :cpp:class:`float_`,
-:cpp:class:`iterable`, :cpp:class:`iterator`,
+:cpp:class:`frozenset`, :cpp:class:`iterable`, :cpp:class:`iterator`,
 :cpp:class:`list`, :cpp:class:`mapping`,
 :cpp:class:`module_`, :cpp:class:`object`, :cpp:class:`set`, :cpp:class:`sequence`,
 :cpp:class:`slice`, :cpp:class:`str`, :cpp:class:`tuple`,

--- a/src/hash.h
+++ b/src/hash.h
@@ -5,11 +5,7 @@
 // The changes are as follows:
 //
 // - fmix32 and fmix64 are exported to other compilation units, since they
-//   are useful has a hash function for 32/64 bit integers and pointers
-//
-// - The MurmurHash3_x64_64() function is a variant of the original
-//   MurmurHash3_x64_128() that only returns the low 64 bit of the hash
-//   value.
+//   are useful as a hash function for 32/64 bit integers and pointers.
 //-----------------------------------------------------------------------------
 
 #pragma once


### PR DESCRIPTION
Also terminates the constructor doc with a dot as per the style in the other docs, and removes a mention of MurmurHash from `src/hash.h`, which has been removed since that note was written.