### PR TITLE
Add test of optional without argument specifier

### DIFF
--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -386,6 +386,11 @@ def test38_std_optional_none():
     assert t.optional_cstr(None) == "none"
     assert t.optional_cstr("hi") == "hi"
 
+    # `.none()` to optional argument specifier to avoid costs.
+    # Ref: https://github.com/wjakob/nanobind/pull/950
+    with pytest.raises(TypeError):
+        assert t.optional_non_assignable(None).value == None
+
 
 def test39_std_optional_ret_opt_movable(clean):
     assert t.optional_ret_opt_movable().value == 5


### PR DESCRIPTION
Ref https://github.com/wjakob/nanobind/pull/950

I agree with:
>  I don't see a way of fixing this without adding quite a bit of complexity and/or adding runtime cost.

Though I'd like to be documented or tested somewhere