### PR TITLE
Bugfix NB_MOD_STATE_SIZE for 32-bit pointers

### DIFF
--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -163,7 +163,7 @@
     X(const X &) = delete;                                                     \
     X &operator=(const X &) = delete;
 
-#define NB_MOD_STATE_SIZE 96
+#define NB_MOD_STATE_SIZE (12 * sizeof(PyObject*))
 
 // Helper macros to ensure macro arguments are expanded before token pasting/stringification
 #define NB_MODULE_IMPL(name, variable) NB_MODULE_IMPL2(name, variable)


### PR DESCRIPTION
Bug was defining `NB_MOD_STATE_SIZE` based on assumption of 8B pointers.
This fixes issue #1238
