### PR TITLE
Fix eigen tests

### DIFF
--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -310,7 +310,7 @@ def test09_sparse_failures():
     del scipy.sparse.csr_matrix
     with pytest.raises(
         AttributeError,
-        match=re.escape("module 'scipy.sparse' has no attribute 'csr_matrix'"),
+        match=re.compile("[mM]odule 'scipy\\.sparse' has no attribute 'csr_matrix'"),
     ):
         t.sparse_r()
 


### PR DESCRIPTION
Scipy 1.16.0 released recently, this commit made some slight changes to the error formatting: https://github.com/scipy/scipy/commit/392c13f7767fb18377e22537a26cb03c9a9017f7. Specifically, it intercepts import errors and (probably inadvertently) changes `module` -> `Module`.