### PR TITLE
docs(bazel): Add documentation for new `nanobind_link_mode` attribute

### DIFF
--- a/docs/api_bazel.rst
+++ b/docs/api_bazel.rst
@@ -30,6 +30,9 @@ The main tool to build nanobind extensions is the ``nanobind_extension`` rule.
             srcs = [],
             copts = [],
             deps = [],
+            dynamic_deps = [],
+            linkstatic = True,
+            nanobind_link_mode = "auto",
             local_defines = [],
             **kwargs):
 
@@ -41,6 +44,8 @@ The main tool to build nanobind extensions is the ``nanobind_extension`` rule.
     The ``domain`` argument can be used to build the target extension under a
     different ABI domain, as described in the :ref:`FAQ <type-visibility>`
     section.
+
+    *New in nanobind-bazel v2.10.2: Added the "nanobind_link_mode" attribute.*
 
 To generate typing stubs for an extension, you can use the ``nanobind_stubgen``
 rule.
@@ -64,9 +69,9 @@ rule.
             exclude_docstrings = False,
             recursive = False):
 
-    It generates a `py_binary <https://bazel.build/reference/be/python#py_binary>`__ 
-    rule with a corresponding runfiles distribution, which invokes nanobind's 
-    builtin stubgen script, outputs a stub file and, optionally, 
+    It generates a `py_binary <https://bazel.build/reference/be/python#py_binary>`__
+    rule with a corresponding runfiles distribution, which invokes nanobind's
+    builtin stubgen script, outputs a stub file and, optionally,
     a typing marker file into ``output_directory`` (defaults to
     the build output directory, commonly called "bindir" in Bazel terms).
 
@@ -92,12 +97,16 @@ To build a C++ library with nanobind as a dependency, use the
             name,
             copts = [],
             deps = [],
+            linkstatic = False,
+            nanobind_link_mode = "auto",
             **kwargs):
 
     It corresponds directly to the builtin
     `cc_library <https://bazel.build/reference/be/c-cpp#cc_library>`__ rule,
     with all keyword arguments being directly forwarded to a ``cc_library``
     target.
+
+    *New in nanobind-bazel v2.10.2: Added the "nanobind_link_mode" attribute.*
 
 To build a C++ shared library with nanobind as a dependency, use the
 ``nanobind_shared_library`` rule.
@@ -134,12 +143,12 @@ To build a C++ static library containing nanobind, use the
         def nanobind_static_library(name, deps, **kwargs):
 
     It corresponds directly to the builtin
-    `cc_static_library <https://bazel.build/reference/be/c-cpp#cc_static_library>`__ 
+    `cc_static_library <https://bazel.build/reference/be/c-cpp#cc_static_library>`__
     rule, with all keyword arguments being directly
     forwarded to a ``cc_static_library`` target.
 
     NB: This macro requires Bazel 7.4.0 or greater to use, as well as setting the
-    ``--experimental_cc_static_library`` flag for the build, since the 
+    ``--experimental_cc_static_library`` flag for the build, since the
     ``cc_static_library`` rule is considered experimental.
 
     *New in nanobind-bazel version 2.7.0.*
@@ -156,11 +165,16 @@ To build a C++ test target requiring nanobind, use the ``nanobind_test`` rule.
             name,
             copts = [],
             deps = [],
+            dynamic_deps = [],
+            linkstatic = False,
+            nanobind_link_mode = "auto",
             **kwargs):
 
     It corresponds directly to the builtin
     `cc_test <https://bazel.build/reference/be/c-cpp#cc_test>`__ rule, with all
     keyword arguments being directly forwarded to a ``cc_test`` target.
+
+    *New in nanobind-bazel v2.10.2: Added the "nanobind_link_mode" attribute.*
 
 .. _flags-bazel:
 
@@ -181,5 +195,5 @@ following flag settings.
 
     Build nanobind extensions against the stable ABI of the configured Python
     version. Allowed values are ``"cp312"``, ``"cp313"``, and ``"cp314"``, which
-    target the stable ABI starting from CPython 3.12, 3.13, or 3.14 respectively. 
+    target the stable ABI starting from CPython 3.12, 3.13, or 3.14 respectively.
     By default, all extensions are built without any ABI limitations.

--- a/docs/bazel.rst
+++ b/docs/bazel.rst
@@ -139,6 +139,26 @@ Naturally, since stub generation relies on the given shared object files, the
 actual extensions are built in the process before invocation of the stub
 generation script.
 
+Controlling shared vs. static library production
+------------------------------------------------
+
+You can control how nanobind is linked to your extensions and libraries with the
+``nanobind_link_mode`` attribute of the ``nanobind_extension``, ``nanobind_library``,
+and ``nanobind_test`` macros.
+
+Setting ``nanobind_link_mode = "static"`` will link nanobind statically, while
+``nanobind_link_mode = "shared"`` will request linkage against a shared ``libnanobind.so``.
+The default, ``nanobind_link_mode = "auto"`` , will set the linkage for nanobind automatically
+based on the value of the given ``linkstatic`` attribute (where ``True`` requests static linkage,
+while ``False`` requests dynamic linkage).
+
+.. note::
+
+    Linking ``nanobind_extension`` s dynamically on macOS can fail because of undefined libpython
+    symbols referenced in the extension's object files. In that case, you can supply a linker
+    response file by using the ``nb_library_linkopts`` function from ``@nanobind_bazel//:helpers.bzl``
+    when setting your extension's ``linkopts``.
+
 Building extensions for free-threaded Python
 --------------------------------------------
 


### PR DESCRIPTION
This documents the changes made lately in `nanobind_bazel` to properly support shared library builds for nanobind in Bazel. In particular, it highlights not only how to use the `nanobind_link_mode` flag, but also how its default works when toggling the `linkstatic` attribute.

-----------------

The BCR release also went through, see https://github.com/bazelbuild/bazel-central-registry/pull/6908. While the `nanobind_example` is great to start, I've decided I will set up more tests with XLA/LLVM/JAX to see if `nanobind_bazel` is mature / interesting enough to be used in those kinds of projects.

And with that, happy holidays! It has been a pleasure to collaborate with you again this year. nanobind is a very cherished part of my development activities outside of my day job, and I'm excited for what the future might hold.