### PR TITLE
Add bfloat to ndarray_import conversion code

### DIFF
--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -704,6 +704,9 @@ ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
                 case (uint8_t) dlpack::dtype_code::Float:
                     prefix = "float";
                     break;
+                case (uint8_t) dlpack::dtype_code::Bfloat:
+                    prefix = "bfloat";
+                    break;
                 case (uint8_t) dlpack::dtype_code::Complex:
                     prefix = "complex";
                     break;


### PR DESCRIPTION
Closes #1227.

`ndarray_import`'s conversion code was missing a case for `bfloat`, causing import conversions to bfloat16 to fail with a `nullptr` and return a `NoneType` back to python. Tested that this behaves as expected in my sandbox and converts to bfloat16 when taking in a `nb::ndarray<nb::array_api>` argument for a `torch` tensor. I'll followup with a test validating the patch soon. Just wanted to get this up before losing it in the holiday rush.