### PR TITLE
Add explicit casts to avoid compiler warnings

### DIFF
--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -195,7 +195,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
     // Pre-initialize argument flags with 'convert'. The 'accepts_none' flag
     // for std::optional<> args is applied after func_extra_apply (see below).
     if constexpr (has_arg_defaults) {
-        ((void)(Is < is_method_det ||
+        ((void)(Is < (size_t)is_method_det ||
                 (f.args[Is - is_method_det] = { nullptr, nullptr, nullptr, nullptr,
                     (uint8_t) cast_flags::convert }, true)), ...);
     } else if constexpr (nargs_provided > 0) {
@@ -328,7 +328,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
     // Apply implicit accepts_none for std::optional<> typed arguments
     // after func_extra_apply, so that explicit nb::arg().noconvert() works.
     if constexpr (has_arg_defaults) {
-        ((void)(Is >= is_method_det && has_arg_defaults_v<Args> &&
+        ((void)(Is >= (size_t)is_method_det && has_arg_defaults_v<Args> &&
                 (f.args[Is - is_method_det].flag |=
                      (uint8_t) cast_flags::accepts_none, true)), ...);
     }

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -271,7 +271,7 @@ static PyObject *nb_ndarray_dlpack(PyObject *self, PyObject *const *args,
 
     ndarray_handle *th = ((nb_ndarray *) self)->th;
     PyObject *capsule;
-    if (max_major_version >= dlpack::major_version)
+    if (max_major_version >= (long)dlpack::major_version)
         capsule = th->make_capsule_versioned();
     else
         capsule = th->make_capsule_unversioned();


### PR DESCRIPTION
As seen in https://github.com/wjakob/nanobind/actions/runs/22058320272/job/63731838031
GCC complains, `comparison of constant ‘1’ with boolean expression is always false [-Wbool-compare]`

Also, MinGW complains:
```
D:/a/nanobind/nanobind/src/nb_ndarray.cpp:274:27: warning: comparison of integer expressions of different signedness: 'long int' and 'const uint32_t' {aka 'const unsigned int'} [-Wsign-compare]
  274 |     if (max_major_version >= dlpack::major_version)
      |         ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
```

This PR makes the compilers happy.