### PR TITLE
Remove argument from Cmake else() command

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -353,8 +353,12 @@ function(nanobind_add_module name)
   endif()
 
   if (NB_ABI MATCHES "t")
+    # Free-threaded Python interpreters don't support building a nanobind
+    # module that uses the stable ABI.
     set(ARG_STABLE_ABI FALSE)
-  else(ARG_STABLE_ABI)
+  else()
+    # A free-threaded Python interpreter is required to build a free-threaded
+    # nanobind module.
     set(ARG_FREE_THREADED FALSE)
   endif()
 


### PR DESCRIPTION
The CMake doc https://cmake.org/cmake/help/latest/command/if.html says
> Per legacy, the `else()` and `endif()` commands admit an optional `<condition>` argument.
> If used, it must be a verbatim repeat of the argument of the opening `if` command.

I think the logic here makes sense:

- If Python is free-threaded, do not build an extension with the stable ABI (i.e., ignore STABLE_ABI)
- If Python is not free-threaded, do not build a free-threaded extension (i.e., ignore FREE_THREADED)

This makes it OK for an extension's CMakeLists.txt to specify both STABLE_ABI and FREE_THREADED.
The choice of what to build is based on what Python is found (e.g., by setting Python_ROOT_DIR).
