### PR TITLE
Enable copying of detail::tuple objects

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -480,7 +480,6 @@ With reference counting
 
    .. code-block:: cpp
 
-
        PyObject* list = ...;
        Py_ssize_t index = ...;
        nb::object o = nb::borrow(PyList_GetItem(list, index));
@@ -1258,8 +1257,18 @@ Wrapper classes
       Compute a slice adjusted to the `size` value of a given container.
       Returns a tuple containing ``(start, stop, step, slice_length)``.
       The elements of the tuple can be obtained using a structured binding or
-      by using the templated ``get`` member function of ``nb::detail::tuple``,
-      for example, ``std::size_t slice_length = tpl.get<3>()``.
+      by using the templated ``get`` member function of ``nb::detail::tuple``.
+      For example:
+
+      .. code-block:: cpp
+
+          m.def("func", [](nb::slice slc) {
+              auto [start, stop, step, slice_length] = slc.compute(17);
+              // Or, if only the computed slice_length is needed:
+              auto tpl = slc.compute(42);
+              std::size_t adjusted_slice_length = tpl.get<3>();
+              // Now do something ...
+          });
 
 .. cpp:class:: ellipsis: public object
 
@@ -1316,8 +1325,8 @@ Wrapper classes
 
    .. code-block:: cpp
 
-      m.def("func", [](MyClass &arg)) { ... });
-      m.def("func", [](nb::fallback arg)) { ... });
+      m.def("func", [](MyClass &arg) { ... });
+      m.def("func", [](nb::fallback arg) { ... });
 
    If :cpp:class:`handle` or :cpp:class:`object` were used instead on the
    second line, they would always match and prevent potential implicit

--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1255,8 +1255,11 @@ Wrapper classes
 
    .. cpp:function:: detail::tuple<Py_ssize_t, Py_ssize_t, Py_ssize_t, size_t> compute(size_t size) const
 
-      Adjust the slice to the `size` value of a given container. Returns a tuple containing
-      ``(start, stop, step, slice_length)``.
+      Compute a slice adjusted to the `size` value of a given container.
+      Returns a tuple containing ``(start, stop, step, slice_length)``.
+      The elements of the tuple can be obtained using a structured binding or
+      by using the templated ``get`` member function of ``nb::detail::tuple``,
+      for example, ``std::size_t slice_length = tpl.get<3>()``.
 
 .. cpp:class:: ellipsis: public object
 

--- a/include/nanobind/nb_tuple.h
+++ b/include/nanobind/nb_tuple.h
@@ -36,9 +36,11 @@ template <typename T, typename... Ts> struct tuple<T, Ts...> : tuple<Ts...> {
     tuple& operator=(tuple &&) = default;
     tuple& operator=(const tuple &) = default;
 
-    template <typename A, typename... As>
+    template <typename A,
+              std::enable_if_t<std::is_convertible_v<A, T>, bool> = true,
+              typename... As>
     NB_INLINE tuple(A &&a, As &&...as)
-        : Base((detail::forward_t<As>) as...), value((detail::forward_t<A>) a) {}
+        : Base((forward_t<As>) as...), value((forward_t<A>) a) {}
 
     template <size_t I> NB_INLINE auto& get() {
         if constexpr (I == 0)

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -278,7 +278,17 @@ NB_MODULE(test_functions_ext, m) {
     // Test slice
     m.def("test_25", [](nb::slice s) { return s; });
     m.def("test_26", []() { return nb::slice(4); });
-    m.def("test_27", []() { return nb::slice(1, 10); });
+    m.def("test_27", []() {
+        nb::slice s(2, 10);
+        auto tpl = s.compute(7);
+        if (tpl.get<0>() != 2) return nb::slice(400);  // fail
+        auto [start, stop, step, slice_length] = tpl;
+        if (start != 2) return nb::slice(401);         // fail
+        if (stop != 7) return nb::slice(402);          // fail
+        if (step != 1) return nb::slice(403);          // fail
+        if (slice_length != 5) return nb::slice(404);  // fail
+        return s;
+    });
     m.def("test_28", []() { return nb::slice(5, -5, -2); });
 
     // Test ellipsis

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -318,7 +318,7 @@ def test27_slice():
     assert t.test_25(s) is s
     assert t.test_25.__doc__ == "test_25(arg: slice, /) -> slice"
     assert t.test_26() == slice(4)
-    assert t.test_27() == slice(1, 10)
+    assert t.test_27() == slice(2, 10)
     assert t.test_28() == slice(5, -5, -2)
 
 


### PR DESCRIPTION
Given `nb::detail::tuple<int, int> tpl = {3, 17};` neither `auto [aa, bb] = tpl;` nor `auto t2 = tpl;` currently compiles.
To fix this, this PR conditionally enables the templated constructor so it is less greedy.

Also, this adds a sentence to slice's compute function to describe how to obtain the elements of a `detail::tuple`.