### PR TITLE
Avoid use of `PyObject_DelAttr{,String}` in Python 3.12 SABI builds

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -451,13 +451,23 @@ void setattr(PyObject *obj, PyObject *key, PyObject *value) {
 }
 
 void delattr(PyObject *obj, const char *key) {
+#if defined(Py_LIMITED_API) && PY_LIMITED_API < 0x030D0000
+    int rv = PyObject_SetAttrString(obj, key, nullptr);
+#else
     int rv = PyObject_DelAttrString(obj, key);
+#endif
+
     if (rv)
         raise_python_error();
 }
 
 void delattr(PyObject *obj, PyObject *key) {
+#if defined(Py_LIMITED_API) && PY_LIMITED_API < 0x030D0000
+    int rv = PyObject_SetAttr(obj, key, nullptr);
+#else
     int rv = PyObject_DelAttr(obj, key);
+#endif
+
     if (rv)
         raise_python_error();
 }


### PR DESCRIPTION
`PyObject_DelAttr{,String}` are part of the stable ABI starting only from Python 3.13. Thus, when building extensions targeting the stable ABI for Python 3.12, we should fall back to the earlier `PyObject_SetAttr{,String}(obj, key, NULL)` pattern.

-----------------

This should fix the `abi3audit` failures I observed in https://github.com/nicholasjng/nanobind-bazel/pull/83.

The implementation idea is based on the second paragraph of the https://docs.python.org/3/c-api/object.html#c.PyObject_SetAttrString doc.