### PR TITLE
macos 314t build: add missing symbols

### DIFF
--- a/cmake/darwin-ld-cpython.sym
+++ b/cmake/darwin-ld-cpython.sym
@@ -919,6 +919,8 @@
 -U _PyWeakref_GetRef
 -U _PyImport_AddModuleRef
 -U _PyUnstable_Module_SetGIL
+-U _PyUnstable_EnableTryIncRef
+-U _PyUnstable_TryIncRef
 -U _PyMutex_Unlock
 -U _PyMutex_Lock
 -U _PyObject_IS_GC


### PR DESCRIPTION
In building against Python 3.14t (freethreaded) on MacOS ARM (https://github.com/flatironinstitute/jax-finufft/pull/154), I ran into:

```
  : && /opt/homebrew/opt/llvm/bin/clang++ -O3 -DNDEBUG -arch arm64 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk -mmacosx-version-min=14.0 -bundle -Wl,-headerpad_max_install_names -L/opt/homebrew/opt/libomp/lib   -Wl,@/private/var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/build-env-b6rv3nx0/lib/python3.14t/site-packages/nanobind/cmake/darwin-ld-cpython.sym -Wl,-dead_strip -Wl,-x -Wl,-S -o jax_finufft_cpu.cpython-314t-darwin.so CMakeFiles/jax_finufft_cpu.dir/lib/jax_finufft_cpu.cc.o  libnanobind-static-ft.a  vendor/finufft/libfinufft.a  /opt/homebrew/opt/libomp/lib/libomp.dylib  _deps/fftw3-build/libfftw3_omp.a  _deps/fftw3-build/libfftw3.a  _deps/fftw3f-build/libfftw3f_omp.a  _deps/fftw3f-build/libfftw3f.a  -lm  /Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/usr/lib/libm.tbd && :
  Undefined symbols for architecture arm64:
    "_PyUnstable_EnableTryIncRef", referenced from:
        nanobind::detail::inst_new_int(_typeobject*, _object*, _object*) in libnanobind-static-ft.a[4](nb_type.cpp.o)
  ld: symbol(s) not found for architecture arm64
  clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

CI logs: https://github.com/flatironinstitute/jax-finufft/actions/runs/16726870645/job/47344734541

This PR adds the `_PyUnstable_EnableTryIncRef` symbol to the sym file, which fixes the build. I also added `_PyUnstable_TryIncRef` based on reading the [`nb_ft.h`](https://github.com/wjakob/nanobind/blob/879bca4869664bdc1446ee7f160ffe3c7028cd7a/src/nb_ft.h) source, but I didn't actually see an error about that symbol.