### PR TITLE
Avoid zero-length arrays

### DIFF
--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -219,7 +219,7 @@ struct arg_data {
     uint8_t flag;
 };
 
-template <size_t Size> struct func_data_prelim {
+struct func_data_prelim_base {
     // A small amount of space to capture data used by the function/closure
     void *capture[3];
 
@@ -245,12 +245,12 @@ template <size_t Size> struct func_data_prelim {
     /// for each of these.
     uint16_t nargs;
 
-    /// Number of paramters to the C++ function that may be filled from
-    /// Python positional arguments without additional ceremony. nb::args and
-    /// nb::kwargs parameters are not counted in this total, nor are any
-    /// parameters after nb::args or after a nb::kw_only annotation.
-    /// The parameters counted here may be either named (nb::arg("name"))
-    /// or unnamed (nb::arg()). If unnamed, they are effectively positional-only.
+    /// Number of parameters to the C++ function that may be filled from
+    /// Python positional arguments without additional ceremony.
+    /// nb::args and nb::kwargs parameters are not counted in this total, nor
+    /// are any parameters after nb::args or after a nb::kw_only annotation.
+    /// The parameters counted here may be either named (nb::arg("name")) or
+    /// unnamed (nb::arg()).  If unnamed, they are effectively positional-only.
     /// nargs_pos is always <= nargs.
     uint16_t nargs_pos;
 
@@ -259,41 +259,14 @@ template <size_t Size> struct func_data_prelim {
     const char *name;
     const char *doc;
     PyObject *scope;
-
-    // *WARNING*: nanobind regularly receives requests from users who run it
-    // through Clang-Tidy, or who compile with increased warnings levels, like
-    //
-    //   -Wpedantic, -Wcast-qual, -Wsign-conversion, etc.
-    //
-    // (i.e., beyond -Wall -Wextra and /W4 that are currently already used)
-    //
-    // Their next step is to open a big pull request needed to silence all of
-    // the resulting messages. This comment is strategically placed here
-    // because the zero-length array construction below will almost certainly
-    // be flagged in this process.
-    //
-    // My policy on this is as follows: I am always happy to fix issues in the
-    // codebase. However, many of the resulting change requests are in the
-    // "ritual purification" category: things that cause churn, decrease
-    // readability, and which don't fix actual problems. It's a never-ending
-    // cycle because each new revision of such tooling adds further warnings
-    // and purification rites.
-    //
-    // So just to be clear: I do not wish to pepper this codebase with
-    // "const_cast" and #pragmas/comments to avoid warnings in external
-    // tooling just so those users can have a "silent" build. I don't think it
-    // is reasonable for them to impose their own style on this project.
-    //
-    // As a workaround it is likely possible to restrict the scope of style
-    // checks to particular C++ namespaces or source code locations.
-#if defined(_MSC_VER)
-    // MSVC doesn't support zero-length arrays
-    arg_data args[Size == 0 ? 1 : Size];
-#else
-    // GCC and Clang do.
-    arg_data args[Size];
-#endif
 };
+
+template<size_t Size> struct func_data_prelim : func_data_prelim_base {
+    arg_data args[Size];
+};
+
+template<> struct func_data_prelim<0> : func_data_prelim_base {};
+
 
 template <typename F>
 NB_INLINE void func_extra_apply(F &f, const name &name, size_t &) {

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -311,7 +311,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
 
     (void) arg_index;
 
-    return nb_func_new((const void *) &f);
+    return nb_func_new(&f);
 }
 
 NAMESPACE_END(detail)

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -273,8 +273,11 @@ NB_CORE PyObject *capsule_new(const void *ptr, const char *name,
 
 // ========================================================================
 
+// Forward declaration for type in nb_attr.h
+struct func_data_prelim_base;
+
 /// Create a Python function object for the given function record
-NB_CORE PyObject *nb_func_new(const void *data) noexcept;
+NB_CORE PyObject *nb_func_new(const func_data_prelim_base *data) noexcept;
 
 // ========================================================================
 

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -162,6 +162,33 @@ public:
 
 NAMESPACE_END(detail)
 
+// *WARNING*: nanobind regularly receives requests from users who run it
+// through Clang-Tidy, or who compile with increased warnings levels, like
+//
+//     -Wcast-qual, -Wsign-conversion, etc.
+//
+// (i.e., beyond -Wall -Wextra and /W4 that are currently already used)
+//
+// Their next step is to open a big pull request needed to silence all of
+// the resulting messages.  This comment is strategically placed here
+// because the (PyObject *) casts below cast away the const qualifier and
+// will almost certainly be flagged in this process.
+//
+// My policy on this is as follows: I am always happy to fix issues in the
+// codebase.  However, many of the resulting change requests are in the
+// "ritual purification" category: things that cause churn, decrease
+// readability, and which don't fix actual problems.  It's a never-ending
+// cycle because each new revision of such tooling adds further warnings
+// and purification rites.
+//
+// So just to be clear: I do not wish to pepper this codebase with
+// "const_cast" and #pragmas/comments to avoid warnings in external
+// tooling just so those users can have a "silent" build.  I don't think it
+// is reasonable for them to impose their own style on this project.
+//
+// As a workaround it is likely possible to restrict the scope of style
+// checks to particular C++ namespaces or source code locations.
+
 class handle : public detail::api<handle> {
     friend class python_error;
     friend struct detail::str_attr;


### PR DESCRIPTION
This PR avoids using a zero-length array by adding a base class `func_data_prelim_base` and specializing `func_data_prelim<0>` not to have an `args` member.

Using MSVC, we no longer have member `arg_data args[1]` when `Size == 0`.
Using g++ or clang++, the following hold true on Linux with or without this PR:
```
static_assert(sizeof(nb::detail::func_data_prelim<0>) == 88);
static_assert(sizeof(nb::detail::func_data_prelim<1>) == 128);
static_assert(sizeof(nb::detail::func_data_prelim<2>) == 168);
```
