### PR TITLE
Add module docstrings in stubgen

### DIFF
--- a/tests/test_functions_ext.pyi.ref
+++ b/tests/test_functions_ext.pyi.ref
@@ -1,3 +1,5 @@
+"""function testcase"""
+
 from collections.abc import Callable
 import types
 from typing import Annotated, Any, overload

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -49,8 +49,8 @@ def test01_check_stub_refs(p_ref, request):
 
     if "test_functions_ext" in p_in.name and sys.version_info < (3, 13):
         s_ref = [line.replace("types.CapsuleType", "typing_extensions.CapsuleType") for line in s_ref]
-        s_ref.insert(3, "")
-        s_ref.insert(4, "import typing_extensions")
+        s_ref.insert(5, "")
+        s_ref.insert(6, "import typing_extensions")
 
     s_in = remove_platform_dependent(s_in)
     s_ref = remove_platform_dependent(s_ref)


### PR DESCRIPTION
The module doc is missing from the generated type stubs, this PR fixes that.