### PR TITLE
[stubgen] Added a new convenience type `nb::typing_self`

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -1321,6 +1321,15 @@ Wrapper classes
    difference is the type signature when used in function arguments and return
    values.
 
+.. cpp:class:: typing_self : public object
+
+   This wrapper class represents Python ``typing.Self``-typed values. On the
+   C++ end, this type is interchangeable with :py:class:`object`. The only
+   difference is the type signature, which renders as ``typing.Self`` when used
+   in function arguments and return values. This is useful for factory methods
+   and other functions whose return type should match the (sub)class they are
+   called on.
+
 .. cpp:class:: fallback : public object
 
    Instances of this wrapper class behave just like :cpp:class:`handle`. When

--- a/docs/typing.rst
+++ b/docs/typing.rst
@@ -320,6 +320,15 @@ checkers). nanobind provides a :py:class:`nb::any <any>` wrapper type that is
 equivalent to :py:class:`nb::object <object>` except that its type signature
 renders as ``typing.Any`` to facilitate this.
 
+Self-typed return values
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Factory methods or other functions that return an instance of the enclosing
+class can use :py:class:`nb::typing_self <typing_self>` as a return type.
+It is equivalent to :py:class:`nb::object <object>` but renders as
+``typing.Self`` in type signatures. This enables static type checkers to
+correctly infer the return type when such methods are called on subclasses.
+
 .. _stubs:
 
 Stub generation

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -804,6 +804,13 @@ public:
     static constexpr auto Name = detail::const_name("typing.Any");
 };
 
+class typing_self : public object {
+public:
+  using object::object;
+  using object::operator=;
+  static constexpr auto Name = detail::const_name("typing.Self");
+};
+
 template <typename T> class handle_t : public handle {
 public:
     static constexpr auto Name = detail::make_caster<T>::Name;

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -446,6 +446,9 @@ NB_MODULE(test_functions_ext, m) {
 
     m.def("test_any", [](nb::any a) { return a; } );
 
+    m.def("test_typing_self",
+          [](nb::object self) { return nb::borrow<nb::typing_self>(self); });
+
     m.def("test_wrappers_list", []{
         nb::list l1, l2;
         l1.append(1);

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -627,6 +627,11 @@ def test41_any():
     assert t.test_any(s) is s
     assert t.test_any.__doc__ == "test_any(arg: typing.Any, /) -> typing.Any"
 
+def test41b_self():
+    s = "hello"
+    assert t.test_typing_self(s) is s
+    assert t.test_typing_self.__doc__ == "test_typing_self(arg: object, /) -> typing.Self"
+
 def test42_wrappers_list():
     assert t.test_wrappers_list()
 

--- a/tests/test_functions_ext.pyi.ref
+++ b/tests/test_functions_ext.pyi.ref
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 import types
-from typing import Annotated, Any, overload
+from typing import Annotated, Any, Self, overload
 
 
 def test_01() -> None: ...
@@ -229,6 +229,8 @@ class kw_only_methods:
     def method_1p1k(self, i: int = 1, *, j: int = 2) -> tuple: ...
 
 def test_any(arg: Any, /) -> Any: ...
+
+def test_typing_self(arg: object, /) -> Self: ...
 
 def test_wrappers_list() -> bool: ...
 


### PR DESCRIPTION
The type is useful for defining factory methods which return an instance of the enclosing class or a subclass.

I was unsure about the best name for this, since `nb::self` is already used for operator definitions. Ideas welcome!