### PR TITLE
docs: Add stubgen instructions using Meson

### DIFF
--- a/docs/meson.rst
+++ b/docs/meson.rst
@@ -57,9 +57,9 @@ The ``meson.build`` definition in your project root should look like:
      default_options: ['cpp_std=c++17', 'b_ndebug=if-release'],
    )
 
-   py = import('python').find_installation()
+   python = import('python').find_installation()
    nanobind_dep = dependency('nanobind')
-   py.extension_module(
+   mod = python.extension_module(
      'my_module_name',
      sources: ['path_to_module.cpp'],
      dependencies: [nanobind_dep],
@@ -103,9 +103,9 @@ to build extensions against the CPython 3.12 stable ABI, use:
      default_options: ['cpp_std=c++17', 'b_ndebug=if-release'],
    )
 
-   py = import('python').find_installation()
+   python = import('python').find_installation()
    nanobind_dep = dependency('nanobind')
-   py.extension_module(
+   mod = python.extension_module(
      'my_module_name',
      sources: ['path_to_module.cpp'],
      dependencies: [nanobind_dep],
@@ -114,3 +114,22 @@ to build extensions against the CPython 3.12 stable ABI, use:
    )
 
 as your ``meson.build`` file.
+
+Stub generation
+---------------
+
+You can configure the build to write a stub file for your extension module
+by adding the following to ``meson.build``:
+
+.. code-block:: meson
+
+   stubgen = nanobind_dep.get_variable('stubgen')
+   custom_target(
+     output: 'my_module_name.pyi',
+     depends: mod,
+     command: [python, stubgen, '-m', 'my_module_name', '-M', 'py.typed'],
+     build_by_default: true
+   )
+
+Then, after building your module, the build system will use nanobind's command
+line interface for :ref:`stub generation <stubs>`.

--- a/docs/typing.rst
+++ b/docs/typing.rst
@@ -357,10 +357,14 @@ An undocumented stub replaces the entire body with the Python ellipsis object
    def square(x: int) -> int: ...
 
 Complex default arguments are often also abbreviated with ``...`` to improve
-the readability of signatures. You can read more about stub files in the
-`typing documentation
-<https://typing.readthedocs.io/en/latest/source/stubs.html>`__ and the `MyPy
-documentation <https://mypy.readthedocs.io/en/stable/stubs.html>`__.
+the readability of signatures.
+
+You can read more about stub files in
+`Writing and Maintaining Stub Files
+<https://typing.python.org/en/latest/guides/writing_stubs.html>`__ and
+`Distributing type information
+<https://typing.python.org/en/latest/spec/distributing.html>`__ and in the
+`MyPy documentation <https://mypy.readthedocs.io/en/stable/stubs.html>`__.
 
 nanobind's ``stubgen`` tool automates the process of stub generation to turn
 modules containing a mixture of ordinary Python code and C++ bindings into an


### PR DESCRIPTION
Also, update the links in `typing.rst` since the old link now simply refers to the two newly added links.

@WillAyd, please review at your convenience.

Thanks,
Paul