### PR TITLE
support defaults for typing.TypeVar and typing.TypeVarTuple

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -1066,7 +1066,15 @@ class StubGen:
         elif (sys.version_info >= (3, 11) and issubclass(tp, typing.TypeVarTuple)) \
             or (typing_extensions is not None and issubclass(tp, typing_extensions.TypeVarTuple)):
             tv = self.import_object(tp.__module__, "TypeVarTuple")
-            return f'{tv}("{e.__name__}")'
+            s = f'{tv}("{e.__name__}"'
+            if sys.version_info >= (3, 13):
+                v = e.__default__
+                if v is not typing.NoDefault:
+                    v = self.expr_str(v, abbrev=False)
+                    if v is None:
+                        return None
+                    s += ", default=" + v
+            return s + ')'
         elif issubclass(tp, typing.TypeVar):
             tv = self.import_object("typing", "TypeVar")
             s = f'{tv}("{e.__name__}"'
@@ -1085,6 +1093,13 @@ class StubGen:
                     if v is None:
                         return None
                     s += f", {k}=" + v
+            if sys.version_info >= (3, 13):
+                v = e.__default__
+                if v is not typing.NoDefault:
+                    v = self.expr_str(v, abbrev=False)
+                    if v is None:
+                        return None
+                    s += ", default=" + v
             s += ")"
             return s
         elif issubclass(tp, str):

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -52,6 +52,38 @@ def test01_check_stub_refs(p_ref, request):
         s_ref.insert(5, "")
         s_ref.insert(6, "from typing_extensions import CapsuleType")
 
+    if "test_typing_ext" in p_in.name and sys.version_info < (3, 13):
+        items = []
+        for idx1, line in enumerate(s_ref):
+            if line == "from typing import (":
+                for idx2, line in enumerate(s_ref[idx1 + 1:], idx1 + 1):
+                    if line == ")":
+                        break
+                    item = line.lstrip().rstrip(",")
+                    if sys.version_info < (3, 11) and item == "TypeVarTuple":
+                        continue
+                    elif item == "Unpack":
+                        continue
+                    items.append(item)
+                break
+        items_v0 = ", ".join(items)
+        items_v0 = f"from typing import {items_v0}"
+        items_v1 = "(\n    " + ",\n    ".join(items) + "\n)"
+        items_v1 = f"from typing import {items_v1}"
+        if len(items_v0) <= 70:
+            s_ref[idx1 : idx2 + 1] = items_v0,
+        else:
+            s_ref[idx1 : idx2 + 1] = items_v1.split('\n')
+        s_ref = [line if line != 'T4 = TypeVar("T4", bound=float, default=int)' else line.replace(", default=int", "")
+                 for line in s_ref]
+        for idx, line in enumerate(s_ref):
+            if line == 'T5 = TypeVarTuple("T5", default=Unpack[tuple[Foo, ...]])':
+                if sys.version_info < (3, 11):
+                    del s_ref[idx : idx + 2]
+                else:
+                    s_ref[idx] = 'T5 = TypeVarTuple("T5")'
+                break
+
     s_in = remove_platform_dependent(s_in)
     s_ref = remove_platform_dependent(s_ref)
 

--- a/tests/test_typing.cpp
+++ b/tests/test_typing.cpp
@@ -125,8 +125,7 @@ NB_MODULE(test_typing_ext, m) {
     );
 
 #if PY_VERSION_HEX >= 0x030B0000
-    m.attr("T5") = nb::type_var_tuple(
-    "T5"
+    m.attr("T5") = nb::type_var_tuple("T5"
 #if PY_VERSION_HEX >= 0x030D0000
       , "default"_a = nb::typing().attr("Unpack")[nb::builtins()["tuple"][nb::make_tuple(nb::type<Foo>(), nb::ellipsis())]]
 #endif

--- a/tests/test_typing.cpp
+++ b/tests/test_typing.cpp
@@ -118,6 +118,21 @@ NB_MODULE(test_typing_ext, m) {
     m.attr("T2") = nb::type_var("T2", "bound"_a = nb::type<Foo>());
     m.attr("T3") = nb::type_var("T3", *nb::make_tuple(nb::type<Foo>(), nb::type<Wrapper>()));
 
+    m.attr("T4") = nb::type_var("T4", "bound"_a = nb::builtins()["float"]
+#if PY_VERSION_HEX >= 0x030D0000
+      , "default"_a = nb::builtins()["int"]
+#endif
+    );
+
+#if PY_VERSION_HEX >= 0x030B0000
+    m.attr("T5") = nb::type_var_tuple(
+    "T5"
+#if PY_VERSION_HEX >= 0x030D0000
+      , "default"_a = nb::typing().attr("Unpack")[nb::builtins()["tuple"][nb::make_tuple(nb::type<Foo>(), nb::ellipsis())]]
+#endif
+    );
+#endif
+
     // Some statements that will be modified by the pattern file
     m.def("remove_me", []{});
     m.def("tweak_me", [](nb::object o) { return o; }, "prior docstring\nremains preserved");

--- a/tests/test_typing_ext.pyi.ref
+++ b/tests/test_typing_ext.pyi.ref
@@ -1,6 +1,15 @@
 from collections.abc import Iterable
 import py_stub_test
-from typing import Any, Generic, Optional, Self, TypeAlias, TypeVar
+from typing import (
+    Any,
+    Generic,
+    Optional,
+    Self,
+    TypeAlias,
+    TypeVar,
+    TypeVarTuple,
+    Unpack
+)
 
 from . import submodule as submodule
 from .submodule import F as F, f as f2
@@ -70,6 +79,10 @@ def list_front[T](arg: list[T], /) -> T: ...
 T2 = TypeVar("T2", bound=Foo)
 
 T3 = TypeVar("T3", Foo, Wrapper)
+
+T4 = TypeVar("T4", bound=float, default=int)
+
+T5 = TypeVarTuple("T5", default=Unpack[tuple[Foo, ...]])
 
 def tweak_me(arg: int):
     """


### PR DESCRIPTION
Python-3.13 added optional defaults for typing.TypeVar and typing.TypeVarTuple. This PR makes stubGen.py document the defaults in stub files.

Tests fine with Python-3.14, and with `test_typing.cpp` containing 
```.cpp
m.attr("T4") = nb::type_var("T4", "bound"_a = nb::builtins()["int"], "default"_a = nb::typing().attr("Literal")[1]);
m.attr("T5") = nb::type_var_tuple(
    "T5", "default"_a = nb::typing().attr("Unpack")[nb::builtins()["tuple"][nb::make_tuple(nb::type<Foo>(), nb::ellipsis())]]);
```

, and `test_typing_ext.pyi` containing
```.py
T4 = TypeVar("T4", bound=int, default=Literal[1])

T5 = TypeVarTuple("T5", default=Unpack[tuple[Foo, ...]])
```

But the CI runs stub tests on Python-3.10+, and doing the comparisons correctly for versions below 3.13 seems too complicated.
