### PR TITLE
Fix a data race in nb_meta_cache initialization.

### DIFF
--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -458,7 +458,9 @@ NB_NOINLINE void nb_module_exec(const char *name, PyObject *) {
     if (internals) {
         init_internals(internals);
         init_pyobjects(internals);
-        nb_meta_cache = internals->nb_meta;
+        if (nb_meta_cache != internals->nb_meta) {
+            nb_meta_cache = internals->nb_meta;
+        }
         internals_inc_ref();
         return;
     }
@@ -486,7 +488,9 @@ NB_NOINLINE void nb_module_exec(const char *name, PyObject *) {
 
         init_internals(internals);
         init_pyobjects(internals);
-        nb_meta_cache = internals->nb_meta;
+        if (nb_meta_cache != internals->nb_meta) {
+            nb_meta_cache = internals->nb_meta;
+        }
         internals_inc_ref();
 
         Py_DECREF(capsule);
@@ -510,7 +514,9 @@ NB_NOINLINE void nb_module_exec(const char *name, PyObject *) {
 
     init_internals(p);
     init_pyobjects(p);
-    nb_meta_cache = p->nb_meta;
+    if (nb_meta_cache != p->nb_meta) {
+        nb_meta_cache = p->nb_meta;
+    }
 
 #if defined(NB_FREE_THREADED)
     p->nb_static_property_disabled = PyThread_tss_alloc();


### PR DESCRIPTION
We must not overwrite nb_meta_cache if it was already set.

In JAX's use of nanobind we have several module that all share the same definition of nb_internals. We observed the following data race when updating to v2.12.0 under Python 3.14t:
* thread t1 imports a nanobind module, which sets nb_meta_cache unconditionally.
* thread t2 calls nb_type_check, which reads nb_meta_cache.

(https://github.com/jax-ml/jax/actions/runs/22562727693/job/65352515157)

Even though t1 is overwriting nb_meta_cache with the exact same value it already had, this is still a data race and therefore undefined behavior. However there's an easy fix: just don't set nb_meta_cache the second time if it's already set correctly.