### PR TITLE
Fix stubgen prefixing issue

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -683,7 +683,7 @@ class StubGen:
             if mod_name == "builtins":
                 # Simplify builtins
                 return cls_name if cls_name != "NoneType" else "None"
-            if full_name.startswith(self.module.__name__):
+            if full_name.startswith(self.module.__name__ + "."):
                 # Strip away the module prefix for local classes
                 return full_name[len(self.module.__name__) + 1 :]
             elif mod_name == "typing" or mod_name == "collections.abc":


### PR DESCRIPTION
Situation: There are two submodules at the same "level", and the name of one of them is a prefix of the name of the other. When stubgen renders the types coming from the longer one in the shorter one, it naively checks that one is a prefix of the other, and ends up stripping away the prefix plus one extra character. I presume this is intended to be a submodule check.

Repro:
```c++
#include "nanobind/nanobind.h"
namespace nb = nanobind;

struct Type {};

NB_MODULE(_core, m) {
  nb::class_<Type>(m.def_submodule("mosh"), "Type");
  m.def_submodule("mo").def("func", [] { return Type{}; });
}
```
Results in 3 files:
`__init__.pyi`
```py
from . import mo as mo
from . import mosh as mosh
```
`mosh.pyi`
```py
class Type:
    pass
```
`mo.pyi`
```py
def func() -> h.Type: ...
```
Note the `h.Type` on the last file, this should be `_core.mosh.Type`.

To fix, we check for an extra `.`, since we're going to be stripping it anyways.