### PR TITLE
Add CI support for MinGW-w64 and Intel ICX compilers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-2022', 'macos-13']
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.2', 'pypy3.9-v7.3.16', 'pypy3.10-v7.3.17']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.9-v7.3.16', 'pypy3.10-v7.3.17']
 
     name: "Python ${{ matrix.python }} / ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -107,63 +107,6 @@ jobs:
         cd build;
         python3 -m pytest
 
-  old-compilers:
-    if: false # Disable for now, the CI is glitchy
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - cc: gcc-8
-            cxx: g++-8
-            apt: gcc-8 g++-8
-          - cc: gcc-9
-            cxx: g++-9
-            apt: gcc-9
-          - cc: clang-8
-            cxx: clang++-8
-            apt: clang-8
-          - cc: clang-9
-            cxx: clang++-9
-            apt: clang-9
-          - cc: clang-10
-            cxx: clang++-10
-            apt: clang-10
-
-    runs-on: ubuntu-latest
-    container: ubuntu:20.04
-    name: "${{matrix.cc}} on Ubuntu 20.04"
-    env:
-      CC: ${{matrix.cc}}
-      CXX: ${{matrix.cxx}}
-      DEBIAN_FRONTEND: noninteractive
-
-    steps:
-    - name: Install dependencies
-      run: |
-        apt-get update
-        apt-get install -y python3-numpy python3-pip python3-pytest libeigen3-dev cmake git ${{matrix.apt}}
-        python3 -m pip install typing_extensions
-
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - name: Configure
-      run: cmake -S . -B build
-
-    - name: Build C++
-      run: cmake --build build -j 2
-
-    - name: Check ABI tag
-      run: >
-        cd build/tests;
-        python3 -c 'import test_functions_ext as t; print(f"ABI tag is \"{ t.abi_tag() }\"")'
-
-    - name: Run tests
-      run: >
-        cd build;
-        python3 -m pytest
-
   free-threaded:
     name: "Python 3.14-dev / ubuntu.latest [free-threaded]"
     runs-on: ubuntu-latest
@@ -201,4 +144,143 @@ jobs:
     - name: Run tests
       run: >
         cd build;
+        python -m pytest
+
+  mingw:
+    runs-on: windows-2022
+    name: "Python ${{ matrix.python }} / MinGW-w64"
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.12']
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Setup Python ${{ matrix.python }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+        cache: 'pip'
+
+    - name: Setup MSYS2 (MINGW64)
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        install: >-
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-ninja
+          mingw-w64-x86_64-python
+          mingw-w64-x86_64-python-pip
+          mingw-w64-x86_64-python-pytest
+
+    - name: Install Python packages
+      shell: msys2 {0}
+      run: |
+        python -m pip install pytest-github-actions-annotate-failures typing_extensions
+
+    - name: Configure
+      shell: msys2 {0}
+      run: |
+        export PATH=/mingw64/bin:$PATH
+        export CC=gcc
+        export CXX=g++
+        PYEXE=/mingw64/bin/python3.exe
+        cmake -S . -B build -G Ninja \
+          -DPython_EXECUTABLE="$(cygpath -w "$PYEXE")" \
+          -DNB_TEST_FREE_THREADED=OFF
+
+    - name: Build C++
+      shell: msys2 {0}
+      run: cmake --build build -j 2
+
+    - name: Check ABI tag
+      shell: msys2 {0}
+      run: |
+        cd build/tests
+        python -c 'import test_functions_ext as t; print(f"ABI tag is \"{t.abi_tag()}\"")'
+
+    - name: Run tests
+      shell: msys2 {0}
+      run: |
+        cd build
+        python -m pytest
+
+  intel:
+    runs-on: ubuntu-22.04
+    name: "Python ${{ matrix.python }} / Intel ICX"
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.12']
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Setup Python ${{ matrix.python }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+        cache: 'pip'
+
+    - name: Cache Intel oneAPI
+      id: cache-oneapi
+      uses: actions/cache@v4
+      with:
+        path: /opt/intel/oneapi
+        key: install-${{ runner.os }}-intel-oneapi-compiler-2025.2
+
+    - name: Add Intel repository
+      if: steps.cache-oneapi.outputs.cache-hit != 'true'
+      run: |
+        wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+
+    - name: Install Intel oneAPI compilers
+      if: steps.cache-oneapi.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp
+
+    - name: Cleanup Intel oneAPI cache
+      if: steps.cache-oneapi.outputs.cache-hit != 'true'
+      run: |
+        sudo rm -rf /opt/intel/oneapi/compiler/*/linux/lib/ia32
+        sudo rm -rf /opt/intel/oneapi/compiler/*/linux/lib/emu
+        sudo rm -rf /opt/intel/oneapi/compiler/*/linux/lib/oclfpga
+
+    - name: Install the latest CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Install PyTest
+      run: |
+        python -m pip install pytest pytest-github-actions-annotate-failures typing_extensions
+
+    - name: Configure
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        export CC=icx
+        export CXX=icpx
+        cmake -S . -B build
+
+    - name: Build C++
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        cmake --build build -j 2
+
+    - name: Check ABI tag
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        cd build/tests
+        python -c 'import test_functions_ext as t; print(f"ABI tag is \"{ t.abi_tag() }\"")'
+
+    - name: Run tests
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        cd build
         python -m pytest

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,13 @@ case, both modules must use the same nanobind ABI version, or they will be
 isolated from each other. Releases that don't explicitly mention an ABI version
 below inherit that of the preceding release.
 
+Version TBD (not yet released)
+------------------------------
+
+- Nanobind now officially supports **MinGW-w64** and **Intel ICX** (the modern
+  Clang-based Intel compiler). Continuous integration tests have been added to
+  ensure compatibility with these compilers on an ongoing basis.
+
 Version 2.9.2 (Sep 4, 2025)
 ---------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,9 +57,10 @@ nanobinds depends on
 - **Python 3.8+** or **PyPy 7.3.10+** (the *3.8* and *3.9* PyPy flavors are
   supported, though there are :ref:`some limitations <pypy_issues>`).
 - **CMake 3.15+**.
-- **A C++17 compiler**: Clang 8+, GCC 8+, MSVC2019+, and the CUDA NVCC compiler
-  are officially supported. Others (MinGW, Cygwin, Intel, ..) may work as well
-  but will not receive support.
+- **A C++17 compiler**: Clang 8+, GCC 8+, MSVC2019+, MinGW-w64, Intel ICX
+  (the modern Clang-based Intel compiler), and the CUDA NVCC compiler are
+  officially supported. Others (Cygwin, older Intel compilers, ..) may work
+  as well but will not receive support.
 
 .. only:: not latex
 

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -493,7 +493,8 @@ template <typename T> struct scoped_pymalloc {
     scoped_pymalloc(size_t size = 1) {
         ptr = (T *) PyMem_Malloc(size * sizeof(T));
         if (!ptr)
-            fail("scoped_pymalloc(): could not allocate %zu bytes of memory!", size);
+            fail("scoped_pymalloc(): could not allocate %llu bytes of memory!",
+                 (unsigned long long) size);
     }
     ~scoped_pymalloc() { PyMem_Free(ptr); }
     T *release() {


### PR DESCRIPTION
This commit adds continuous integration testing for two additional compiler toolchains:

- MinGW-w64: Tests with Python 3.12 on Windows using MSYS2
- Intel ICX: Tests with Python 3.12 on Ubuntu using the modern
  Clang-based Intel oneAPI compiler (with caching to reduce install time)

Additional changes:
- Update Python 3.14.0-rc.2 to 3.14 (official release)
- Remove disabled old-compilers job for Ubuntu 20.04
- Fix format string warning in scoped_pymalloc for MinGW (%zu -> %llu)
- Update documentation to list MinGW-w64 and Intel ICX as officially supported compilers
