### PR TITLE
Fix function calls after module deletion (fixes #1283)

### DIFF
--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -169,8 +169,6 @@
     X(const X &) = delete;                                                     \
     X &operator=(const X &) = delete;
 
-#define NB_MOD_STATE_SIZE (12 * sizeof(PyObject*))
-
 // Helper macros to ensure macro arguments are expanded before token pasting/stringification
 #define NB_MODULE_IMPL(name, variable) NB_MODULE_IMPL2(name, variable)
 #define NB_MODULE_IMPL2(name, variable)                                        \
@@ -196,9 +194,9 @@
         NB_MODULE_SLOTS_2                                                      \
     };                                                                         \
     static struct PyModuleDef nanobind_##name##_module = {                     \
-        PyModuleDef_HEAD_INIT, #name, nullptr, NB_MOD_STATE_SIZE, nullptr,     \
-        nanobind_##name##_slots, nanobind::detail::nb_module_traverse,         \
-        nanobind::detail::nb_module_clear, nanobind::detail::nb_module_free    \
+        PyModuleDef_HEAD_INIT, #name, nullptr, 0, nullptr,                     \
+        nanobind_##name##_slots, nullptr, nullptr,                             \
+        nanobind::detail::nb_module_free                                       \
     };                                                                         \
     extern "C" [[maybe_unused]] NB_EXPORT PyObject *PyInit_##name(void);       \
     extern "C" PyObject *PyInit_##name(void) {                                 \

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -117,8 +117,6 @@ NB_CORE void raise_next_overload_if_null(void *p);
 // ========================================================================
 
 NB_CORE void nb_module_exec(const char *domain, PyObject *m);
-NB_CORE int  nb_module_traverse(PyObject *m, visitproc visit, void *arg);
-NB_CORE int  nb_module_clear(PyObject *m);
 NB_CORE void nb_module_free(void *m);
 
 // ========================================================================

--- a/src/nb_abi.h
+++ b/src/nb_abi.h
@@ -14,7 +14,7 @@
 
 /// Tracks the version of nanobind's internal data structures
 #ifndef NB_INTERNALS_VERSION
-#  define NB_INTERNALS_VERSION 18
+#  define NB_INTERNALS_VERSION 19
 #endif
 
 #if defined(__MINGW32__)

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -121,6 +121,8 @@ void nb_func_dealloc(PyObject *self) {
     }
 
     PyObject_GC_Del(self);
+
+    internals_dec_ref();
 }
 
 int nb_bound_method_traverse(PyObject *self, visitproc visit, void *arg) {
@@ -296,6 +298,7 @@ PyObject *nb_func_new(const func_data_prelim_base *f) noexcept {
           name_cstr);
 
     make_immortal((PyObject *) func);
+    internals_inc_ref();
 
     // Check if the complex dispatch loop is needed
     bool complex_call = can_mutate_args || has_var_kwargs || has_var_args ||

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -338,7 +338,7 @@ static PyTypeObject *nb_ndarray_tp() noexcept {
             /* .slots = */ slots
         };
 
-        tp = (PyTypeObject *) PyType_FromSpec(&spec);
+        tp = new_type(internals_, &spec);
         check(tp, "nb_ndarray type creation failed!");
 
         internals_->nb_ndarray.store_release(tp);

--- a/src/nb_static_property.cpp
+++ b/src/nb_static_property.cpp
@@ -62,7 +62,7 @@ PyTypeObject *nb_static_property_tp() noexcept {
             /* .slots = */ slots
         };
 
-        tp = (PyTypeObject *) PyType_FromSpec(&spec);
+        tp = new_type(internals_, &spec);
         check(tp, "nb_static_property type creation failed!");
 
         internals_->nb_static_property_descr_set = nb_static_property_descr_set;


### PR DESCRIPTION
Nanobind 2.10 introduced a local stash of interned strings to accelerate element access in some common situations (mostly related to ndarrays). The lifetime of this stash was coupled to that of the module.

However, this meant that freeing the module (e.g., by dropping the reference from ``sys.modules``) and subsequently calling functions from that module could cause a use-after-free issue.

This commit fixes this by making the internals state reference-counted. References are held by

- modules
- functions
- types

When the reference count reaches zero, we now not only release the interned strings but also other nanobind-related constructs (nb_func, nb_type, etc.). This should also address the memory leak issue reported in issue #957.

An ABI version bump is required by these changes.