### PR TITLE
stubgen.py Performance Optimization using `io.StringIO`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,9 @@ Version TBD (not yet released)
 
 - ABI version 18.
 
+- Fixed O(n^2) string concatenation performance issue in stub generation.
+  (PR `#1274 <https://github.com/wjakob/nanobind/pull/1274>`__).
+
 Version 2.10.2 (Dec 10, 2025)
 ----------------------------
 


### PR DESCRIPTION
In `stubgen.py` replaced string concatenation on the output buffer with `io.StringIO`. I have a Nanobind module with over 20k bound objects generating into 37 stub files; stubgen took 24.0s before this change, with this diff it now takes 0.9s.

There should be a [CPython optimisation applied to += on string](https://stackoverflow.com/questions/75774350/special-case-when-for-string-concatenation-is-more-efficient-than), but this does not always appear to be applied. For reference I have tested with Python 3.11 on Fedora and Ubuntu 20.04.

Original PR: https://github.com/wjakob/nanobind/pull/1274