### PR TITLE
Mention `nanobind_json` in the nanobind docs

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -5,41 +5,6 @@
 Frequently asked questions
 ==========================
 
-Is there a way to pass ``JSON`` objects between Python and C++? 
--------------------------------------------------
-Yes, an unofficial, currently maintained, package supporting that can be found `here
-<https://github.com/Griger5/nanobind_json>`_. It is based on a similar package for 
-``pybind11`` called ``pybind11_json``. 
-
-The library is header-only, and uses ``nlohmann::json``. It supports ordered and
-unordered JSON objects and works on all platforms. The library requires no code
-changes other than including the header:
-
-.. code-block:: cpp
-   
-   #include <nlohmann/json.hpp>
-   #include <nanobind/nanobind.h>
-   #include <nanobind_json/nanobind_json.h>
-
-   void take_json(const nlohmann::json &j) {
-       std::cout << "This function took an nlohmann::json instance as argument: " << j << std::endl;
-   }
-
-   nlohmann::json return_json() {
-       nlohmann::json j = {{"value", 1}};
-
-       std::cout << "This function returns an nlohmann::json instance: "  << j << std::endl;
-
-       return j;
-   }
-
-   NB_MODULE(my_module, m) {
-       m.doc() = "My awesome module";
-
-       m.def("take_json", &take_json, "pass nb::object to a C++ function that takes an nlohmann::json");
-       m.def("return_json", &return_json, "return nb::object from a C++ function that returns an nlohmann::json");
-   }
-
 Importing my module fails with an ``ImportError``
 -------------------------------------------------
 
@@ -403,6 +368,12 @@ that would be nice to retain in an alternative build system. If you've made a
 build system compatible with another tool that is sufficiently
 feature-complete, then please file an issue and I am happy to reference it in
 the documentation.
+
+Is there a way to pass ``JSON`` objects between Python and C++? 
+-------------------------------------------------
+Yes, an unofficial, currently maintained, package supporting that can be found `here
+<https://github.com/Griger5/nanobind_json>`_. It is based on a similar package for 
+``pybind11`` called ``pybind11_json``.
 
 Are there tools to generate nanobind bindings automatically?
 ------------------------------------------------------------


### PR DESCRIPTION
Hello, this PR adds a small section focused on [nanobind_json](https://github.com/Griger5/nanobind_json) to the FAQ page of the documentation. 

I have discussed this matter previously through emails. Let me know if this is the correct place for such a mention in the docs.

To give a little bit more detail on `nanobind_json`:
- It is built on top of https://github.com/ianhbell/nanobind_json, which currently seems to be unmaintained (I have made a PR there with all the changes)
- The library has tests and a CI workflow, running on Ubuntu, Ubuntu-ARM, Windows and macOS
- Added support for `ordered_json` objects, which was also missing in `pybind11_json`