### PR TITLE
Remove /MP when using Clang in MSVC compat mode

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -326,7 +326,10 @@ endfunction()
 
 function (nanobind_compile_options name)
   if (MSVC)
-    target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/bigobj /MP>)
+    target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/bigobj>)
+  endif()
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/MP>)
   endif()
 endfunction()
 


### PR DESCRIPTION
When using Clang in MSVC compatibility mode `/MP` is not supported. This PR ensures that `/MP` is limited to MSVC proper.