### PR TITLE
[stubgen] Added support for typing.ParamSpec

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -1561,6 +1561,16 @@ include directive:
    <https://docs.python.org/3/library/typing.html#typing.TypeVarTuple>`__
    (i.e., an instance of ``typing.TypeVarTuple``).
 
+.. cpp:function:: template <typename... Args> object param_spec(Args&&... args)
+
+   Analogous to :cpp:func:`type_var`, create a `parameter specification variable
+   <https://docs.python.org/3/library/typing.html#typing.ParamSpec>`__
+   (i.e., an instance of ``typing.ParamSpec``).
+
+   .. code-block:: cpp
+
+        m.attr("P") = nb::param_spec("P");
+
 .. cpp:function:: object any_type()
 
    Convenience wrapper, which returns ``typing.Any``.

--- a/include/nanobind/typing.h
+++ b/include/nanobind/typing.h
@@ -28,4 +28,9 @@ object type_var_tuple(Args&&... args) {
     return typing().attr("TypeVarTuple")((detail::forward_t<Args>) args...);
 }
 
+template <typename... Args>
+object param_spec(Args&&... args) {
+    return typing().attr("ParamSpec")((detail::forward_t<Args>) args...);
+}
+
 NAMESPACE_END(NB_NAMESPACE)


### PR DESCRIPTION
I did not add any tests, because typing.ParamSpec is 3.10+ and we have no support for version-conditioned stubgen tests atm.