### PR TITLE
[stubgen] Added a new --exclude-values flag

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -590,7 +590,7 @@ endfunction()
 # ---------------------------------------------------------------------------
 
 function (nanobind_add_stub name)
-  cmake_parse_arguments(PARSE_ARGV 1 ARG "VERBOSE;INCLUDE_PRIVATE;EXCLUDE_DOCSTRINGS;INSTALL_TIME;RECURSIVE;EXCLUDE_FROM_ALL" "MODULE;COMPONENT;PATTERN_FILE;OUTPUT_PATH" "PYTHON_PATH;DEPENDS;MARKER_FILE;OUTPUT")
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "VERBOSE;INCLUDE_PRIVATE;EXCLUDE_DOCSTRINGS;EXCLUDE_VALUES;INSTALL_TIME;RECURSIVE;EXCLUDE_FROM_ALL" "MODULE;COMPONENT;PATTERN_FILE;OUTPUT_PATH" "PYTHON_PATH;DEPENDS;MARKER_FILE;OUTPUT")
 
   if (EXISTS ${NB_DIR}/src/stubgen.py)
     set(NB_STUBGEN "${NB_DIR}/src/stubgen.py")
@@ -612,6 +612,10 @@ function (nanobind_add_stub name)
 
   if (ARG_EXCLUDE_DOCSTRINGS)
     list(APPEND NB_STUBGEN_ARGS -D)
+  endif()
+
+  if (ARG_EXCLUDE_VALUES)
+    list(APPEND NB_STUBGEN_ARGS --exclude-values)
   endif()
 
   if (ARG_RECURSIVE)

--- a/docs/typing.rst
+++ b/docs/typing.rst
@@ -540,7 +540,7 @@ The program has the following command line options:
 .. code-block:: text
 
    usage: python -m nanobind.stubgen [-h] [-o FILE] [-O PATH] [-i PATH] [-m MODULE]
-                                     [-r] [-M FILE] [-P] [-D] [-q]
+                                     [-r] [-M FILE] [-P] [-D] [--exclude-values] [-q]
 
    Generate stubs for nanobind-based extensions.
 
@@ -559,6 +559,7 @@ The program has the following command line options:
      -P, --include-private         include private members (with single leading or
                                    trailing underscore)
      -D, --exclude-docstrings      exclude docstrings from the generated stub
+     --exclude-values              force the use of ... for values
      -q, --quiet                   do not generate any output in the absence of failures
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,7 @@ foreach (NAME functions classes ndarray jax tensorflow stl enum typing make_iter
     set(EXTRA
       MARKER_FILE py.typed
       PATTERN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/pattern_file.nb"
+      EXCLUDE_VALUES
     )
     set(EXTRA_DEPENDS "${OUT_DIR}/py_stub_test.py")
   else()

--- a/tests/test_typing.cpp
+++ b/tests/test_typing.cpp
@@ -114,6 +114,10 @@ NB_MODULE(test_typing_ext, m) {
     m.def("list_front", [](nb::list l) { return l[0]; },
           nb::sig("def list_front[T](arg: list[T], /) -> T"));
 
+    // Type variables with constraints and a bound.
+    m.attr("T2") = nb::type_var("T2", "bound"_a = nb::type<Foo>());
+    m.attr("T3") = nb::type_var("T3", *nb::make_tuple(nb::type<Foo>(), nb::type<Wrapper>()));
+
     // Some statements that will be modified by the pattern file
     m.def("remove_me", []{});
     m.def("tweak_me", [](nb::object o) { return o; }, "prior docstring\nremains preserved");

--- a/tests/test_typing_ext.pyi.ref
+++ b/tests/test_typing_ext.pyi.ref
@@ -44,7 +44,7 @@ class CustomSignature(Iterable[int]):
     def value(self, value: Optional[int], /) -> None:
         """docstring for setter"""
 
-pytree: dict = {'a' : ('b', [123])}
+pytree: dict = ...
 
 T = TypeVar("T", contravariant=True)
 
@@ -62,6 +62,10 @@ class WrapperTypeParam[T]:
     pass
 
 def list_front[T](arg: list[T], /) -> T: ...
+
+T2 = TypeVar("T2", bound=Foo)
+
+T3 = TypeVar("T3", Foo, Wrapper)
 
 def tweak_me(arg: int):
     """


### PR DESCRIPTION
The flag forces all values to be rendered as ..., which is usually what you want in a .pyi file.

The motivating use-case in JAX was version attributes, which are currently rendered as

    foo_version: int = 42

so every version bump will be unnecessarily reflected in the .pyis.