### PR TITLE
Fix compile with Werror.

### DIFF
--- a/include/nanobind/nanobind.h
+++ b/include/nanobind/nanobind.h
@@ -26,6 +26,9 @@
 #define NB_VERSION_PATCH 1
 #define NB_VERSION_DEV   1 // A value > 0 indicates a development release
 
+// As it includes Python.h, it needs to be the first file included
+#include "nb_python.h"
+
 // Core C++ headers that nanobind depends on
 #include <cstddef>
 #include <cstdint>
@@ -39,7 +42,6 @@
 
 // Implementation. The nb_*.h files should only be included through nanobind.h
 // IWYU pragma: begin_exports
-#include "nb_python.h"
 #include "nb_defs.h"
 #include "nb_enums.h"
 #include "nb_traits.h"

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -195,7 +195,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
     // Initialize argument flags. The first branch turns std::optional<> types
     // into implicit nb::none() annotations (skipping 'self' for methods).
     if constexpr (has_arg_defaults) {
-        ((void)(Is < is_method_det ||
+        ((void)(Is < int(is_method_det) ||
                 (f.args[Is - is_method_det] = { nullptr, nullptr, nullptr, nullptr,
                     has_arg_defaults_v<Args> ? (uint8_t) cast_flags::accepts_none
                                              : (uint8_t) 0 }, true)), ...);

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -3,11 +3,11 @@
 // directly keep a Python object alive (they're trivially copyable), we
 // maintain a sideband structure to manage the lifetimes.
 
+#include <nanobind/nanobind.h>
+
 #include <algorithm>
-#include <unordered_set>
 #include <vector>
 
-#include <nanobind/nanobind.h>
 #include <nanobind/stl/unordered_set.h>
 
 namespace nb = nanobind;

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -1,6 +1,7 @@
+#include <nanobind/nanobind.h>
+
 #include <string.h>
 
-#include <nanobind/nanobind.h>
 #include <nanobind/stl/function.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/string.h>

--- a/tests/test_stl_bind_map.cpp
+++ b/tests/test_stl_bind_map.cpp
@@ -1,3 +1,5 @@
+#include <nanobind/nanobind.h>
+
 #include <map>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Two fixes when compiling with -Werror (on archlinux)

`CXX='g++ -Werror'  cmake ..`


<img width="432" height="200" alt="image" src="https://github.com/user-attachments/assets/2585d0fa-0c1b-47b1-9fd7-5c958770f40d" />

- Include <nanobind/nanobind.h> should be done first
- bool - int compare compiler whining with constexpr


First error: 
issue is  <feature.h>  (through any c/c++ header) being included before <Python.h> (pyconfig.h)
```
      In file included from /usr/include/python3.14/Python.h:14,
                       from /tmp/pip-build-env-5jkxxqam/overlay/lib/python3.14/site-packages/nanobind/include/nanobind/nb_python.h:21,
                       from /tmp/pip-build-env-5jkxxqam/overlay/lib/python3.14/site-packages/nanobind/include/nanobind/nanobind.h:42,
                       from /tmp/pip-install-haessxtg/manifold3d_88e14348b9e84ea7858f5987f75a7c95/bindings/python/manifold3d.cpp:22:
      /usr/include/python3.14/pyconfig.h:2007:9: error: ‘_POSIX_C_SOURCE’ redefined [-Werror]
       2007 | #define _POSIX_C_SOURCE 200809L
            |         ^~~~~~~~~~~~~~~
      In file included from /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/os_defines.h:39,
                       from /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/c++config.h:727,
                       from /usr/include/c++/15.2.1/bits/version.h:51,
                       from /usr/include/c++/15.2.1/optional:40,
                       from /tmp/pip-install-haessxtg/manifold3d_88e14348b9e84ea7858f5987f75a7c95/bindings/python/manifold3d.cpp:15:
      /usr/include/features.h:319:10: note: this is the location of the previous definition
        319 | # define _POSIX_C_SOURCE        202405L
            |          ^~~~~~~~~~~~~~~
      /usr/include/python3.14/pyconfig.h:2043:9: error: ‘_XOPEN_SOURCE’ redefined [-Werror]
       2043 | #define _XOPEN_SOURCE 700
            |         ^~~~~~~~~~~~~
      /usr/include/features.h:234:10: note: this is the location of the previous definition
        234 | # define _XOPEN_SOURCE  800
            |          ^~~~~~~~~~~~~
```

Second error:
```
/home/benoit/repos/nanobind/include/nanobind/nb_func.h:198:20: error: comparison of constant ‘1’ with boolean expression is always false [-Werror=bool-compare]
```