### PR TITLE
Improve fail_unspecified()'s default error message

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -237,7 +237,7 @@ function (nanobind_build_library TARGET_NAME)
   endif()
 
   # Nanobind performs many assertion checks -- detailed error messages aren't
-  # included in Release/MinSizeRel modes
+  # included in Release/MinSizeRel/RelWithDebInfo modes
   target_compile_definitions(${TARGET_NAME} PRIVATE
     $<${NB_OPT_SIZE}:NB_COMPACT_ASSERTIONS>)
 

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -487,9 +487,8 @@ NB_NOINLINE void fail_unspecified() noexcept {
     #if defined(NB_COMPACT_ASSERTION_MESSAGE)
         fail(NB_COMPACT_ASSERTION_MESSAGE);
     #else
-        fail("nanobind: encountered an unrecoverable error condition. Recompile "
-             "using the 'Debug' or 'RelWithDebInfo' modes to obtain further "
-             "information about this problem.");
+        fail("encountered an unrecoverable error condition. Recompile using the"
+             " 'Debug' mode to obtain further information about this problem.");
     #endif
 }
 #endif


### PR DESCRIPTION
When `NB_COMPACT_ASSERTIONS` is defined and `fail_unspecified()` is called, this changes the printed output from:
```
Critical nanobind error: nanobind: encountered an unrecoverable error condition. Recompile using the 'Debug' or 'RelWithDebInfo' modes to obtain further information about this problem.
```
to
```
Critical nanobind error: encountered an unrecoverable error condition. Recompile using the 'Debug' mode to obtain further information about this problem.
```
