### PR TITLE
Add support to generate type stubs recursively from cmake

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -590,7 +590,7 @@ endfunction()
 # ---------------------------------------------------------------------------
 
 function (nanobind_add_stub name)
-  cmake_parse_arguments(PARSE_ARGV 1 ARG "VERBOSE;INCLUDE_PRIVATE;EXCLUDE_DOCSTRINGS;INSTALL_TIME;EXCLUDE_FROM_ALL" "MODULE;OUTPUT;MARKER_FILE;COMPONENT;PATTERN_FILE" "PYTHON_PATH;DEPENDS")
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "VERBOSE;INCLUDE_PRIVATE;EXCLUDE_DOCSTRINGS;INSTALL_TIME;EXCLUDE_FROM_ALL;RECURSIVE" "MODULE;OUTPUT;MARKER_FILE;COMPONENT;PATTERN_FILE" "PYTHON_PATH;DEPENDS")
 
   if (EXISTS ${NB_DIR}/src/stubgen.py)
     set(NB_STUBGEN "${NB_DIR}/src/stubgen.py")
@@ -612,6 +612,10 @@ function (nanobind_add_stub name)
 
   if (ARG_EXCLUDE_DOCSTRINGS)
     list(APPEND NB_STUBGEN_ARGS -D)
+  endif()
+  
+  if (ARG_RECURSIVE)
+    list(APPEND NB_STUBGEN_ARGS --recursive)
   endif()
 
   foreach (TMP IN LISTS ARG_PYTHON_PATH)
@@ -636,7 +640,11 @@ function (nanobind_add_stub name)
   if (NOT ARG_OUTPUT)
     message(FATAL_ERROR "nanobind_add_stub(): an 'OUTPUT' argument must be specified!")
   else()
-    list(APPEND NB_STUBGEN_ARGS -o "${ARG_OUTPUT}")
+    if (ARG_RECURSIVE)
+      list(APPEND NB_STUBGEN_ARGS -O "${ARG_OUTPUT}")
+    else()
+      list(APPEND NB_STUBGEN_ARGS -o "${ARG_OUTPUT}")
+    endif()
     list(APPEND NB_STUBGEN_OUTPUTS "${ARG_OUTPUT}")
   endif()
 

--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -667,6 +667,7 @@ function (nanobind_add_stub name)
   if (NOT ARG_INSTALL_TIME)
     add_custom_command(
       OUTPUT ${NB_STUBGEN_OUTPUTS}
+      COMMAND ${CMAKE_COMMAND} -E rm -rf ${ARG_OUTPUT}  
       COMMAND ${NB_STUBGEN_CMD}
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
       DEPENDS ${ARG_DEPENDS} "${NB_STUBGEN}" "${ARG_PATTERN_FILE}"

--- a/docs/api_cmake.rst
+++ b/docs/api_cmake.rst
@@ -443,7 +443,7 @@ Nanobind's CMake tooling includes a convenience command to interface with the
       * - ``MODULE``
         - Specifies the name of the module that should be imported. Mandatory.
       * - ``OUTPUT``
-        - Specifies the name of the stub file that should be written. The path
+        - Specifies the name of the stub file (or directory if RECURSIVE option was specified) that should be written. The path
           is relative to ``CMAKE_CURRENT_BINARY_DIR`` for build-time stub
           generation and relative to ``CMAKE_INSTALL_PREFIX`` for install-time
           stub generation. Mandatory.
@@ -489,3 +489,7 @@ Nanobind's CMake tooling includes a convenience command to interface with the
           component-specific installation when ``INSTALL_TIME`` stub generation
           is used. This is analogous to ``install(..., EXCLUDE_FROM_ALL)`` in
           other install targets.
+       * - ``RECURSIVE``
+        - If specified, stubs will be generated recursively for all
+          submodules of the specified module.
+


### PR DESCRIPTION
Nanobind stub generators supports `--recursive` option to generate stubs also for submodules. However cmake function `nanobind_add_stub `doesn't support passing this option. This adds support.