### PR TITLE
Remove the function `module_new()`

### DIFF
--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -455,9 +455,6 @@ NB_CORE PyObject *module_import(const char *name);
 /// Try to import a Python extension module, raises an exception upon failure
 NB_CORE PyObject *module_import(PyObject *name);
 
-/// Create a new extension module with the given name
-NB_CORE PyObject *module_new(const char *name, PyModuleDef *def) noexcept;
-
 /// Create a submodule of an existing module
 NB_CORE PyObject *module_new_submodule(PyObject *base, const char *name,
                                        const char *doc) noexcept;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -141,16 +141,6 @@ void cleanup_list::expand() noexcept {
 
 // ========================================================================
 
-PyObject *module_new(const char *name, PyModuleDef *def) noexcept {
-    memset(def, 0, sizeof(PyModuleDef));
-    def->m_name = name;
-    def->m_size = -1;
-    PyObject *m = PyModule_Create(def);
-
-    check(m, "nanobind::detail::module_new(): allocation failed!");
-    return m;
-}
-
 PyObject *module_import(const char *name) {
     PyObject *res = PyImport_ImportModule(name);
     if (!res)

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -42,7 +42,7 @@ NAMESPACE_BEGIN(detail)
 #endif
 
 /// Nanobind function metadata (overloads, etc.)
-struct func_data : func_data_prelim<0> {
+struct func_data : func_data_prelim_base {
     arg_data *args;
     char *signature;
 };


### PR DESCRIPTION
I think the function `module_new()` is no longer needed, so this PR will tell if I'm right.
Also, I think it's nicer for `func_data_prelim_base` to be the base class of `func_data`.