### PR TITLE
feat(stubgen): allow `__suffix__` and `__prefix__` for classes

### DIFF
--- a/docs/typing.rst
+++ b/docs/typing.rst
@@ -673,6 +673,6 @@ you may use the special ``\from`` escape code to import them:
        def lookup(array: Array[T], index: Literal[0] = 0) -> _Opt[T]:
            \doc
 
-You may also add free-form text the beginning or the end of the generated stub.
-To do so, add an entry that matches on ``module_name.__prefix__`` or
-``module_name.__suffix__``.
+You may also add free-form text the beginning or the end of the generated stub
+module or of a class. To do so, add an entry that matches on ``name.__prefix__``
+or ``name.__suffix__`` where ``name`` is the name of the module or class.

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -523,8 +523,10 @@ class StubGen:
                 self.put_docstr(docstr)
                 if len(tp_dict):
                     self.write("\n")
+            self.apply_pattern(self.prefix + ".__prefix__", None)
             for k, v in tp_dict.items():
                 self.put(v, k, tp)
+            self.apply_pattern(self.prefix + ".__suffix__", None)
             if output_len == len(self.output):
                 self.write_ln("pass\n")
             self.depth -= 1

--- a/tests/pattern_file.nb
+++ b/tests/pattern_file.nb
@@ -17,3 +17,9 @@ test_typing_ext.__prefix__:
 
 test_typing_ext.__suffix__:
     # a suffix
+
+test_typing_ext.Foo.__prefix__:
+    # a class prefix
+
+test_typing_ext.Foo.__suffix__:
+    # a class suffix

--- a/tests/test_typing_ext.pyi.ref
+++ b/tests/test_typing_ext.pyi.ref
@@ -9,6 +9,8 @@ from .submodule import F as F, f as f2
 # a prefix
 
 class Foo:
+    # a class prefix
+
     def __lt__(self, arg: int, /) -> bool: ...
 
     def __gt__(self, arg: int, /) -> bool: ...
@@ -18,6 +20,8 @@ class Foo:
     def __ge__(self, arg: Foo, /) -> bool: ...
 
     lt_alias = __lt__
+
+    # a class suffix
 
 def f() -> None: ...
 


### PR DESCRIPTION
It is currently not possible to *add* functions to a class using patterns. This may be necessary if functions are added to a class through mechanisms other than nanobind. This PR adds the possibility to match on `__suffix__` and `__prefix__` within a class, like it is possible to do within modules already, which can be used to add anything to the beginning or end of a class using patterns.