### PR TITLE
Remove space from user defined string literal

### DIFF
--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -452,7 +452,7 @@ class bytes : public object {
 };
 
 NAMESPACE_BEGIN(literals)
-inline str operator"" _s(const char *s, size_t n) {
+inline str operator""_s(const char *s, size_t n) {
     return str(s, n);
 }
 NAMESPACE_END(literals)


### PR DESCRIPTION
The Intel `icpx` 2025.2.0 compiler, which is based on clang, warns that identifier '_s' preceded by whitespace in a literal operator declaration is deprecated.

That seems to be correct.  https://en.cppreference.com/w/cpp/language/user_literal.html documents
> `user-defined-string-literal`  the character sequence "" followed, without a space, by the character sequence that becomes the `ud-suffix`

Note that nanobind's definition of `operator""_a` in `nb_attr.h` does not have whitespace, so this PR is consistent.
