### PR TITLE
Allow to use nanobind as an archive in FetchContent

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -246,7 +246,10 @@ function (nanobind_build_library TARGET_NAME)
   # However, if the directory _does_ exist, then the user is free to choose
   # whether nanobind uses them (based on `NB_USE_SUBMODULE_DEPS`), with a
   # preference to choose them if `NB_USE_SUBMODULE_DEPS` is not defined
-  if(IS_DIRECTORY ${NB_DIR}/ext/robin_map/include AND (DEFINED NB_USE_SUBMODULE_DEPS AND NB_USE_SUBMODULE_DEPS))
+  if(IS_DIRECTORY ${NB_DIR}/ext/robin_map/include 
+      AND (DEFINED NB_USE_SUBMODULE_DEPS AND NB_USE_SUBMODULE_DEPS)
+      AND NOT TARGET tsl::robin_map
+    )
     add_library(tsl::robin_map INTERFACE IMPORTED)
     set_target_properties(tsl::robin_map PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES ${NB_DIR}/ext/robin_map/include)


### PR DESCRIPTION
- Only find the dependency when tsl::robin_map is not present (fetchcontent archive support)
- Requires tsl-robin-map as mandatory

### Problem

Cannot use nanobind as archive as it contains a submodule, which is not included in the tarball.
Side effects:
* Brew does not ship or install `tsl-robin-map` when installing nanobind `brew install nanobind`, only when building from source.
* `pip install nanobind` ships `tsl-robin-map` internally (= includes the submodule)

### To reproduce

The following `CMakeLists.txt`:
```cmake
cmake_minimum_required(VERSION 3.22)
project(n)

find_package(Python REQUIRED COMPONENTS Development.Module)

include(FetchContent)
FetchContent_Declare(
  robin-map
  URL https://github.com/Tessil/robin-map/archive/refs/tags/v1.4.1.zip
)
FetchContent_MakeAvailable(robin-map)

set(NB_USE_SUBMODULE_DEPS OFF CACHE BOOL "")
FetchContent_Declare(
  nanobind
  URL https://github.com/wjakob/nanobind/archive/refs/tags/v2.9.2.zip
)
FetchContent_MakeAvailable(nanobind)

file(WRITE my_ext.cpp "
#include <nanobind/nanobind.h>
int add(int a, int b) { return a + b; }
NB_MODULE(my_ext, m) { m.def("add", &add);}
")
nanobind_add_module(my_ext my_ext.cpp)
```

Results in:
```
[cmake] CMake Warning at C:/Program Files/CMake/share/cmake-4.1/Modules/CMakeFindDependencyMacro.cmake:78 (find_package):
[cmake]   By not providing "Findtsl-robin-map.cmake" in CMAKE_MODULE_PATH this
[cmake]   project has asked CMake to find a package configuration file provided by
[cmake]   "tsl-robin-map", but CMake did not find one.
[cmake] 
[cmake]   Could not find a package configuration file provided by "tsl-robin-map"
[cmake]   with any of the following names:
[cmake] 
[cmake]     tsl-robin-mapConfig.cmake
[cmake]     tsl-robin-map-config.cmake
[cmake] 
[cmake]   Add the installation prefix of "tsl-robin-map" to CMAKE_PREFIX_PATH or set
[cmake]   "tsl-robin-map_DIR" to a directory containing one of the above files.  If
[cmake]   "tsl-robin-map" provides a separate development package or SDK, be sure it
[cmake]   has been installed.
```
Which later results build failure:
```
fatal error C1083: Cannot open include file: 'nanobind/nanobind.h': No such file or directory
```

### Possibles solutions
* create a release that contains the submodule
* Ship `tsl-robin-map` includes inside this repo (no submodule)
* Fetchcontent `tsl-robin-map` is user decides via a new option `NB_USE_FETCHCONTENT_DEPS`
* This fix.

To test, replace the nanobind `URL` by `URL https://github.com/ahoarau/nanobind/archive/refs/heads/fix-robin-map-fetchcontent.zip`