### PR TITLE
Include cstdlib.

### DIFF
--- a/include/nanobind/nanobind.h
+++ b/include/nanobind/nanobind.h
@@ -29,6 +29,7 @@
 // Core C++ headers that nanobind depends on
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <exception>
 #include <stdexcept>
 #include <type_traits>


### PR DESCRIPTION
nanobind uses std::abs, which is either defined in cstdlib or cmath. We must include one or the other.

Fixes a build failure in our build environment:

```
In file included from third_party/benchmark/bindings/python/google_benchmark/benchmark.cc:6:
./third_party/nanobind/include/nanobind/operators.h:135:45: error: no member named 'abs' in namespace 'std'; did you mean simply 'abs'?
  135 | NB_UNARY_OPERATOR(abs,        abs,          std::abs(l))
      |                                             ^    ~~~
.../src/libcxx/include/math.h:456:20: note: 'abs' declared here
  456 | using std::__math::abs;
      |
```