### PR TITLE
Support casting of datetime with timezone information

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -1164,10 +1164,11 @@ to a Python :py:class:`~datetime.datetime` object; other clocks may convert to
 
 The first clock defined by the standard is ``std::chrono::system_clock``.
 This clock measures the current date and time, much like the Python
-:py:func:`time.time` function. It can change abruptly due to
-administrative actions, daylight savings time transitions, or
-synchronization with an external time server. That makes this clock a
-poor choice for timing purposes, but a good choice for wall-clock time.
+:py:func:`time.time` function. While it tracks elapsed time since 1970, in
+the UTC timezone, It can change abruptly due to administrative actions,
+leap seconds changes or synchronization with an external time server.
+That makes this clock a poor choice for timing purposes,
+but a good choice for wall-clock time.
 
 The second clock defined by the standard is ``std::chrono::steady_clock``.
 This clock ticks at a steady rate and is never adjusted, like
@@ -1204,6 +1205,8 @@ converting to Python.
     :py:class:`~datetime.datetime` instance.  The result describes a time in the
     local timezone, but does not have any timezone information
     attached to it (it is a naive datetime object).
+    Note that some time conversion can occur if your system is not set to use the
+    UTC timezone as the C++ and Python types follow different conventions.
 
 - ``std::chrono::duration`` → :py:class:`datetime.timedelta`
     A duration will be converted to a Python :py:class:`~datetime.timedelta`.
@@ -1219,9 +1222,11 @@ converting to Python.
 - :py:class:`datetime.datetime` or :py:class:`datetime.date` or :py:class:`datetime.time` → ``std::chrono::system_clock::time_point``
     A Python date, time, or datetime object can be converted into a
     system clock timepoint.  A :py:class:`~datetime.time` with no date
-    information is treated as that time on January 1, 1970. A
-    :py:class:`~datetime.date` with no time information is treated as midnight
-    on that date. **Any timezone information is ignored.**
+    information is treated as that time on January 1, 1970 (timezone information
+    is ignored). A :py:class:`~datetime.date` with no time information is treated
+    as midnight on that date. A :py:class:`~datetime.datetime` is treated as a
+    local time if no timezone information is provided. Otherwise, it is treated as
+    a time in its associated tzinfo.
 
 - :py:class:`datetime.timedelta` → ``std::chrono::duration``
     A Python time delta object can be converted into a duration

--- a/include/nanobind/stl/chrono.h
+++ b/include/nanobind/stl/chrono.h
@@ -153,8 +153,13 @@ public:
         ch::microseconds msecs;
         int yy, mon, dd, hh, min, ss, uu;
         try {
-            if (!unpack_datetime(src.ptr(), &yy, &mon, &dd,
-                                 &hh, &min, &ss, &uu)) {
+            PyObject* shifted_time_ptr{};
+            if (!shift_to_timezone(src.ptr(), &shifted_time_ptr)) {
+                return false;
+            }
+
+            if (!unpack_datetime(bool(shifted_time_ptr) ? steal(shifted_time_ptr).ptr() : src.ptr(),
+                                 &yy, &mon, &dd, &hh, &min, &ss, &uu)) {
                 return false;
             }
         } catch (python_error& e) {


### PR DESCRIPTION
Before these changes, nanobind would silently accept datetime objects with timezone information and treat them as local time.

In the default case (tzinfo=None), the cost should be small.
However, reading the previous PR discussions, I realize that the maintenance of these chrono bindings is not a core goal of nanobind. So I'll leave it up to you if you think it is worth making these conversions a bit more robust.

cc @oremanj who contributed the initial version