### PR TITLE
Avoid `Py_INCREF` on immortal True, False, None

### DIFF
--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -387,10 +387,14 @@ class bool_ : public object {
     NB_OBJECT_DEFAULT(bool_, object, "bool", PyBool_Check)
 
     explicit bool_(handle h)
-        : object(detail::bool_from_obj(h.ptr()), detail::borrow_t{}) { }
+        : object(detail::bool_from_obj(h.ptr()), detail::steal_t{}) { }
 
     explicit bool_(bool value)
+#if PY_VERSION_HEX < 0x030C0000
         : object(value ? Py_True : Py_False, detail::borrow_t{}) { }
+#else
+        : object(value ? Py_True : Py_False, detail::steal_t{}) { }
+#endif
 
     explicit operator bool() const {
         return m_ptr == Py_True;
@@ -727,7 +731,12 @@ inline void print(const char *str, handle end = handle(), handle file = handle()
     print(nanobind::str(str), end, file);
 }
 
+#if PY_VERSION_HEX < 0x030C0000
 inline object none() { return borrow(Py_None); }
+#else
+inline object none() { return steal(Py_None); }
+#endif
+
 inline dict builtins() { return borrow<dict>(PyEval_GetBuiltins()); }
 
 inline iterator iter(handle h) {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -626,9 +626,13 @@ PyObject *bytearray_from_cstr_and_size(const void *str, size_t size) {
 
 PyObject *bool_from_obj(PyObject *o) {
     int rv = PyObject_IsTrue(o);
-    if (rv == -1)
+    if (rv == 1) {
+        Py_RETURN_TRUE;
+    } else if (rv == 0) {
+        Py_RETURN_FALSE;
+    } else {
         raise_python_error();
-    return rv == 1 ? Py_True : Py_False;
+    }
 }
 
 PyObject *int_from_obj(PyObject *o) {

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -1369,8 +1369,7 @@ static PyObject *nb_func_get_qualname(PyObject *self) {
             return PyUnicode_FromString(f->name);
         }
     } else {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
 }
 
@@ -1380,8 +1379,7 @@ static PyObject *nb_func_get_module(PyObject *self) {
         return PyObject_GetAttrString(
             f->scope, PyModule_Check(f->scope) ? "__name__" : "__module__");
     } else {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
 }
 

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1573,8 +1573,7 @@ static PyObject *keep_alive_callback(PyObject *self, PyObject *const *args,
           "nanobind::detail::keep_alive_callback(): invalid input!");
     Py_DECREF(args[0]); // self
     Py_DECREF(self); // patient
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyMethodDef keep_alive_callback_def = {
@@ -1763,8 +1762,7 @@ PyObject *nb_type_put(const std::type_info *cpp_type,
                       bool *is_new) noexcept {
     // Convert nullptr -> None
     if (!value) {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
 
     nb_internals *internals_ = internals;
@@ -1839,8 +1837,7 @@ PyObject *nb_type_put_p(const std::type_info *cpp_type,
                         bool *is_new) noexcept {
     // Convert nullptr -> None
     if (!value) {
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_RETURN_NONE;
     }
 
     // Check if the instance is already registered with nanobind


### PR DESCRIPTION
In Python 3.12, `Py_True`, `Py_False`, and `Py_None` became immortal.  The functions `Py_INCREF()` and `Py_DECREF()` have no effect on immortal objects.  We can gain some small performance benefit by not calling `Py_INCREF()` when the object is one of these three.

In Python 3.11 and earlier, the macros `Py_RETURN_TRUE`, `Py_RETURN_FALSE`, and `Py_RETURN_NONE` increment the reference count of the object and return it.  In Python 3.12 and later, these macros simply return the object.  So, it's a good idea to use these macros when needing to return one of these constants.   (Regarding style, since these are macros, I thought it best to keep curly braces when these are in an `if (condition) { Py_RETURN_NONE; }` construct.)

The generated code for a module (using Python 3.14) might be a little smaller:

|           test            |   old size   |   new size   |  ratio  |
| ------------------------- | ------------ | ------------ | ------- |
| test\_classes\_ext...so   |    193264    |    189168    |  1.02   |

and a little faster:

|        test          |   old   |   new   |  ratio  |
| -------------------- | ------- | ------- | ------- |
|      s.none()        | 18.4 ns | 18.3 ns |  1.005  |
|   t.none\_3(None)    | 22.8 ns | 22.1 ns |  1.032  |

as measured with:
```
python3 -m timeit -n 10000000 -r 10 -s "import test_classes_ext as t; s = t.Struct()" "s.none()"
python3 -m timeit -n 10000000 -r 10 -s "import test_classes_ext as t" "t.none_3(None)"
```
