### PR TITLE
Reduce global namespace pollution

### DIFF
--- a/include/nanobind/nb_python.h
+++ b/include/nanobind/nb_python.h
@@ -21,7 +21,6 @@
 #include <Python.h>
 #include <frameobject.h>
 #include <pythread.h>
-#include <structmember.h>
 
 /* Python #defines overrides on all sorts of core functions, which
    tends to weak havok in C++ codebases that expect these to work

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -10,6 +10,8 @@
 #include "nb_internals.h"
 #include "nb_ft.h"
 
+#include <structmember.h>
+
 #if defined(_MSC_VER)
 #  pragma warning(disable: 4706) // assignment within conditional expression
 #endif


### PR DESCRIPTION
Move #include <structmember.h> from header to the cpp files to avoid exporting defines without Py_ prefix like READONLY and RESTRICTED to the global namespace.