### PR TITLE
A few minor improvements to the stubgen

### DIFF
--- a/tests/test_typing.cpp
+++ b/tests/test_typing.cpp
@@ -57,7 +57,9 @@ NB_MODULE(test_typing_ext, m) {
 
     m.def("makeNestedClass", [] { return NestedClass(); });
 
-    // Aliases to local functoins and types
+    m.attr("AnyTuple") = nb::typing().attr("Tuple")[nb::make_tuple(nb::any_type(), nb::ellipsis())];
+
+    // Aliases to local functions and types
     m.attr("FooAlias") = m.attr("Foo");
     m.attr("f_alias") = m.attr("f");
     nb::type<Foo>().attr("lt_alias") = nb::type<Foo>().attr("__lt__");

--- a/tests/test_typing_ext.pyi.ref
+++ b/tests/test_typing_ext.pyi.ref
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 import py_stub_test
-from typing import Generic, Optional, Self, TypeAlias, TypeVar
+from typing import Any, Generic, Optional, Self, TypeAlias, TypeVar
 
 from . import submodule as submodule
 from .submodule import F as F, f as f2
@@ -22,6 +22,8 @@ class Foo:
 def f() -> None: ...
 
 def makeNestedClass() -> py_stub_test.AClass.NestedClass: ...
+
+AnyTuple: TypeAlias = tuple[Any, ...]
 
 FooAlias: TypeAlias = Foo
 


### PR DESCRIPTION
* Generalized support for `types.ModuleType` to a few other interpreter internal types.
* Fixed rendering of ellipsis in expression context, e.g. `Alias = tuple[T, ...]`.