### PR TITLE
Support casting of datetime with timezone information

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -1169,10 +1169,11 @@ to a Python :py:class:`~datetime.datetime` object; other clocks may convert to
 
 The first clock defined by the standard is ``std::chrono::system_clock``.
 This clock measures the current date and time, much like the Python
-:py:func:`time.time` function. It can change abruptly due to
-administrative actions, daylight savings time transitions, or
-synchronization with an external time server. That makes this clock a
-poor choice for timing purposes, but a good choice for wall-clock time.
+:py:func:`time.time` function. It tracks elapsed time since 1970 in
+the UTC timezone, but can change abruptly due to administrative actions,
+leap second changes, or synchronization with an external time server.
+That makes this clock a poor choice for timing purposes, but a good choice
+for wall-clock time.
 
 The second clock defined by the standard is ``std::chrono::steady_clock``.
 This clock ticks at a steady rate and is never adjusted, like
@@ -1209,6 +1210,8 @@ converting to Python.
     :py:class:`~datetime.datetime` instance.  The result describes a time in the
     local timezone, but does not have any timezone information
     attached to it (it is a naive datetime object).
+    Note that some time conversion can occur if your system is not set to use the
+    UTC timezone as the C++ and Python types follow different conventions.
 
 - ``std::chrono::duration`` → :py:class:`datetime.timedelta`
     A duration will be converted to a Python :py:class:`~datetime.timedelta`.
@@ -1224,9 +1227,11 @@ converting to Python.
 - :py:class:`datetime.datetime` or :py:class:`datetime.date` or :py:class:`datetime.time` → ``std::chrono::system_clock::time_point``
     A Python date, time, or datetime object can be converted into a
     system clock timepoint.  A :py:class:`~datetime.time` with no date
-    information is treated as that time on January 1, 1970. A
-    :py:class:`~datetime.date` with no time information is treated as midnight
-    on that date. **Any timezone information is ignored.**
+    information is treated as that time on January 1, 1970 (timezone information
+    is ignored). A :py:class:`~datetime.date` with no time information is treated
+    as midnight on that date. A :py:class:`~datetime.datetime` is treated as a
+    local time if no timezone information is provided. Otherwise, it is treated as
+    a time in its associated tzinfo.
 
 - :py:class:`datetime.timedelta` → ``std::chrono::duration``
     A Python time delta object can be converted into a duration

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,16 @@ Version TBD (not yet released)
 - Added the :cpp:class:`nb::never_destruct <never_destruct>` class binding
   annotation to inform nanobind that it should not bind the destructor.
 
+- Improved the behavior of ``datetime``/``std::chrono`` type caster when
+  converting ``datetime`` with timezone information ("aware datetime") to C++:
+  the tz annotation is no longer silently dropped but first translated into
+  the system time zone and then to UTC.
+
+  Note that this second translation between system time zone and UTC also applies
+  to "naive datetime" conversions due to their use of ``mktime()`` and
+  ``localtime_r()`` functions.
+  (PR `#1253 <https://github.com/wjakob/nanobind/pull/1253>`__).
+
 - ABI version 18.
 
 Version 2.10.2 (Dec 10, 2025)

--- a/include/nanobind/stl/chrono.h
+++ b/include/nanobind/stl/chrono.h
@@ -148,8 +148,13 @@ public:
         ch::microseconds msecs;
         int yy, mon, dd, hh, min, ss, uu;
         try {
-            if (!unpack_datetime(src.ptr(), &yy, &mon, &dd,
-                                 &hh, &min, &ss, &uu)) {
+            PyObject* shifted_time_ptr{};
+            if (!shift_to_timezone(src.ptr(), &shifted_time_ptr)) {
+                return false;
+            }
+
+            if (!unpack_datetime(bool(shifted_time_ptr) ? steal(shifted_time_ptr).ptr() : src.ptr(),
+                                 &yy, &mon, &dd, &hh, &min, &ss, &uu)) {
                 return false;
             }
         } catch (python_error& e) {

--- a/include/nanobind/stl/detail/chrono.h
+++ b/include/nanobind/stl/detail/chrono.h
@@ -144,6 +144,29 @@ NB_NOINLINE inline bool unpack_timedelta(PyObject *o, int *days,
     return false;
 }
 
+NB_NOINLINE inline bool shift_to_timezone(PyObject *o, PyObject** shifted_o, PyObject* tz = Py_None) {
+    *shifted_o = nullptr;
+
+    datetime_types.ensure_ready();
+    if (!PyType_IsSubtype(Py_TYPE(o), (PyTypeObject*) datetime_types.datetime.ptr()))
+        return true;
+
+    object tzinfo = steal(PyObject_GetAttrString(o, "tzinfo"));
+    if (!tzinfo.is_valid() || tzinfo.ptr() == Py_None) {
+        return true;
+    }
+
+    try {
+        handle shifted_datetime = borrow(o).attr("astimezone")(borrow(tz)).release();
+        *shifted_o = shifted_datetime.ptr();
+    } catch (python_error& e) {
+        e.restore();
+        return false;
+    }
+
+    return true;
+}
+
 NB_NOINLINE inline bool unpack_datetime(PyObject *o,
                                         int *year, int *month, int *day,
                                         int *hour, int *minute, int *second,
@@ -227,6 +250,41 @@ NB_NOINLINE inline bool unpack_timedelta(PyObject *o, int *days,
         return true;
     }
     return false;
+}
+
+NB_NOINLINE inline bool shift_to_timezone(PyObject *o, PyObject** shifted_o, PyObject* tz = Py_None) {
+    if (!PyDateTimeAPI) {
+        PyDateTime_IMPORT;
+        if (!PyDateTimeAPI)
+            raise_python_error();
+    }
+
+    *shifted_o = nullptr;
+
+    if (!PyDateTime_Check(o)) {
+        return true;
+    }
+
+#if PY_VERSION_HEX < 0x03100000
+     object tzinfo = borrow(o).attr("tzinfo");
+     if (tzinfo.is_none()) {
+         return true;
+     }
+ #else
+     if (PyDateTime_DATE_GET_TZINFO(o) == Py_None) {
+         return true;
+     }
+ #endif
+
+    try {
+        handle shifted_datetime = borrow(o).attr("astimezone")(borrow(tz)).release();
+        *shifted_o = shifted_datetime.ptr();
+    } catch (python_error& e) {
+        e.restore();
+        return false;
+    }
+
+    return true;
 }
 
 NB_NOINLINE inline bool unpack_datetime(PyObject *o,

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -8,6 +8,13 @@ import sys
 
 import pytest
 
+# tzset is unix-only but necessary after changing timezones
+try:
+    from time import tzset
+except ImportError:
+    def tzset():
+        pass
+
 
 def test_chrono_system_clock():
     # Get the time from both c++ and datetime
@@ -104,6 +111,7 @@ SKIP_TZ_ENV_ON_WIN = pytest.mark.skipif(
 def test_chrono_system_clock_roundtrip_time(time1, tz, monkeypatch):
     if tz is not None:
         monkeypatch.setenv("TZ", f"/usr/share/zoneinfo/{tz}")
+    tzset()
 
     # Roundtrip the time
     datetime2 = m.test_chrono2(time1)
@@ -261,6 +269,36 @@ def test_chrono_misc():
     # time_point -> datetime conversion
     assert roundtrip_datetime(d1) == d1
     assert roundtrip_datetime(d2) == d2
+
+
+
+@SKIP_TZ_ENV_ON_WIN
+@pytest.mark.parametrize(
+    "tz",
+    [
+        None,
+        pytest.param("UTC"),
+        pytest.param("America/New_York"),
+    ],
+)
+@pytest.mark.parametrize(
+    "sys_tz",
+    [
+        None,
+        pytest.param("UTC"),
+        pytest.param("America/New_York"),
+    ]
+)
+def test_chrono_tz_aware(sys_tz, tz, monkeypatch):
+    if sys_tz is not None:
+        monkeypatch.setenv("TZ", f"/usr/share/zoneinfo/{sys_tz}")
+    tzset()
+    from datetime import datetime, timedelta, timezone
+    from zoneinfo import ZoneInfo
+    roundtrip_datetime = m.test_nano_timepoint_roundtrip
+    now = datetime.now()
+    now_tz = now.astimezone(ZoneInfo(tz) if tz is not None else None)
+    assert roundtrip_datetime(now) == roundtrip_datetime(now_tz)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Updated (and fixed) version of #1144.

> Before these changes, nanobind would silently accept datetime objects with timezone information and treat them as local time.
>
> In the naive timestamp case (tzinfo=None), the cost should be small.