### PR TITLE
Fix segfault in GC traversal of Python subclasses with weak references

### DIFF
--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -128,10 +128,8 @@ struct type_data {
     };
     void (*set_self_py)(void *, PyObject *) noexcept;
     bool (*keep_shared_from_this_alive)(PyObject *) noexcept;
-#if defined(Py_LIMITED_API)
     uint32_t dictoffset;
     uint32_t weaklistoffset;
-#endif
 };
 
 /// Information about a type that is only relevant when it is being created

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -644,6 +644,11 @@ NB_MODULE(test_classes_ext, m) {
                nb::is_weak_referenceable(), nb::dynamic_attr())
         .def(nb::init<int>());
 
+    // test50_weakref_with_slots_subclass
+    struct StructWithWeakrefsOnly : Struct { };
+    nb::class_<StructWithWeakrefsOnly, Struct>(m, "StructWithWeakrefsOnly", nb::is_weak_referenceable())
+        .def(nb::init<int>());
+
     union Union {
         int i;
         float f;

--- a/tests/test_classes_ext.pyi.ref
+++ b/tests/test_classes_ext.pyi.ref
@@ -281,6 +281,9 @@ class StructWithWeakrefs(Struct):
 class StructWithWeakrefsAndDynamicAttrs(Struct):
     def __init__(self, arg: int, /) -> None: ...
 
+class StructWithWeakrefsOnly(Struct):
+    def __init__(self, arg: int, /) -> None: ...
+
 class Union:
     def __init__(self) -> None: ...
 


### PR DESCRIPTION
When ``nb::is_weak_referenceable()`` is used, nanobind installs ``tp_traverse`` and ``tp_clear`` callbacks to handle garbage collection of instance dictionaries and weak reference lists.

When a Python subclass is created, Python may add its own instance dictionary (potentially using managed dictionaries on Python 3.12+) or weak reference list. Python's ``subtype_traverse`` function walks up the MRO and calls our ``tp_traverse`` callback. However, our callback was reading ``tp_dictoffset`` and ``tp_weaklistoffset`` directly from the type object, which includes Python's additions. This caused crashes because:

1. On Python 3.11+, negative offsets are used (measured from the end of the object rather than the beginning) which we didn't handle
2. On Python 3.12+, managed dictionaries require special APIs that we weren't using and that aren't even available in the stable ABI/limited API

The fix is to always cache ``dictoffset``/``weaklistoffset`` in ``type_data`` when creating nanobind types, and use these cached values in ``nb_dict_ptr()`` and ``nb_weaklist_ptr()``. This ensures we only access dicts and weaklists that nanobind created, while Python's ``subtype_traverse`` handles any additions made by Python subclasses.

This requires an ABI bump due to the addition of ``dictoffset``/``weaklistoffset`` fields to ``type_data`` unconditionally (previously only in ``Py_LIMITED_API`` builds). Fortunately, the ABI was just bumped in commit aa1c9fd.

The commit also removes some extra `Py_TYPE` calls that have a nontrivial cost on stable ABI builds.

Fixes #1201