### PR TITLE
tests : change Eigen `find_package()` version test to include Eigen version 5

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,7 +130,7 @@ foreach (NAME functions classes ndarray jax tensorflow stl enum typing make_iter
     ${EXTRA})
 endforeach()
 
-find_package (Eigen3 3.3.1 NO_MODULE)
+find_package (Eigen3 3...5 NO_MODULE)
 if (TARGET Eigen3::Eigen)
   nanobind_add_module(test_eigen_ext test_eigen.cpp ${NB_EXTRA_ARGS})
   target_link_libraries(test_eigen_ext PRIVATE Eigen3::Eigen)


### PR DESCRIPTION
This small PR ensures that the tests do not reject Eigen3 if the version number is 5.x