### PR TITLE
Fix standard macro redefinition warnings from GCC 15.2.1

### DIFF
--- a/include/nanobind/nanobind.h
+++ b/include/nanobind/nanobind.h
@@ -26,6 +26,11 @@
 #define NB_VERSION_PATCH 1
 #define NB_VERSION_DEV   1 // A value > 0 indicates a development release
 
+// nb_python.h includes Python.h, which according to
+// https://docs.python.org/3/c-api/intro.html#include-files, must be included
+// before standard headers because it overrides feature test macros
+#include "nb_python.h"
+
 // Core C++ headers that nanobind depends on
 #include <cstddef>
 #include <cstdint>
@@ -39,7 +44,6 @@
 
 // Implementation. The nb_*.h files should only be included through nanobind.h
 // IWYU pragma: begin_exports
-#include "nb_python.h"
 #include "nb_defs.h"
 #include "nb_enums.h"
 #include "nb_traits.h"

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -3,11 +3,12 @@
 // directly keep a Python object alive (they're trivially copyable), we
 // maintain a sideband structure to manage the lifetimes.
 
+#include <nanobind/nanobind.h>
+
 #include <algorithm>
 #include <unordered_set>
 #include <vector>
 
-#include <nanobind/nanobind.h>
 #include <nanobind/stl/unordered_set.h>
 
 namespace nb = nanobind;

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -1,6 +1,7 @@
+#include <nanobind/nanobind.h>
+
 #include <string.h>
 
-#include <nanobind/nanobind.h>
 #include <nanobind/stl/function.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/string.h>

--- a/tests/test_stl_bind_map.cpp
+++ b/tests/test_stl_bind_map.cpp
@@ -1,9 +1,10 @@
+#include <nanobind/stl/bind_map.h>
+
 #include <map>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include <nanobind/stl/bind_map.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 


### PR DESCRIPTION
Here's the warnings I was getting for one of the files when compiling the nanobind repo itself:
```
In file included from /usr/include/python3.14/Python.h:14,
                 from /home/tav/git/nanobind/include/nanobind/nb_python.h:21,
                 from /home/tav/git/nanobind/include/nanobind/nanobind.h:42,
                 from /home/tav/git/nanobind/tests/test_tensorflow.cpp:1:
/usr/include/python3.14/pyconfig.h:2007:9: warning: ‘_POSIX_C_SOURCE’ redefined
 2007 | #define _POSIX_C_SOURCE 200809L
      |         ^~~~~~~~~~~~~~~
In file included from /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/os_defines.h:39,
                 from /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/c++config.h:727,
                 from /usr/include/c++/15.2.1/cstddef:51,
                 from /home/tav/git/nanobind/include/nanobind/nanobind.h:30:
/usr/include/features.h:319:10: note: this is the location of the previous definition
  319 | # define _POSIX_C_SOURCE        202405L
      |          ^~~~~~~~~~~~~~~
/usr/include/python3.14/pyconfig.h:2043:9: warning: ‘_XOPEN_SOURCE’ redefined
 2043 | #define _XOPEN_SOURCE 700
      |         ^~~~~~~~~~~~~
/usr/include/features.h:234:10: note: this is the location of the previous definition
  234 | # define _XOPEN_SOURCE  800
      |          ^~~~~~~~~~~~~
```
```bash
[tav@myriad ~]$ g++ --version
g++ (GCC) 15.2.1 20260209
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

[tav@myriad ~]$ python --version
Python 3.14.2
```
These are the g++ and python packages from the Arch Linux distro, in case you'd like to reproduce the issue.

nb_python.h includes Python.h, which according to
https://docs.python.org/3/c-api/intro.html#include-files, must be included before standard headers because it overrides feature test macros. Apparently they've been doing this cursed thing since at least 2003: https://bugs.python.org/issue691005.

In practice, this means nanobind headers that transitively include Python.h should be included before standard headers, as weird as that is. I moved the minimum amount to make the warnings go away in the nanobind project.

I also tried suppressing the warnings in my downstream project's build system because they're super noisy, but I couldn't find a compiler warning flag for it.