### PR TITLE
[stubgen] Use from-import for types from `typing_extensions`

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -741,7 +741,7 @@ class StubGen:
             if full_name.startswith(self.module.__name__ + "."):
                 # Strip away the module prefix for local classes
                 return full_name[len(self.module.__name__) + 1 :]
-            elif mod_name == "typing" or mod_name == "collections.abc":
+            elif mod_name in ("typing", "typing_extensions", "collections.abc"):
                 # Import frequently-occurring typing classes and ABCs directly
                 return self.import_object(mod_name, cls_name)
             else:

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -48,9 +48,9 @@ def test01_check_stub_refs(p_ref, request):
         s_in = f.read().split('\n')
 
     if "test_functions_ext" in p_in.name and sys.version_info < (3, 13):
-        s_ref = [line.replace("types.CapsuleType", "typing_extensions.CapsuleType") for line in s_ref]
+        s_ref = [line.replace("types.CapsuleType", "CapsuleType") for line in s_ref]
         s_ref.insert(5, "")
-        s_ref.insert(6, "import typing_extensions")
+        s_ref.insert(6, "from typing_extensions import CapsuleType")
 
     s_in = remove_platform_dependent(s_in)
     s_ref = remove_platform_dependent(s_ref)


### PR DESCRIPTION
This is consistent with how `typing` and `collections.abc` are treated.