### PR TITLE
Add xtensor support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,21 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get -y install libeigen3-dev
 
+    # ubuntu packages xtensor-dev and xtl-dev are outdated
+    # so we will install them from sources
+    - name: Install xtensor and xtl
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        mkdir -p /tmp/xtensor-install && cd /tmp/xtensor-install
+        wget https://github.com/xtensor-stack/xtl/archive/refs/tags/0.8.2.zip -O xtl-0.8.2.zip
+        unzip xtl-0.8.2.zip && cd xtl-0.8.2
+        cmake . && sudo make install
+        cd /tmp/xtensor-install
+        wget https://github.com/xtensor-stack/xtensor/archive/refs/tags/0.26.0.zip -O xtensor-0.26.0.zip
+        unzip xtensor-0.26.0.zip && cd xtensor-0.26.0
+        mkdir build && cd build
+        cmake .. && sudo make install
+
     - name: Install PyTest
       run: |
         python -m pip install pytest pytest-github-actions-annotate-failures typing_extensions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,21 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get -y install libeigen3-dev
 
+    # ubuntu packages xtensor-dev and xtl-dev are outdated
+    # so we will install them from sources    
+    - name: Install xtensor and xtl
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        mkdir -p /tmp/xtensor-install && cd /tmp/xtensor-install
+        wget https://github.com/xtensor-stack/xtl/archive/refs/tags/0.8.2.zip -O xtl-0.8.2.zip
+        unzip xtl-0.8.2.zip && cd xtl-0.8.2
+        cmake . && sudo make install
+        cd /tmp/xtensor-install
+        wget https://github.com/xtensor-stack/xtensor/archive/refs/tags/0.26.0.zip -O xtensor-0.26.0.zip
+        unzip xtensor-0.26.0.zip && cd xtensor-0.26.0
+        mkdir build && cd build
+        cmake .. && sudo make install
+
     - name: Install PyTest
       run: |
         python -m pip install pytest pytest-github-actions-annotate-failures typing_extensions

--- a/docs/exchanging.rst
+++ b/docs/exchanging.rst
@@ -145,6 +145,8 @@ to external projects that provide further casters:
     - ``#include <nanobind/eigen/sparse.h>``
   * - ``Eigen::Tensor<..>``, ``Eigen::TensorMap<..>``, ``Eigen::TensorRef<..>``
     - ``#include <nanobind/eigen/tensor.h>``
+  * - ``xt::xarray<..>``, ``xt::xarray_container<..>``, ``xt::xtensor<..>``, ``xt::xtensor_container<..>``
+    - ``#include <nanobind/xtensor/xcontainer.h>``
   * - Apache Arrow types
     -  `https://github.com/maximiliank/nanobind_pyarrow <https://github.com/maximiliank/nanobind_pyarrow>`__
   * - ...

--- a/docs/ndarray_index.rst
+++ b/docs/ndarray_index.rst
@@ -11,3 +11,4 @@ Python and C++.
 
    ndarray
    eigen
+   xtensor

--- a/docs/xtensor.rst
+++ b/docs/xtensor.rst
@@ -1,0 +1,401 @@
+.. cpp:namespace:: nanobind
+
+.. _xtensor:
+
+The *xtensor* multi-dimensional array library
+==============================================
+
+`xtensor <https://github.com/xtensor-stack/xtensor>`__ is a header-only C++
+library for multi-dimensional arrays and tensors with lazy evaluation
+semantics. It provides NumPy-like syntax for element-wise operations,
+broadcasting, and mathematical functions.
+
+nanobind includes custom type casters that enable bidirectional conversion
+between xtensor and NumPy arrays. These casters build on the :ref:`n-dimensional array <ndarray_class>` class.
+
+Setup
+-----
+
+Add the following include directive to your binding code:
+
+.. code-block:: cpp
+
+   #include <nanobind/xtensor.h>
+
+This umbrella header pulls in casters for all supported xtensor types. You can
+also include individual headers if you only need a subset:
+
+.. code-block:: cpp
+
+   #include <nanobind/xtensor/xcontainer.h>  // xt::xarray, xt::xtensor
+   #include <nanobind/xtensor/xview.h>       // nb::xarray_view, nb::xtensor_view
+   #include <nanobind/xtensor/xexpression.h> // lazy xexpression return
+   #include <nanobind/xtensor/xvectorize.h>  // nb::xvectorize
+
+Owning containers
+-----------------
+
+Owning containers (``xt::xarray<T>`` and ``xt::xtensor<T, N>``) manage their
+own memory. When converting between Python and C++, data is **always copied**.
+
+Python → C++
+^^^^^^^^^^^^^
+
+When a Python NumPy array is passed to a C++ function expecting an owning
+container, the data is **always copied** into the container. This means the
+container owns its memory independently of the Python object.
+
+.. code-block:: cpp
+
+   // Data is copied into the xarray, safe to modify
+   m.def("process", [](xt::xarray<double>& arr) {
+       arr(0) = 999.0;  // does NOT affect the Python array
+       return arr;
+   });
+
+The owning caster supports implicit conversion at two levels: if the NumPy
+array has a different dtype (e.g., ``float32`` when ``double`` is expected),
+nanobind will convert it automatically. For containers with a strict layout
+(e.g., ``row_major``), a non-matching memory order is also reordered during
+the copy. Both can be disabled with ``nb::arg().noconvert()``, which rejects
+dtype or layout mismatches with a ``TypeError``.
+
+C++ → Python
+^^^^^^^^^^^^^
+
+When a C++ function returns an owning container, the caster creates a NumPy
+array. The behavior depends on the return value policy:
+
+- **Return by value** (``rv_policy::move``): the container is move-constructed
+  into a capsule that owns the data. The resulting NumPy array references this
+  capsule with zero copy.
+
+- **Return by reference**: the NumPy array references the original C++ data.
+  Use ``rv_policy::reference_internal`` when the data is owned by a bound C++
+  object to ensure correct lifetimes.
+
+.. code-block:: cpp
+
+   // Returns by value, data is moved, no copy
+   m.def("make_array", []() {
+       return xt::xarray<double>{1.0, 2.0, 3.0};
+   });
+
+   // Returns by reference from a method, reference_internal keeps self alive
+   nb::class_<MyClass>(m, "MyClass")
+       .def("get_data", &MyClass::get_data, nb::rv_policy::reference_internal);
+
+.. warning::
+
+   ``rv_policy::reference_internal`` must only be used with **methods** (where
+   a ``self`` object exists). It works by preventing the Python wrapper of
+   ``self`` from being garbage-collected while the returned array is alive.
+
+   For **free functions** returning references to static or global data, use
+   ``rv_policy::reference`` instead, there is no ``self`` to keep alive, and
+   using ``reference_internal`` will cause a segmentation fault:
+
+   .. code-block:: cpp
+
+      static xt::xarray<double> global = {1.0, 2.0, 3.0};
+
+      // WRONG, free function has no self → segfault
+      m.def("bad", []() -> xt::xarray<double>& {
+          return global;
+      }, nb::rv_policy::reference_internal);
+
+      // CORRECT, use reference for static/global data
+      m.def("good", []() -> xt::xarray<double>& {
+          return global;
+      }, nb::rv_policy::reference);
+
+Non-owning views
+----------------
+
+Non-owning views (``nb::xarray_view<T>`` and ``nb::xtensor_view<T, N>``)
+provide **zero-copy** access to the underlying NumPy array's data. They do not
+own the memory and instead wrap the Python buffer directly using
+``xt::adapt()`` with ``xt::no_ownership()``.
+
+.. code-block:: cpp
+
+   #include <nanobind/xtensor.h>
+   namespace nb = nanobind;
+
+   // Zero-copy read access
+   m.def("sum_view", [](const nb::xarray_view<double>& a) {
+       return xt::sum(a)();
+   });
+
+   // Zero-copy write, modifies the Python array in-place
+   m.def("mutate", [](nb::xarray_view<double>& a) {
+       a(0) = 999.0;
+   });
+
+Because views wrap existing memory without copying, they **do not support
+implicit type conversion**. If the NumPy array's dtype does not match the
+expected scalar type exactly, nanobind will raise a ``TypeError``. This is
+intentional: converting to a temporary buffer would create a copy that the view
+would reference, leading to a dangling pointer when the temporary is destroyed.
+
+Owning vs. non-owning: when to use which
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++-------------------+---------------------------+---------------------------+
+|                   | Owning                    | Non-owning (view)         |
+|                   | (``xt::xarray``,          | (``nb::xarray_view``,     |
+|                   | ``xt::xtensor``)          | ``nb::xtensor_view``)     |
++===================+===========================+===========================+
+| Memory            | Copies data               | Wraps existing buffer     |
++-------------------+---------------------------+---------------------------+
+| Type conversion   | Implicit (converts dtype) | Strict (exact dtype only) |
++-------------------+---------------------------+---------------------------+
+| Mutability        | Modifications are local   | Modifies Python array     |
++-------------------+---------------------------+---------------------------+
+| Use when          | You need an independent   | You need fast, zero-copy  |
+|                   | copy or will return data  | access to Python data     |
++-------------------+---------------------------+---------------------------+
+
+Fixed-rank tensors
+------------------
+
+Both owning and view types have fixed-rank variants that enforce a specific
+number of dimensions at binding time:
+
+.. code-block:: cpp
+
+   // Accepts only 2D arrays, raises TypeError for other ranks
+   m.def("matrix_op", [](const xt::xtensor<double, 2>& a) {
+       return xt::sin(a);
+   });
+
+   // Fixed-rank view
+   m.def("matrix_view", [](const nb::xtensor_view<double, 2>& a) {
+       return xt::sum(a)();
+   });
+
+If a NumPy array with the wrong number of dimensions is passed, the caster
+reports failure and nanobind raises a ``TypeError``.
+
+Layout and allocator support
+----------------------------
+
+Owning containers
+^^^^^^^^^^^^^^^^^
+
+The owning type casters match at the ``xt::xarray_container`` /
+``xt::xtensor_container`` class template level, which means they automatically
+support non-default layout types and custom allocators:
+
+.. code-block:: cpp
+
+   // Column-major layout
+   m.def("column_major", [](const xt::xarray<double, xt::layout_type::column_major>& a) {
+       return a * 2.0;
+   });
+
+   // Custom allocator
+   m.def("custom_alloc", [](const xt::xarray<double, xt::layout_type::row_major,
+                                              std::allocator<double>>& a) {
+       return a * 2.0;
+   });
+
+Because owning types copy data and xtensor's assignment operator handles
+stride reordering, a column-major C++ function can accept both C-contiguous
+and Fortran-contiguous NumPy arrays, the data is reordered during the copy.
+
+Non-owning views
+^^^^^^^^^^^^^^^^
+
+View types accept an optional layout template parameter that defaults to
+``xt::layout_type::dynamic``. The layout determines how xtensor iterates over
+the data:
+
+.. code-block:: cpp
+
+   // Default (dynamic), accepts any array including non-contiguous slices.
+   // Detects the actual memory layout to enable optimizations when contiguous.
+   m.def("any_sum", [](const nb::xarray_view<double>& a) {
+       return xt::sum(a)();
+   });
+
+   // Row-major, only accepts C-contiguous arrays. Enables fast flat-pointer
+   // iteration since the layout is known at compile time.
+   m.def("fast_sum", [](const nb::xarray_view<double, xt::layout_type::row_major>& a) {
+       return xt::sum(a)();
+   });
+
+   // Column-major, only accepts Fortran-contiguous arrays.
+   m.def("fortran_sum", [](const nb::xarray_view<double, xt::layout_type::column_major>& a) {
+       return xt::sum(a)();
+   });
+
+The same applies to ``nb::xtensor_view``:
+
+.. code-block:: cpp
+
+   // Default (dynamic), accepts any 2D array layout
+   m.def("any_matrix", [](const nb::xtensor_view<double, 2>& a) {
+       return xt::sin(a);
+   });
+
+   // Row-major, only accepts C-contiguous 2D arrays
+   m.def("matrix_op", [](const nb::xtensor_view<double, 2, xt::layout_type::row_major>& a) {
+       return xt::sin(a);
+   });
+
+   // Column-major, only accepts Fortran-contiguous 2D arrays
+   m.def("fortran_matrix", [](const nb::xtensor_view<double, 2, xt::layout_type::column_major>& a) {
+       return xt::sin(a);
+   });
+
+.. note::
+
+   For 1-dimensional arrays, ``row_major`` and ``column_major`` are
+   equivalent (both have a single stride of 1), so a 1D Fortran-contiguous
+   array is accepted by a ``row_major`` view and vice versa. Non-contiguous
+   1D arrays (e.g., ``a[::2]``) are still rejected by strict-layout views.
+
+The default ``dynamic`` layout accepts any array without restrictions and
+detects the input memory order to enable optimizations when the data is
+contiguous. Use ``row_major`` or ``column_major`` when you want to enforce
+a specific memory order in the function signature and benefit from
+compile-time layout optimizations.
+
+.. _xtensor_lazy_expressions:
+
+Returning lazy expressions
+--------------------------
+
+xtensor uses *expression templates* for lazy evaluation. Arithmetic operations
+like ``a + b`` or ``xt::sin(a) * s + t`` do not compute results immediately,
+they return lightweight expression objects that capture **references** to their
+operands and evaluate on demand.
+
+nanobind includes an ``xexpression`` caster that materializes lazy
+expressions into a NumPy array before returning them to Python. The caster
+matches any type satisfying ``xt::is_xexpression<T>``, which covers
+expression templates (``a + b``, ``xt::sin(a)``, etc.), strided views
+(``xt::strided_view(...)``), and adaptors (``xt::adapt(...)``):
+
+.. code-block:: cpp
+
+   m.def("compute", [](const xt::xarray<double>& a, const double& s, const double& t) {
+       return xt::sin(a) * s + t;  // returns a lazy xexpression
+   });
+
+The expression is evaluated and wrapped in a NumPy array automatically.
+
+.. warning::
+
+   **Function parameters must be accepted as references when returning lazy
+   expressions.** This is critical for correctness.
+
+   Because expression templates hold **references** to their operands (not
+   copies), the operands must remain alive until the expression is evaluated.
+   nanobind's type casters store converted values on the dispatch stack,
+   which remains alive long enough for the expression to be evaluated and
+   materialized by the ``xexpression`` caster. But if a parameter is accepted
+   by value, the lambda receives a *local copy* and that copy is destroyed
+   when the lambda returns, **before** the expression is evaluated.
+
+   .. code-block:: cpp
+
+      // WRONG, undefined behavior! Parameters are by-value copies that are
+      // destroyed before the lazy expression is evaluated.
+      m.def("bad", [](xt::xarray<double> a, double s) {
+          return a * s;  // xexpression references destroyed locals
+      });
+
+      // CORRECT, parameters are references to caster-managed data that
+      // remain alive until the expression is materialized.
+      m.def("good", [](const xt::xarray<double>& a, const double& s) {
+          return a * s;
+      });
+
+   This applies equally to owning types (``xt::xarray``, ``xt::xtensor``),
+   views (``nb::xarray_view``, ``nb::xtensor_view``), and scalar parameters.
+   **Always use references** (``const T&`` or ``T&``) for parameters when the
+   return type is a lazy expression.
+
+   If you prefer to avoid this pitfall entirely, you can force eager evaluation
+   by specifying a concrete return type:
+
+   .. code-block:: cpp
+
+      // Also correct, explicit return type forces evaluation inside the lambda
+      m.def("also_good", [](xt::xarray<double> a, double s) -> xt::xarray<double> {
+          return a * s;  // evaluated immediately into the return container
+      });
+
+Vectorization
+-------------
+
+``nb::xvectorize`` wraps a scalar C++ function to operate element-wise on
+xtensor arrays, similar to NumPy's ``vectorize``:
+
+.. code-block:: cpp
+
+   double scalar_add(double a, double b) { return a + b; }
+
+   m.def("vectorized_add", nb::xvectorize(scalar_add));
+
+This also works with lambdas:
+
+.. code-block:: cpp
+
+   m.def("vectorized_sin", nb::xvectorize([](double x) {
+       return std::sin(x);
+   }));
+
+The vectorized function accepts ``nb::xarray_view`` parameters (zero-copy) and
+returns a lazy expression that is automatically materialized by the
+``xexpression`` caster. Broadcasting follows NumPy semantics.
+
+Supported scalar types
+----------------------
+
+The xtensor casters support all scalar types that nanobind's ``nb::ndarray``
+supports. Under the hood, nanobind uses the `DLPack
+<https://github.com/dmlc/dlpack>`__ protocol for dtype representation, so any
+type recognized by DLPack works transparently.
+
+The supported C++ types and their NumPy equivalents are:
+
++----------------------------+----------------------------+
+| C++ type                   | NumPy dtype                |
++============================+============================+
+| ``bool``                   | ``numpy.bool_``            |
++----------------------------+----------------------------+
+| ``int8_t``                 | ``numpy.int8``             |
++----------------------------+----------------------------+
+| ``int16_t``                | ``numpy.int16``            |
++----------------------------+----------------------------+
+| ``int32_t``                | ``numpy.int32``            |
++----------------------------+----------------------------+
+| ``int64_t``                | ``numpy.int64``            |
++----------------------------+----------------------------+
+| ``uint8_t``                | ``numpy.uint8``            |
++----------------------------+----------------------------+
+| ``uint16_t``               | ``numpy.uint16``           |
++----------------------------+----------------------------+
+| ``uint32_t``               | ``numpy.uint32``           |
++----------------------------+----------------------------+
+| ``uint64_t``               | ``numpy.uint64``           |
++----------------------------+----------------------------+
+| ``float``                  | ``numpy.float32``          |
++----------------------------+----------------------------+
+| ``double``                 | ``numpy.float64``          |
++----------------------------+----------------------------+
+| ``std::complex<float>``    | ``numpy.complex64``        |
++----------------------------+----------------------------+
+| ``std::complex<double>``   | ``numpy.complex128``       |
++----------------------------+----------------------------+
+
+Example with complex numbers:
+
+.. code-block:: cpp
+
+   m.def("complex_op", [](const xt::xarray<std::complex<double>>& a) {
+       return a * std::complex<double>(0.0, 1.0);
+   });

--- a/docs/xtensor.rst
+++ b/docs/xtensor.rst
@@ -1,0 +1,398 @@
+.. cpp:namespace:: nanobind
+
+.. _xtensor:
+
+The *xtensor* multi-dimensional array library
+==============================================
+
+`xtensor <https://github.com/xtensor-stack/xtensor>`__ is a header-only C++
+library for multi-dimensional arrays and tensors with lazy evaluation
+semantics. It provides NumPy-like syntax for element-wise operations,
+broadcasting, and mathematical functions.
+
+nanobind includes custom type casters that enable bidirectional conversion
+between xtensor and NumPy arrays. These casters build on the :ref:`n-dimensional array <ndarray_class>` class.
+
+Setup
+-----
+
+Add the following include directive to your binding code:
+
+.. code-block:: cpp
+
+   #include <nanobind/xtensor.h>
+
+This umbrella header pulls in casters for all supported xtensor types. You can
+also include individual headers if you only need a subset:
+
+.. code-block:: cpp
+
+   #include <nanobind/xtensor/xcontainer.h>  // xt::xarray, xt::xtensor
+   #include <nanobind/xtensor/xview.h>       // nb::xarray_view, nb::xtensor_view
+   #include <nanobind/xtensor/xexpression.h> // lazy xexpression return
+   #include <nanobind/xtensor/xvectorize.h>  // nb::xvectorize
+
+Owning containers
+-----------------
+
+Owning containers (``xt::xarray<T>`` and ``xt::xtensor<T, N>``) manage their
+own memory. When converting between Python and C++, data is **always copied**.
+
+Python → C++
+^^^^^^^^^^^^^
+
+When a Python NumPy array is passed to a C++ function expecting an owning
+container, the data is **always copied** into the container. This means the
+container owns its memory independently of the Python object.
+
+.. code-block:: cpp
+
+   // Data is copied into the xarray, safe to modify
+   m.def("process", [](xt::xarray<double>& arr) {
+       arr(0) = 999.0;  // does NOT affect the Python array
+       return arr;
+   });
+
+The owning caster supports implicit type conversion: if the NumPy array has a
+different dtype (e.g., ``float32`` when ``double`` is expected), nanobind will
+convert it automatically. This can be disabled with ``nb::arg().noconvert()``.
+
+C++ → Python
+^^^^^^^^^^^^^
+
+When a C++ function returns an owning container, the caster creates a NumPy
+array. The behavior depends on the return value policy:
+
+- **Return by value** (``rv_policy::move``): the container is move-constructed
+  into a capsule that owns the data. The resulting NumPy array references this
+  capsule with zero copy.
+
+- **Return by reference**: the NumPy array references the original C++ data.
+  Use ``rv_policy::reference_internal`` when the data is owned by a bound C++
+  object to ensure correct lifetimes.
+
+.. code-block:: cpp
+
+   // Returns by value, data is moved, no copy
+   m.def("make_array", []() {
+       return xt::xarray<double>{1.0, 2.0, 3.0};
+   });
+
+   // Returns by reference from a method, reference_internal keeps self alive
+   nb::class_<MyClass>(m, "MyClass")
+       .def("get_data", &MyClass::get_data, nb::rv_policy::reference_internal);
+
+.. warning::
+
+   ``rv_policy::reference_internal`` must only be used with **methods** (where
+   a ``self`` object exists). It works by preventing the Python wrapper of
+   ``self`` from being garbage-collected while the returned array is alive.
+
+   For **free functions** returning references to static or global data, use
+   ``rv_policy::reference`` instead, there is no ``self`` to keep alive, and
+   using ``reference_internal`` will cause a segmentation fault:
+
+   .. code-block:: cpp
+
+      static xt::xarray<double> global = {1.0, 2.0, 3.0};
+
+      // WRONG, free function has no self → segfault
+      m.def("bad", []() -> xt::xarray<double>& {
+          return global;
+      }, nb::rv_policy::reference_internal);
+
+      // CORRECT, use reference for static/global data
+      m.def("good", []() -> xt::xarray<double>& {
+          return global;
+      }, nb::rv_policy::reference);
+
+Non-owning views
+----------------
+
+Non-owning views (``nb::xarray_view<T>`` and ``nb::xtensor_view<T, N>``)
+provide **zero-copy** access to the underlying NumPy array's data. They do not
+own the memory and instead wrap the Python buffer directly using
+``xt::adapt()`` with ``xt::no_ownership()``.
+
+.. code-block:: cpp
+
+   #include <nanobind/xtensor.h>
+   namespace nb = nanobind;
+
+   // Zero-copy read access
+   m.def("sum_view", [](const nb::xarray_view<double>& a) {
+       return xt::sum(a)();
+   });
+
+   // Zero-copy write, modifies the Python array in-place
+   m.def("mutate", [](nb::xarray_view<double>& a) {
+       a(0) = 999.0;
+   });
+
+Because views wrap existing memory without copying, they **do not support
+implicit type conversion**. If the NumPy array's dtype does not match the
+expected scalar type exactly, nanobind will raise a ``TypeError``. This is
+intentional: converting to a temporary buffer would create a copy that the view
+would reference, leading to a dangling pointer when the temporary is destroyed.
+
+Owning vs. non-owning: when to use which
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++-------------------+---------------------------+---------------------------+
+|                   | Owning                    | Non-owning (view)         |
+|                   | (``xt::xarray``,          | (``nb::xarray_view``,     |
+|                   | ``xt::xtensor``)          | ``nb::xtensor_view``)     |
++===================+===========================+===========================+
+| Memory            | Copies data               | Wraps existing buffer     |
++-------------------+---------------------------+---------------------------+
+| Type conversion   | Implicit (converts dtype) | Strict (exact dtype only) |
++-------------------+---------------------------+---------------------------+
+| Mutability        | Modifications are local   | Modifies Python array     |
++-------------------+---------------------------+---------------------------+
+| Use when          | You need an independent   | You need fast, zero-copy  |
+|                   | copy or will return data  | access to Python data     |
++-------------------+---------------------------+---------------------------+
+
+Fixed-rank tensors
+------------------
+
+Both owning and view types have fixed-rank variants that enforce a specific
+number of dimensions at binding time:
+
+.. code-block:: cpp
+
+   // Accepts only 2D arrays, raises TypeError for other ranks
+   m.def("matrix_op", [](const xt::xtensor<double, 2>& a) {
+       return xt::sin(a);
+   });
+
+   // Fixed-rank view
+   m.def("matrix_view", [](const nb::xtensor_view<double, 2>& a) {
+       return xt::sum(a)();
+   });
+
+If a NumPy array with the wrong number of dimensions is passed, the caster
+reports failure and nanobind raises a ``TypeError``.
+
+Layout and allocator support
+----------------------------
+
+Owning containers
+^^^^^^^^^^^^^^^^^
+
+The owning type casters match at the ``xt::xarray_container`` /
+``xt::xtensor_container`` class template level, which means they automatically
+support non-default layout types and custom allocators:
+
+.. code-block:: cpp
+
+   // Column-major layout
+   m.def("column_major", [](const xt::xarray<double, xt::layout_type::column_major>& a) {
+       return a * 2.0;
+   });
+
+   // Custom allocator
+   m.def("custom_alloc", [](const xt::xarray<double, xt::layout_type::row_major,
+                                              std::allocator<double>>& a) {
+       return a * 2.0;
+   });
+
+Because owning types copy data and xtensor's assignment operator handles
+stride reordering, a column-major C++ function can accept both C-contiguous
+and Fortran-contiguous NumPy arrays, the data is reordered during the copy.
+
+Non-owning views
+^^^^^^^^^^^^^^^^
+
+View types accept an optional layout template parameter that defaults to
+``XTENSOR_DEFAULT_LAYOUT`` (typically ``row_major``). This layout is set at
+**compile time** and enables xtensor's fast flat-pointer iteration instead of
+slower stride-based stepping.
+
+By default, views only accept arrays whose memory layout matches the
+compile-time layout parameter. Passing a non-matching array raises a
+``TypeError``:
+
+.. code-block:: cpp
+
+   // Default (row_major), only accepts C-contiguous arrays
+   m.def("fast_sum", [](const nb::xarray_view<double>& a) {
+       return xt::sum(a)();
+   });
+
+   // Explicit column_major, only accepts Fortran-contiguous arrays
+   m.def("fortran_sum", [](const nb::xarray_view<double, xt::layout_type::column_major>& a) {
+       return xt::sum(a)();
+   });
+
+   // Dynamic layout, accepts any layout (including non-contiguous slices),
+   // but iteration uses the slower stride-based path
+   m.def("any_sum", [](const nb::xarray_view<double, xt::layout_type::dynamic>& a) {
+       return xt::sum(a)();
+   });
+
+The same applies to ``nb::xtensor_view``:
+
+.. code-block:: cpp
+
+   // Default (row_major), only accepts C-contiguous 2D arrays
+   m.def("matrix_op", [](const nb::xtensor_view<double, 2>& a) {
+       return xt::sin(a);
+   });
+
+   // Column-major, only accepts Fortran-contiguous 2D arrays
+   m.def("fortran_matrix", [](const nb::xtensor_view<double, 2, xt::layout_type::column_major>& a) {
+       return xt::sin(a);
+   });
+
+   // Dynamic, accepts any 2D array layout
+   m.def("any_matrix", [](const nb::xtensor_view<double, 2, xt::layout_type::dynamic>& a) {
+       return xt::sin(a);
+   });
+
+.. note::
+
+   For 1-dimensional arrays, ``row_major`` and ``column_major`` are
+   equivalent (both have a single stride of 1), so a 1D Fortran-contiguous
+   array is accepted by a ``row_major`` view and vice versa. Non-contiguous
+   1D arrays (e.g., ``a[::2]``) are still rejected by non-dynamic views.
+
+The default ``row_major`` layout matches NumPy's default C-contiguous order,
+so most NumPy arrays work without any extra configuration. Use
+``column_major`` when interfacing with Fortran-ordered data, and ``dynamic``
+when you need to accept arbitrary strides at the cost of slower iteration.
+
+.. _xtensor_lazy_expressions:
+
+Returning lazy expressions
+--------------------------
+
+xtensor uses *expression templates* for lazy evaluation. Arithmetic operations
+like ``a + b`` or ``xt::sin(a) * s + t`` do not compute results immediately,
+they return lightweight expression objects that capture **references** to their
+operands and evaluate on demand.
+
+nanobind includes an ``xexpression`` caster that materializes any lazy
+expression into a concrete ``xt::xarray`` before returning it to Python:
+
+.. code-block:: cpp
+
+   m.def("compute", [](const xt::xarray<double>& a, const double& s, const double& t) {
+       return xt::sin(a) * s + t;  // returns a lazy xexpression
+   });
+
+The expression is evaluated and wrapped in a NumPy array automatically.
+
+.. warning::
+
+   **Function parameters must be accepted as references when returning lazy
+   expressions.** This is critical for correctness.
+
+   Because expression templates hold **references** to their operands (not
+   copies), the operands must remain alive until the expression is evaluated.
+   nanobind's type casters store converted values on the dispatch stack,
+   which remains alive long enough for the expression to be evaluated and
+   materialized by the ``xexpression`` caster. But if a parameter is accepted
+   by value, the lambda receives a *local copy* and that copy is destroyed
+   when the lambda returns, **before** the expression is evaluated.
+
+   .. code-block:: cpp
+
+      // WRONG, undefined behavior! Parameters are by-value copies that are
+      // destroyed before the lazy expression is evaluated.
+      m.def("bad", [](xt::xarray<double> a, double s) {
+          return a * s;  // xexpression references destroyed locals
+      });
+
+      // CORRECT, parameters are references to caster-managed data that
+      // remain alive until the expression is materialized.
+      m.def("good", [](const xt::xarray<double>& a, const double& s) {
+          return a * s;
+      });
+
+   This applies equally to owning types (``xt::xarray``, ``xt::xtensor``),
+   views (``nb::xarray_view``, ``nb::xtensor_view``), and scalar parameters.
+   **Always use references** (``const T&`` or ``T&``) for parameters when the
+   return type is a lazy expression.
+
+   If you prefer to avoid this pitfall entirely, you can force eager evaluation
+   by specifying a concrete return type:
+
+   .. code-block:: cpp
+
+      // Also correct, explicit return type forces evaluation inside the lambda
+      m.def("also_good", [](xt::xarray<double> a, double s) -> xt::xarray<double> {
+          return a * s;  // evaluated immediately into the return container
+      });
+
+Vectorization
+-------------
+
+``nb::xvectorize`` wraps a scalar C++ function to operate element-wise on
+xtensor arrays, similar to NumPy's ``vectorize``:
+
+.. code-block:: cpp
+
+   double scalar_add(double a, double b) { return a + b; }
+
+   m.def("vectorized_add", nb::xvectorize(scalar_add));
+
+This also works with lambdas:
+
+.. code-block:: cpp
+
+   m.def("vectorized_sin", nb::xvectorize([](double x) {
+       return std::sin(x);
+   }));
+
+The vectorized function accepts ``nb::xarray_view`` parameters (zero-copy) and
+returns a lazy expression that is automatically materialized by the
+``xexpression`` caster. Broadcasting follows NumPy semantics.
+
+Supported scalar types
+----------------------
+
+The xtensor casters support all scalar types that nanobind's ``nb::ndarray``
+supports. Under the hood, nanobind uses the `DLPack
+<https://github.com/dmlc/dlpack>`__ protocol for dtype representation, so any
+type recognized by DLPack works transparently.
+
+The supported C++ types and their NumPy equivalents are:
+
++----------------------------+----------------------------+
+| C++ type                   | NumPy dtype                |
++============================+============================+
+| ``bool``                   | ``numpy.bool_``            |
++----------------------------+----------------------------+
+| ``int8_t``                 | ``numpy.int8``             |
++----------------------------+----------------------------+
+| ``int16_t``                | ``numpy.int16``            |
++----------------------------+----------------------------+
+| ``int32_t``                | ``numpy.int32``            |
++----------------------------+----------------------------+
+| ``int64_t``                | ``numpy.int64``            |
++----------------------------+----------------------------+
+| ``uint8_t``                | ``numpy.uint8``            |
++----------------------------+----------------------------+
+| ``uint16_t``               | ``numpy.uint16``           |
++----------------------------+----------------------------+
+| ``uint32_t``               | ``numpy.uint32``           |
++----------------------------+----------------------------+
+| ``uint64_t``               | ``numpy.uint64``           |
++----------------------------+----------------------------+
+| ``float``                  | ``numpy.float32``          |
++----------------------------+----------------------------+
+| ``double``                 | ``numpy.float64``          |
++----------------------------+----------------------------+
+| ``std::complex<float>``    | ``numpy.complex64``        |
++----------------------------+----------------------------+
+| ``std::complex<double>``   | ``numpy.complex128``       |
++----------------------------+----------------------------+
+
+Example with complex numbers:
+
+.. code-block:: cpp
+
+   m.def("complex_op", [](const xt::xarray<std::complex<double>>& a) {
+       return a * std::complex<double>(0.0, 1.0);
+   });

--- a/include/nanobind/xtensor.h
+++ b/include/nanobind/xtensor.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <nanobind/xtensor/xcontainer.h>
+#include <nanobind/xtensor/xview.h>
+#include <nanobind/xtensor/xexpression.h>
+#include <nanobind/xtensor/xvectorize.h>

--- a/include/nanobind/xtensor/traits.h
+++ b/include/nanobind/xtensor/traits.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <nanobind/ndarray.h>
+#include <nanobind/xtensor/version.h>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/containers/xtensor.hpp>
+#include <xtensor/core/xexpression.hpp>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename T>
+struct xcaster_traits;
+
+template <typename T, typename = void>
+constexpr bool has_xcaster_traits_v = false;
+
+template <typename T>
+constexpr bool has_xcaster_traits_v<T,
+    std::void_t<typename xcaster_traits<T>::scalar_type>> = true;
+
+template <typename T>
+constexpr bool is_xexpression_v =
+    xt::is_xexpression<T>::value && !has_xcaster_traits_v<T>;
+
+template <typename T, xt::layout_type L = xt::layout_type::dynamic>
+using xarray_view = xt::xarray_adaptor<
+    xt::xbuffer_adaptor<T*, xt::no_ownership>,
+    L,
+    std::vector<std::size_t>>;
+
+template <typename T, std::size_t N, xt::layout_type L = xt::layout_type::dynamic>
+using xtensor_view = xt::xtensor_adaptor<
+    xt::xbuffer_adaptor<T*, xt::no_ownership>,
+    N,
+    L>;
+
+/// Pick an ndarray type with an order annotation that matches xtensor static layout.
+template <typename Scalar, xt::layout_type L>
+using layout_ndarray =
+    std::conditional_t<L == xt::layout_type::row_major,
+        ndarray<Scalar, numpy, c_contig>,
+    std::conditional_t<L == xt::layout_type::column_major,
+        ndarray<Scalar, numpy, f_contig>, ndarray<Scalar, numpy>>>;
+
+/// Trait base for xarray, uses dynamic-size vectors with any ndim.
+template <typename Scalar, xt::layout_type L>
+struct xarray_traits_base {
+    using scalar_type = Scalar;
+    using shape_type = std::vector<size_t>;
+    using stride_type = std::vector<int64_t>;
+    static constexpr xt::layout_type layout = L;
+
+    static bool check_ndim(size_t) { return true; }
+    static shape_type make_shape(size_t nd) { return shape_type(nd); }
+    static stride_type make_strides(size_t nd) { return stride_type(nd); }
+};
+
+/// Trait base for xtensor, uses fixed-size arrays with ndim matches N.
+template <typename Scalar, std::size_t N, xt::layout_type L>
+struct xtensor_traits_base {
+    using scalar_type = Scalar;
+    using shape_type = std::array<size_t, N>;
+    using stride_type = std::array<int64_t, N>;
+    static constexpr xt::layout_type layout = L;
+
+    static bool check_ndim(size_t nd) { return nd == N; }
+    static shape_type make_shape(size_t) { return {}; }
+    static stride_type make_strides(size_t) { return {}; }
+};
+
+template <typename EC, xt::layout_type L, typename SC, typename Tag>
+struct xcaster_traits<xt::xarray_container<EC, L, SC, Tag>>
+    : xarray_traits_base<typename EC::value_type, L> {};
+
+template <typename EC, std::size_t N, xt::layout_type L, typename Tag>
+struct xcaster_traits<xt::xtensor_container<EC, N, L, Tag>>
+    : xtensor_traits_base<typename EC::value_type, N, L> {};
+
+template <typename T, xt::layout_type L>
+struct xcaster_traits<xarray_view<T, L>>
+    : xarray_traits_base<T, L> {};
+
+template <typename T, std::size_t N, xt::layout_type L>
+struct xcaster_traits<xtensor_view<T, N, L>>
+    : xtensor_traits_base<T, N, L> {};
+
+/// Inspect strides to determine the memory layout of an ndarray.
+/// Returns row_major / column_major for contiguous data, dynamic for non-contiguous.
+/// 1D contiguous arrays always return row_major (since row and column are equivalent for 1D),
+/// so column_major is only returned for ndim >= 2.
+template <typename NDArray>
+xt::layout_type detect_layout(const NDArray &arr) {
+    size_t ndim = arr.ndim();
+    if (ndim == 0)
+        return xt::layout_type::row_major;
+
+    bool row_major = (arr.stride(ndim - 1) == 1);
+    for (size_t i = ndim - 1; row_major && i > 0; --i)
+        row_major = (arr.stride(i - 1) == static_cast<int64_t>(arr.shape(i)) * arr.stride(i));
+
+    if (row_major)
+        return xt::layout_type::row_major;
+
+    if (ndim > 1) {
+        bool col_major = (arr.stride(0) == 1);
+        for (size_t i = 1; col_major && i < ndim; ++i)
+            col_major = (arr.stride(i) == static_cast<int64_t>(arr.shape(i - 1)) * arr.stride(i - 1));
+
+        if (col_major)
+            return xt::layout_type::column_major;
+    }
+
+    return xt::layout_type::dynamic;
+}
+
+NAMESPACE_END(detail)
+
+template <typename T, xt::layout_type L = xt::layout_type::dynamic>
+using xarray_view = detail::xarray_view<T, L>;
+
+template <typename T, std::size_t N, xt::layout_type L = xt::layout_type::dynamic>
+using xtensor_view = detail::xtensor_view<T, N, L>;
+
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/xtensor/traits.h
+++ b/include/nanobind/xtensor/traits.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <nanobind/xtensor/version.h>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/containers/xtensor.hpp>
+#include <xtensor/core/xexpression.hpp>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename T>
+struct xcaster_traits;
+
+template <typename T, typename = void>
+constexpr bool has_xcaster_traits_v = false;
+
+template <typename T>
+constexpr bool has_xcaster_traits_v<T,
+    std::void_t<typename xcaster_traits<T>::scalar_type>> = true;
+
+template <typename T>
+constexpr bool is_xexpression_v =
+    xt::is_xexpression<T>::value && !has_xcaster_traits_v<T>;
+
+template <typename T, xt::layout_type L = XTENSOR_DEFAULT_LAYOUT>
+using xarray_view = xt::xarray_adaptor<
+    xt::xbuffer_adaptor<T*, xt::no_ownership>,
+    L,
+    std::vector<std::size_t>>;
+
+template <typename T, std::size_t N, xt::layout_type L = XTENSOR_DEFAULT_LAYOUT>
+using xtensor_view = xt::xtensor_adaptor<
+    xt::xbuffer_adaptor<T*, xt::no_ownership>,
+    N,
+    L>;
+
+/// Trait base for xarray: uses dynamic-size vectors (any ndim).
+template <typename Scalar>
+struct xarray_traits_base {
+    using scalar_type = Scalar;
+    using shape_type = std::vector<size_t>;
+    using stride_type = std::vector<int64_t>;
+
+    static bool check_ndim(size_t) { return true; }
+    static shape_type make_shape(size_t nd) { return shape_type(nd); }
+    static stride_type make_strides(size_t nd) { return stride_type(nd); }
+};
+
+/// Trait base for xtensor: uses fixed-size arrays (ndim must match N at runtime).
+template <typename Scalar, std::size_t N>
+struct xtensor_traits_base {
+    using scalar_type = Scalar;
+    using shape_type = std::array<size_t, N>;
+    using stride_type = std::array<int64_t, N>;
+
+    static bool check_ndim(size_t nd) { return nd == N; }
+    /// std::array is default-initialized (size known at compile time).
+    static shape_type make_shape(size_t) { return {}; }
+    static stride_type make_strides(size_t) { return {}; }
+};
+
+template <typename EC, xt::layout_type L, typename SC, typename Tag>
+struct xcaster_traits<xt::xarray_container<EC, L, SC, Tag>>
+    : xarray_traits_base<typename EC::value_type> {};
+
+template <typename EC, std::size_t N, xt::layout_type L, typename Tag>
+struct xcaster_traits<xt::xtensor_container<EC, N, L, Tag>>
+    : xtensor_traits_base<typename EC::value_type, N> {};
+
+template <typename T, xt::layout_type L>
+struct xcaster_traits<xarray_view<T, L>>
+    : xarray_traits_base<T> {};
+
+template <typename T, std::size_t N, xt::layout_type L>
+struct xcaster_traits<xtensor_view<T, N, L>>
+    : xtensor_traits_base<T, N> {};
+
+/// Inspect strides to determine the memory layout of an ndarray.
+/// Returns row_major / column_major for contiguous data, dynamic otherwise.
+/// Note: 1D contiguous arrays always return row_major (row and column are equivalent for 1D),
+/// so column_major is only returned for ndim >= 2.
+template <typename NDArray>
+xt::layout_type detect_layout(const NDArray &arr) {
+    size_t ndim = arr.ndim();
+    if (ndim == 0)
+        return xt::layout_type::row_major;
+
+    bool row_major = (arr.stride(ndim - 1) == 1);
+    for (size_t i = ndim - 1; row_major && i > 0; --i)
+        row_major = (arr.stride(i - 1) == static_cast<int64_t>(arr.shape(i)) * arr.stride(i));
+
+    if (row_major)
+        return xt::layout_type::row_major;
+
+    if (ndim > 1) {
+        bool col_major = (arr.stride(0) == 1);
+        for (size_t i = 1; col_major && i < ndim; ++i)
+            col_major = (arr.stride(i) == static_cast<int64_t>(arr.shape(i - 1)) * arr.stride(i - 1));
+
+        if (col_major)
+            return xt::layout_type::column_major;
+    }
+
+    return xt::layout_type::dynamic;
+}
+
+NAMESPACE_END(detail)
+
+template <typename T, xt::layout_type L = XTENSOR_DEFAULT_LAYOUT>
+using xarray_view = detail::xarray_view<T, L>;
+
+template <typename T, std::size_t N, xt::layout_type L = XTENSOR_DEFAULT_LAYOUT>
+using xtensor_view = detail::xtensor_view<T, N, L>;
+
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/xtensor/version.h
+++ b/include/nanobind/xtensor/version.h
@@ -1,0 +1,19 @@
+#pragma once
+
+/// xtensor 0.26.0 changed the location of header files.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)
+#include <xtensor/core/xtensor_config.hpp>
+#else
+#error "xtensor/core/xtensor_config.hpp not found, probably using xtensor < 0.26.0");
+#endif
+
+#ifndef NB_XTENSOR_VERSION_AT_LEAST
+#define NB_XTENSOR_VERSION_AT_LEAST(major, minor, patch)                      \
+    (XTENSOR_VERSION_MAJOR > (major) ||                                       \
+     (XTENSOR_VERSION_MAJOR == (major) && XTENSOR_VERSION_MINOR > (minor)) || \
+     (XTENSOR_VERSION_MAJOR == (major) && XTENSOR_VERSION_MINOR == (minor) && \
+      XTENSOR_VERSION_PATCH >= (patch)))
+#endif
+
+static_assert(NB_XTENSOR_VERSION_AT_LEAST(0, 26, 0),
+              "xtensor support in nanobind requires xtensor >= 0.26.0");

--- a/include/nanobind/xtensor/version.h
+++ b/include/nanobind/xtensor/version.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <xtensor/core/xtensor_config.hpp>
+
+#ifndef NB_XTENSOR_VERSION_AT_LEAST
+#define NB_XTENSOR_VERSION_AT_LEAST(major, minor, patch)                      \
+    (XTENSOR_VERSION_MAJOR > (major) ||                                       \
+     (XTENSOR_VERSION_MAJOR == (major) && XTENSOR_VERSION_MINOR > (minor)) || \
+     (XTENSOR_VERSION_MAJOR == (major) && XTENSOR_VERSION_MINOR == (minor) && \
+      XTENSOR_VERSION_PATCH >= (patch)))
+#endif
+
+/// xtensor 0.26.0 changed the location of header files.
+static_assert(NB_XTENSOR_VERSION_AT_LEAST(0, 26, 0),
+              "xtensor support in nanobind requires xtensor >= 0.26.0");

--- a/include/nanobind/xtensor/xcontainer.h
+++ b/include/nanobind/xtensor/xcontainer.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <cstring>
+
+#include <nanobind/ndarray.h>
+#include <nanobind/xtensor/traits.h>
+#include <xtensor/containers/xadapt.hpp>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+/// Caster for owning xtensor containers (xt::xarray / xt::xtensor).
+///
+/// The input ndarray is unconstrained, this preserves
+/// the single copy of the data. The layout check would trigger ndarray's
+/// re-layout of the data, costing two passes over the data.
+///
+/// When the caller wants to restrict the layout, the flag nonconvert()
+/// could be used, then mismatched non-dynamic input layouts will be rejected.
+template <typename Container>
+struct xcontainer_caster {
+    using Traits = xcaster_traits<Container>;
+    using Scalar = typename Traits::scalar_type;
+    using NDArray = ndarray<Scalar, numpy>;
+    using NDArrayCaster = make_caster<NDArray>;
+
+    NB_TYPE_CASTER(Container, NDArrayCaster::Name)
+
+    NDArrayCaster caster;
+
+    bool from_python(handle src, uint8_t flags, cleanup_list *cl) noexcept {
+        if (!caster.from_python(src, flags, cl))
+            return false;
+
+        NDArray &arr = caster.value;
+        size_t ndim = arr.ndim();
+        if (!Traits::check_ndim(ndim))
+            return false;
+
+        xt::layout_type detected_layout = detect_layout(arr);
+
+        /// When the container declares a strict layout and noconvert() flag is set,
+        /// reject layout of the ndarray that does not match layout of the container.
+        /// 1D contiguous arrays always pass, since row_major and column_major
+        /// layouts are equivalent for 1D arrays.
+        if constexpr (Traits::layout != xt::layout_type::dynamic) {
+            bool layout_matches = (detected_layout == Traits::layout) ||
+                                  (ndim <= 1 && detected_layout != xt::layout_type::dynamic);
+
+            if (!layout_matches && !(flags & (uint8_t) cast_flags::convert))
+                return false;
+        }
+
+        auto shape = Traits::make_shape(ndim);
+        for (size_t i = 0; i < ndim; ++i)
+            shape[i] = arr.shape(i);
+
+        /// When the container layout is dynamic, we use XTENSOR_DEFAULT_LAYOUT
+        /// as the storage layout of the owning container (row_major by default).
+        constexpr xt::layout_type storage_layout =
+            Traits::layout == xt::layout_type::dynamic
+                ? XTENSOR_DEFAULT_LAYOUT
+                : Traits::layout;
+
+        if (detected_layout == storage_layout) {
+            /// Iteration optimization: when input array is contiguous
+            /// and its layout matches the storage layout, we just memcpy() raw bytes.
+            /// This avoids xtensor's generic iteration, which uses iterators
+            /// even when the array is contiguous.
+            value = Container::from_shape(shape);
+            std::memcpy(value.data(), arr.data(), arr.size() * sizeof(Scalar));
+        } else if (detected_layout != xt::layout_type::dynamic) {
+            /// When the layout is non-dynamic, but does not match the storage layout,
+            /// we wrap the numpy data in the adaptor and assign it to the container,
+            /// then xtensor re-layouts the array while copying.
+            value = xt::adapt<xt::layout_type::dynamic>(
+                arr.data(), arr.size(), xt::no_ownership(), shape, detected_layout);
+        } else {
+            /// When input layout is dynamic, we consider the input
+            /// as strided array and pass explicit strides to xtensor.
+            auto strides = Traits::make_strides(ndim);
+            for (size_t i = 0; i < ndim; ++i)
+                strides[i] = static_cast<int64_t>(arr.stride(i));
+
+            value = xt::adapt(arr.data(), arr.size(), xt::no_ownership(), shape, strides);
+        }
+
+        return true;
+    }
+
+    template <typename T_>
+    static handle from_cpp(T_ &&v, rv_policy policy, cleanup_list *cl) noexcept {
+        policy = infer_policy<T_>(policy);
+        if constexpr (std::is_pointer_v<T_>)
+            return from_cpp_internal((const Value &) *v, policy, cl);
+        else
+            return from_cpp_internal((const Value &) v, policy, cl);
+    }
+
+private:
+    static handle from_cpp_internal(const Value &arr, rv_policy policy, cleanup_list *cl) noexcept {
+        /// We pass the strict layout to the output ndarray type,
+        /// so the Python signature shows the order.
+        using OutArray = layout_ndarray<Scalar, Traits::layout>;
+        using OutCaster = make_caster<OutArray>;
+
+        size_t ndim = arr.dimension();
+
+        auto shape = Traits::make_shape(ndim);
+        auto strides = Traits::make_strides(ndim);
+        for (size_t i = 0; i < ndim; ++i) {
+            shape[i] = arr.shape()[i];
+            strides[i] = static_cast<int64_t>(arr.strides()[i]);
+        }
+
+        void *ptr = (void *) arr.data();
+        object owner;
+
+        if (policy == rv_policy::move) {
+            Value *temp = new Value((Value&&) arr);
+            owner = capsule(temp, [](void *p) noexcept { delete (Value*)p; });
+            ptr = temp->data();
+            policy = rv_policy::reference;
+        } else if (policy == rv_policy::reference_internal && cl->self()) {
+            owner = borrow(cl->self());
+            policy = rv_policy::reference;
+        }
+
+        OutArray ndarr(ptr, ndim, shape.data(), owner, strides.data());
+        return OutCaster::from_cpp(ndarr, policy, cl);
+    }
+};
+
+template <typename EC, xt::layout_type L, typename SC, typename Tag>
+struct type_caster<xt::xarray_container<EC, L, SC, Tag>,
+    enable_if_t<is_ndarray_scalar_v<typename EC::value_type>>>
+    : xcontainer_caster<xt::xarray_container<EC, L, SC, Tag>> {};
+
+template <typename EC, std::size_t N, xt::layout_type L, typename Tag>
+struct type_caster<xt::xtensor_container<EC, N, L, Tag>,
+    enable_if_t<is_ndarray_scalar_v<typename EC::value_type>>>
+    : xcontainer_caster<xt::xtensor_container<EC, N, L, Tag>> {};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/xtensor/xcontainer.h
+++ b/include/nanobind/xtensor/xcontainer.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <nanobind/ndarray.h>
+#include <nanobind/xtensor/traits.h>
+#include <xtensor/containers/xadapt.hpp>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename Container>
+struct xcontainer_caster {
+    using Traits = xcaster_traits<Container>;
+    using Scalar = typename Traits::scalar_type;
+    using NDArray = ndarray<Scalar, numpy>;
+    using Caster = make_caster<NDArray>;
+
+    NB_TYPE_CASTER(Container, Caster::Name)
+
+    Caster caster;
+
+    bool from_python(handle src, uint8_t flags, cleanup_list *cl) noexcept {
+        if (!caster.from_python(src, flags, cl))
+            return false;
+
+        NDArray &arr = caster.value;
+        size_t ndim = arr.ndim();
+        if (!Traits::check_ndim(ndim))
+            return false;
+
+        auto shape = Traits::make_shape(ndim);
+        for (size_t i = 0; i < ndim; ++i)
+            shape[i] = arr.shape(i);
+
+        /// Build a temporary adaptor over the input buffer, then assign into
+        /// an owning container which copies and re-layouts the data.
+        /// The adaptor uses adapt<dynamic> because the input layout may differ
+        /// from the container's layout, this is fine since the adaptor is
+        /// never iterated by user code, only by xtensor's copy/assign logic.
+        xt::layout_type layout = detect_layout(arr);
+        if (layout != xt::layout_type::dynamic) {
+            value = xt::adapt<xt::layout_type::dynamic>(
+                arr.data(), arr.size(), xt::no_ownership(), shape, layout);
+        } else {
+            auto strides = Traits::make_strides(ndim);
+            for (size_t i = 0; i < ndim; ++i)
+                strides[i] = static_cast<int64_t>(arr.stride(i));
+
+            value = xt::adapt(arr.data(), arr.size(), xt::no_ownership(), shape, strides);
+        }
+
+        return true;
+    }
+
+    template <typename T_>
+    static handle from_cpp(T_ &&v, rv_policy policy, cleanup_list *cl) noexcept {
+        policy = infer_policy<T_>(policy);
+        if constexpr (std::is_pointer_v<T_>)
+            return from_cpp_internal((const Value &) *v, policy, cl);
+        else
+            return from_cpp_internal((const Value &) v, policy, cl);
+    }
+
+private:
+    static handle from_cpp_internal(const Value &arr, rv_policy policy, cleanup_list *cl) noexcept {
+        size_t ndim = arr.dimension();
+
+        auto shape = Traits::make_shape(ndim);
+        auto strides = Traits::make_strides(ndim);
+        for (size_t i = 0; i < ndim; ++i) {
+            shape[i] = arr.shape()[i];
+            strides[i] = static_cast<int64_t>(arr.strides()[i]);
+        }
+
+        void *ptr = (void *) arr.data();
+        object owner;
+
+        if (policy == rv_policy::move) {
+            Value *temp = new Value((Value&&) arr);
+            owner = capsule(temp, [](void *p) noexcept { delete (Value*)p; });
+            ptr = temp->data();
+            policy = rv_policy::reference;
+        } else if (policy == rv_policy::reference_internal && cl->self()) {
+            owner = borrow(cl->self());
+            policy = rv_policy::reference;
+        }
+
+        NDArray ndarr(ptr, ndim, shape.data(), owner, strides.data());
+        return Caster::from_cpp(ndarr, policy, cl);
+    }
+};
+
+template <typename EC, xt::layout_type L, typename SC, typename Tag>
+struct type_caster<xt::xarray_container<EC, L, SC, Tag>,
+    enable_if_t<is_ndarray_scalar_v<typename EC::value_type>>>
+    : xcontainer_caster<xt::xarray_container<EC, L, SC, Tag>> {};
+
+template <typename EC, std::size_t N, xt::layout_type L, typename Tag>
+struct type_caster<xt::xtensor_container<EC, N, L, Tag>,
+    enable_if_t<is_ndarray_scalar_v<typename EC::value_type>>>
+    : xcontainer_caster<xt::xtensor_container<EC, N, L, Tag>> {};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/xtensor/xexpression.h
+++ b/include/nanobind/xtensor/xexpression.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <nanobind/xtensor/xcontainer.h>
+#include <xtensor/core/xnoalias.hpp>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+/// Caster for xtensor expressions (xt::xexpression).
+///
+/// Expressions are materialized into an xarray and returned as a numpy array.
+template <typename T>
+struct type_caster<T, enable_if_t<is_xexpression_v<T> &&
+                                  is_ndarray_scalar_v<typename T::value_type>>> {
+    using Scalar = typename T::value_type;
+    using XArray = xt::xarray<Scalar>;
+    using XArrayCaster = make_caster<XArray>;
+
+    static constexpr auto Name = XArrayCaster::Name;
+    template <typename T_> using Cast = T;
+    template <typename T_> static constexpr bool can_cast() { return true; }
+
+    /// Expressions cannot be received from Python.
+    bool from_python(handle, uint8_t, cleanup_list*) noexcept = delete;
+
+    template <typename T_>
+    static handle from_cpp(T_ &&expr, rv_policy, cleanup_list *cl) noexcept {
+        /// Expressions always evaluate into a XTENSOR_DEFAULT_LAYOUT (row_major) buffer,
+        /// so we explicitly set row_major layout in the ndarray container.
+        using NDArray = ndarray<Scalar, numpy, c_contig>;
+        using NDCaster = make_caster<NDArray>;
+
+        size_t ndim = expr.dimension();
+        std::vector<size_t> shape(ndim);
+        for (size_t i = 0; i < ndim; ++i)
+            shape[i] = expr.shape()[i];
+
+        /// Allocate the output buffer directly (single allocation).
+        size_t size = expr.size();
+        Scalar *data = new Scalar[size];
+        object owner = capsule(data, [](void *p) noexcept {
+            delete[] static_cast<Scalar*>(p);
+        });
+
+        /// Evaluate expression into the buffer using the xtensor adaptor.
+        /// Since the output buffer is allocated, no aliasing with input data is possible.
+        auto out = xt::adapt<XTENSOR_DEFAULT_LAYOUT>(
+            data, size, xt::no_ownership(), shape, XTENSOR_DEFAULT_LAYOUT);
+        xt::noalias(out) = std::forward<T_>(expr);
+
+        std::vector<int64_t> strides(ndim);
+        int64_t stride = 1;
+        for (size_t i = ndim; i-- > 0;) {
+            strides[i] = stride;
+            stride *= static_cast<int64_t>(shape[i]);
+        }
+
+        NDArray ndarr(data, ndim, shape.data(), owner, strides.data());
+        return NDCaster::from_cpp(ndarr, rv_policy::reference, cl);
+    }
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/xtensor/xexpression.h
+++ b/include/nanobind/xtensor/xexpression.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <nanobind/xtensor/xcontainer.h>
+#include <xtensor/core/xnoalias.hpp>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename T>
+struct type_caster<T, enable_if_t<is_xexpression_v<T> &&
+                                  is_ndarray_scalar_v<typename T::value_type>>> {
+    using Scalar = typename T::value_type;
+    using XArray = xt::xarray<Scalar>;
+    using XArrayCaster = make_caster<XArray>;
+
+    static constexpr auto Name = XArrayCaster::Name;
+    template <typename T_> using Cast = T;
+    template <typename T_> static constexpr bool can_cast() { return true; }
+
+    /// Expressions are output-only: they are evaluated into an xarray
+    /// and returned as a NumPy array. Cannot be received from Python.
+    bool from_python(handle, uint8_t, cleanup_list*) noexcept = delete;
+
+    template <typename T_>
+    static handle from_cpp(T_ &&expr, rv_policy, cleanup_list *cl) noexcept {
+        using NDArray = ndarray<Scalar, numpy>;
+        using NDCaster = make_caster<NDArray>;
+
+        size_t ndim = expr.dimension();
+        std::vector<size_t> shape(ndim);
+        for (size_t i = 0; i < ndim; ++i)
+            shape[i] = expr.shape()[i];
+
+        /// Allocate output buffer directly (single allocation).
+        size_t size = expr.size();
+        Scalar *data = new Scalar[size];
+        object owner = capsule(data, [](void *p) noexcept {
+            delete[] static_cast<Scalar*>(p);
+        });
+
+        /// Evaluate expression into the buffer via xtensor adaptor.
+        /// Output buffer is freshly allocated, no aliasing with input data possible.
+        auto out = xt::adapt<XTENSOR_DEFAULT_LAYOUT>(
+            data, size, xt::no_ownership(), shape, XTENSOR_DEFAULT_LAYOUT);
+        xt::noalias(out) = std::forward<T_>(expr);
+
+        std::vector<int64_t> strides(ndim);
+        int64_t stride = 1;
+        for (size_t i = ndim; i-- > 0;) {
+            strides[i] = stride;
+            stride *= static_cast<int64_t>(shape[i]);
+        }
+
+        NDArray ndarr(data, ndim, shape.data(), owner, strides.data());
+        return NDCaster::from_cpp(ndarr, rv_policy::reference, cl);
+    }
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/xtensor/xvectorize.h
+++ b/include/nanobind/xtensor/xvectorize.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <nanobind/xtensor/xview.h>
+#include <xtensor/core/xvectorize.hpp>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <class F>
+using get_function_type =
+    xt::remove_class_t<decltype(&std::remove_reference_t<F>::operator())>;
+
+NAMESPACE_END(detail)
+
+template <class Func, class R, class... Args>
+struct xvectorizer {
+    xt::xvectorizer<Func, R> m_vectorizer;
+
+    template <class F, class = std::enable_if_t<
+        !std::is_same_v<std::decay_t<F>, xvectorizer>>>
+    xvectorizer(F&& func)
+        : m_vectorizer(std::forward<F>(func)) {}
+
+    /// We use view to preserve zero-copy behaviour.
+    /// The const modifier rejects the modification of the source array.
+    auto operator()(const xarray_view<Args>&... args) const {
+        return m_vectorizer(args...);
+    }
+};
+
+template <class R, class... Args>
+inline xvectorizer<R (*)(Args...), R, Args...> xvectorize(R (*f)(Args...)) {
+    return xvectorizer<R (*)(Args...), R, Args...>(f);
+}
+
+template <class F, class R, class... Args>
+inline xvectorizer<F, R, Args...> xvectorize(F&& f, R (*)(Args...)) {
+    return xvectorizer<F, R, Args...>(std::forward<F>(f));
+}
+
+template <class F>
+inline auto xvectorize(F&& f) {
+    return xvectorize(std::forward<F>(f), (detail::get_function_type<F>*) nullptr);
+}
+
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/xtensor/xvectorize.h
+++ b/include/nanobind/xtensor/xvectorize.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <nanobind/xtensor/xview.h>
+#include <xtensor/core/xvectorize.hpp>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <class F>
+using get_function_type =
+    xt::remove_class_t<decltype(&std::remove_reference_t<F>::operator())>;
+
+NAMESPACE_END(detail)
+
+template <class Func, class R, class... Args>
+struct xvectorizer {
+    xt::xvectorizer<Func, R> m_vectorizer;
+
+    template <class F, class = std::enable_if_t<
+        !std::is_same_v<std::decay_t<F>, xvectorizer>>>
+    xvectorizer(F&& func)
+        : m_vectorizer(std::forward<F>(func)) {}
+
+    auto operator()(const xarray_view<Args>&... args) const {
+        return m_vectorizer(args...);
+    }
+};
+
+template <class R, class... Args>
+inline xvectorizer<R (*)(Args...), R, Args...> xvectorize(R (*f)(Args...)) {
+    return xvectorizer<R (*)(Args...), R, Args...>(f);
+}
+
+template <class F, class R, class... Args>
+inline xvectorizer<F, R, Args...> xvectorize(F&& f, R (*)(Args...)) {
+    return xvectorizer<F, R, Args...>(std::forward<F>(f));
+}
+
+template <class F>
+inline auto xvectorize(F&& f) {
+    return xvectorize(std::forward<F>(f), (detail::get_function_type<F>*) nullptr);
+}
+
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/xtensor/xview.h
+++ b/include/nanobind/xtensor/xview.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <optional>
+#include <nanobind/ndarray.h>
+#include <nanobind/xtensor/traits.h>
+#include <xtensor/containers/xadapt.hpp>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+/// Caster for zero-copy views (xt::xarray_adaptor / xt::xtensor_adaptor).
+/// Views wrap existing numpy memory without copying.
+///
+/// The input ndarray should match the container static layout.
+/// Mismatched layouts are rejected, since views cannot copy the data.
+/// Dynamic layouts accept any strides.
+template <typename View>
+struct xview_caster {
+    using Traits = xcaster_traits<View>;
+    using Scalar = typename Traits::scalar_type;
+
+    /// Compile-time layout from the View type determines iteration strategy.
+    /// The strict layout (row_major / column_major) enables fast iteration,
+    /// dynamic layout falls back to the slower stride-based stepping.
+    static constexpr xt::layout_type ViewLayout = View::static_layout;
+
+    using NDArray = layout_ndarray<Scalar, ViewLayout>;
+    using NDArrayCaster = make_caster<NDArray>;
+
+    static constexpr auto Name = NDArrayCaster::Name;
+    template <typename T_> using Cast = movable_cast_t<T_>;
+    template <typename T_> static constexpr bool can_cast() { return true; }
+
+    NDArrayCaster caster;
+    std::optional<View> view_;
+
+    explicit operator View*() { return &*view_; }
+    explicit operator View&() { return *view_; }
+    explicit operator View&&() { return (View&&) *view_; }
+
+    bool from_python(handle src, uint8_t flags, cleanup_list *cl) noexcept {
+        /// Disable convert flag. Views wrap existing memory without copying,
+        /// so implicit conversions are not supported.
+        if (!caster.from_python(src, flags & ~(uint8_t)cast_flags::convert, cl))
+            return false;
+
+        NDArray &arr = caster.value;
+        size_t ndim = arr.ndim();
+        if (!Traits::check_ndim(ndim))
+            return false;
+
+        auto shape = Traits::make_shape(ndim);
+        for (size_t i = 0; i < ndim; ++i)
+            shape[i] = arr.shape(i);
+
+        if constexpr (ViewLayout != xt::layout_type::dynamic) {
+            /// Iteration optimization: when the input is contiguous,
+            /// xtensor computes strides from shape.
+            view_.emplace(xt::adapt<ViewLayout>(
+                static_cast<Scalar*>(arr.data()), arr.size(),
+                xt::no_ownership(), std::move(shape), ViewLayout));
+        } else {
+            /// When the input is dynamic, we detect the input layout.
+            xt::layout_type layout = detect_layout(arr);
+
+            if (layout != xt::layout_type::dynamic) {
+                /// If the array is contiguous, pass the detected layout
+                /// to xtensor to enable its internal optimizations.
+                view_.emplace(xt::adapt<xt::layout_type::dynamic>(
+                    static_cast<Scalar*>(arr.data()), arr.size(),
+                    xt::no_ownership(), std::move(shape), layout));
+            } else {
+                /// When the array is non-contiguous, pass the explicit strides.
+                auto strides = Traits::make_strides(ndim);
+                for (size_t i = 0; i < ndim; ++i)
+                    strides[i] = static_cast<int64_t>(arr.stride(i));
+
+                view_.emplace(xt::adapt(
+                    static_cast<Scalar*>(arr.data()), arr.size(),
+                    xt::no_ownership(), std::move(shape), std::move(strides)));
+            }
+        }
+
+        return true;
+    }
+
+    template <typename T_>
+    static handle from_cpp(T_ &&arr, rv_policy policy, cleanup_list *cl) noexcept {
+        size_t ndim = arr.dimension();
+
+        auto shape = Traits::make_shape(ndim);
+        auto strides = Traits::make_strides(ndim);
+        for (size_t i = 0; i < ndim; ++i) {
+            shape[i] = arr.shape()[i];
+            strides[i] = static_cast<int64_t>(arr.strides()[i]);
+        }
+
+        object owner;
+        if (policy == rv_policy::reference_internal && cl->self()) {
+            owner = borrow(cl->self());
+            policy = rv_policy::reference;
+        }
+
+        NDArray ndarr((void *) arr.data(), ndim, shape.data(), owner, strides.data());
+        if (policy == rv_policy::automatic || policy == rv_policy::automatic_reference)
+            policy = rv_policy::reference;
+
+        return NDArrayCaster::from_cpp(ndarr, policy, cl);
+    }
+};
+
+template <typename T, xt::layout_type L>
+struct type_caster<xarray_view<T, L>, enable_if_t<is_ndarray_scalar_v<T>>>
+    : xview_caster<xarray_view<T, L>> {};
+
+template <typename T, std::size_t N, xt::layout_type L>
+struct type_caster<xtensor_view<T, N, L>, enable_if_t<is_ndarray_scalar_v<T>>>
+    : xview_caster<xtensor_view<T, N, L>> {};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/include/nanobind/xtensor/xview.h
+++ b/include/nanobind/xtensor/xview.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <optional>
+#include <nanobind/ndarray.h>
+#include <nanobind/xtensor/traits.h>
+#include <xtensor/containers/xadapt.hpp>
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+template <typename View>
+struct xview_caster {
+    using Traits = xcaster_traits<View>;
+    using Scalar = typename Traits::scalar_type;
+    using NDArray = ndarray<Scalar, numpy>;
+    using Caster = make_caster<NDArray>;
+
+    /// Compile-time layout from the View type. Determines iteration strategy:
+    /// known layout (row_major / column_major) enables fast flat-pointer iteration,
+    /// dynamic falls back to slower stride-based stepping.
+    static constexpr xt::layout_type ViewLayout = View::static_layout;
+
+    static constexpr auto Name = Caster::Name;
+    template <typename T_> using Cast = movable_cast_t<T_>;
+    template <typename T_> static constexpr bool can_cast() { return true; }
+
+    Caster caster;
+    std::optional<View> view_;
+
+    bool from_python(handle src, uint8_t flags, cleanup_list *cl) noexcept {
+        /// Strip the convert flag: views wrap existing memory without copying,
+        /// so implicit conversions (e.g. int->float) are not supported.
+        if (!caster.from_python(src, flags & ~(uint8_t)cast_flags::convert, cl))
+            return false;
+
+        NDArray &arr = caster.value;
+        size_t ndim = arr.ndim();
+        if (!Traits::check_ndim(ndim))
+            return false;
+
+        auto shape = Traits::make_shape(ndim);
+        for (size_t i = 0; i < ndim; ++i)
+            shape[i] = arr.shape(i);
+
+        xt::layout_type layout = detect_layout(arr);
+        if constexpr (ViewLayout != xt::layout_type::dynamic) {
+            /// Known layout: reject mismatched arrays, but allow 1D contiguous
+            /// arrays through (row_major == column_major for 1D).
+            /// Non-contiguous 1D (layout==dynamic) is still rejected.
+            if (layout != ViewLayout && (ndim > 1 || layout == xt::layout_type::dynamic))
+                return false;
+
+            /// adapt<Layout>(..., shape, layout), no strides needed, xtensor
+            /// computes them from shape. This enables flat-pointer iteration.
+            view_.emplace(xt::adapt<ViewLayout>(
+                static_cast<Scalar*>(arr.data()), arr.size(),
+                xt::no_ownership(), std::move(shape), ViewLayout));
+        } else {
+            /// Dynamic layout: accepts any array. When data is contiguous,
+            /// pass detected layout to enable xtensor's internal optimization.
+            if (layout != xt::layout_type::dynamic) {
+                view_.emplace(xt::adapt<xt::layout_type::dynamic>(
+                    static_cast<Scalar*>(arr.data()), arr.size(),
+                    xt::no_ownership(), std::move(shape), layout));
+            } else {
+                // Non-contiguous: must pass explicit strides.
+                auto strides = Traits::make_strides(ndim);
+                for (size_t i = 0; i < ndim; ++i)
+                    strides[i] = static_cast<int64_t>(arr.stride(i));
+
+                view_.emplace(xt::adapt(
+                    static_cast<Scalar*>(arr.data()), arr.size(),
+                    xt::no_ownership(), std::move(shape), std::move(strides)));
+            }
+        }
+        return true;
+    }
+
+    explicit operator View*()  { return &*view_; }
+    explicit operator View&()  { return *view_; }
+    explicit operator View&&() { return (View&&) *view_; }
+
+    template <typename T_>
+    static handle from_cpp(T_ &&arr, rv_policy policy, cleanup_list *cl) noexcept {
+        size_t ndim = arr.dimension();
+
+        auto shape = Traits::make_shape(ndim);
+        auto strides = Traits::make_strides(ndim);
+        for (size_t i = 0; i < ndim; ++i) {
+            shape[i] = arr.shape()[i];
+            strides[i] = static_cast<int64_t>(arr.strides()[i]);
+        }
+
+        object owner;
+        if (policy == rv_policy::reference_internal && cl->self()) {
+            owner = borrow(cl->self());
+            policy = rv_policy::reference;
+        }
+
+        NDArray ndarr((void *) arr.data(), ndim, shape.data(), owner, strides.data());
+        if (policy == rv_policy::automatic || policy == rv_policy::automatic_reference)
+            policy = rv_policy::reference;
+
+        return Caster::from_cpp(ndarr, policy, cl);
+    }
+};
+
+template <typename T, xt::layout_type L>
+struct type_caster<xarray_view<T, L>, enable_if_t<is_ndarray_scalar_v<T>>>
+    : xview_caster<xarray_view<T, L>> {};
+
+template <typename T, std::size_t N, xt::layout_type L>
+struct type_caster<xtensor_view<T, N, L>, enable_if_t<is_ndarray_scalar_v<T>>>
+    : xview_caster<xtensor_view<T, N, L>> {};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,13 @@ if (TARGET Eigen3::Eigen)
   target_link_libraries(test_eigen_tensor_ext PRIVATE Eigen3::Eigen)
 endif()
 
+find_package (xtl NO_MODULE)
+find_package (xtensor NO_MODULE)
+if (TARGET xtl AND TARGET xtensor)
+  nanobind_add_module(test_xtensor_ext test_xtensor.cpp ${NB_EXTRA_ARGS})
+  target_link_libraries(test_xtensor_ext PRIVATE xtensor xtl)
+endif()
+
 add_library(
   inter_module
   SHARED
@@ -162,6 +169,7 @@ set(TEST_FILES
   test_classes.py
   test_eigen.py
   test_eigen_tensor.py
+  test_xtensor.py
   test_enum.py
   test_eval.py
   test_exception.py

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,14 @@ if (TARGET Eigen3::Eigen)
   target_link_libraries(test_eigen_tensor_ext PRIVATE Eigen3::Eigen)
 endif()
 
+find_package (xtl NO_MODULE)
+find_package (xtensor NO_MODULE)
+if (TARGET xtl AND TARGET xtensor)
+  nanobind_add_module(test_xtensor_ext test_xtensor.cpp ${NB_EXTRA_ARGS})
+  target_link_libraries(test_xtensor_ext PRIVATE xtensor xtl)
+  target_compile_features(test_xtensor_ext PRIVATE cxx_std_20)
+endif()
+
 add_library(
   inter_module
   SHARED
@@ -162,6 +170,7 @@ set(TEST_FILES
   test_classes.py
   test_eigen.py
   test_eigen_tensor.py
+  test_xtensor.py
   test_enum.py
   test_eval.py
   test_exception.py

--- a/tests/test_xtensor.cpp
+++ b/tests/test_xtensor.cpp
@@ -1,0 +1,315 @@
+#include <complex>
+#include <nanobind/nanobind.h>
+#include <nanobind/xtensor.h>
+#include <xtensor/core/xlayout.hpp>
+#include <xtensor/views/xstrided_view.hpp>
+#include <xtensor/containers/xadapt.hpp>
+
+using complex_t = std::complex<double>;
+
+namespace nb = nanobind;
+
+static xt::xarray<double> static_array = {10.0, 20.0, 30.0};
+static xt::xtensor<double, 2> static_tensor = {{10.0, 20.0}, {30.0, 40.0}};
+
+double scalar_add(double a, double b) { return a + b; }
+
+template <typename E>
+inline auto array_multiply(E &&arr) {
+    return arr * 1234.0;
+}
+
+struct Owner {
+    xt::xarray<double> array = {1.0, 2.0, 3.0};
+    xt::xtensor<double, 2> tensor = {{1.0, 2.0}, {3.0, 4.0}};
+
+    xt::xarray<double>& get_array() { return array; }
+    xt::xtensor<double, 2>& get_tensor() { return tensor; }
+};
+
+NB_MODULE(test_xtensor_ext, m) {
+    // xt::xarray tests
+
+    m.def("test_xarray", [](const xt::xarray<double>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xarray_mutate", [](xt::xarray<double>& a) {
+        a(0) = 999.0;
+        return a;
+    });
+
+    m.def("test_xarray_return_by_value", []() {
+        return xt::xarray<double>{1.0, 2.0, 3.0};
+    });
+
+    m.def("test_xarray_return_by_ref", []() -> xt::xarray<double>& {
+        return static_array;
+    });
+
+    m.def("test_xarray_return_by_const_ref", []() -> const xt::xarray<double>& {
+        return static_array;
+    });
+
+    m.def("test_xarray_accept_column_major", [](const xt::xarray<double, xt::layout_type::column_major>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xarray_accept_custom_allocator", [](const xt::xarray<double, xt::layout_type::row_major, std::allocator<double>>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xarray_dynamic_type", [](const xt::xarray<double>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xarray_type_overload", [](const xt::xarray<double>& a) {
+        return 2.0 * a;
+    });
+
+    m.def("test_xarray_type_overload", [](const xt::xarray<float>& a) {
+        return 3.0 * a;
+    });
+
+    m.def("test_xarray_template_func", [](const xt::xarray<double>& a) {
+        return array_multiply(a);
+    });
+
+    m.def("test_xarray_complex", [](const xt::xarray<complex_t>& a, const xt::xarray<complex_t>& b) {
+        return a + b;
+    });
+
+    m.def("test_xarray_row_major_noconvert", [](const xt::xarray<double, xt::layout_type::row_major>& a) {
+        return a * 2.0;
+    }, nb::arg("a").noconvert());
+
+    m.def("test_xarray_column_major_noconvert", [](const xt::xarray<double, xt::layout_type::column_major>& a) {
+        return a * 2.0;
+    }, nb::arg("a").noconvert());
+
+    m.def("test_xarray_dynamic_noconvert", [](const xt::xarray<double, xt::layout_type::dynamic>& a) {
+        return a * 2.0;
+    }, nb::arg("a").noconvert());
+
+    m.def("test_xarray_return_column_major", []() {
+        return xt::xarray<double, xt::layout_type::column_major>{1.0, 2.0, 3.0, 4.0};
+    });
+
+    m.def("test_xarray_mixed_layouts",
+        [](const xt::xarray<double, xt::layout_type::row_major>& a)
+              -> xt::xarray<double, xt::layout_type::column_major> {
+        return a;
+    });
+
+
+    // xt::xtensor tests
+
+    m.def("test_xtensor", [](const xt::xtensor<double, 2>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xtensor_mutate", [](xt::xtensor<double, 2>& a) {
+        a(0, 0) = 999.0;
+        return a;
+    });
+
+    m.def("test_xtensor_return_by_value", []() {
+        return xt::xtensor<double, 2>{{1.0, 2.0}, {3.0, 4.0}};
+    });
+
+    m.def("test_xtensor_return_by_ref", []() -> xt::xtensor<double, 2>& {
+        return static_tensor;
+    });
+
+    m.def("test_xtensor_return_by_const_ref", []() -> const xt::xtensor<double, 2>& {
+        return static_tensor;
+    });
+
+    m.def("test_xtensor_accept_column_major", [](const xt::xtensor<double, 2, xt::layout_type::column_major>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xtensor_accept_custom_allocator", [](const xt::xtensor<double, 2, xt::layout_type::row_major, std::allocator<double>>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xtensor_dynamic_type", [](const xt::xtensor<double, 2>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xtensor_type_overload", [](const xt::xtensor<double, 2>& a) {
+        return 2 * a;
+    });
+
+    m.def("test_xtensor_type_overload", [](const xt::xtensor<float, 2>& a) {
+        return 3 * a;
+    });
+
+    m.def("test_xtensor_template_func", [](const xt::xtensor<double, 2>& a) {
+        return array_multiply(a);
+    });
+
+    m.def("test_xtensor_complex", [](const xt::xtensor<complex_t, 2>& a, const xt::xtensor<complex_t, 2>& b) {
+        return a + b;
+    });
+
+    m.def("test_xtensor_row_major_noconvert_1d", [](const xt::xtensor<double, 1, xt::layout_type::row_major>& a) {
+        return a * 2.0;
+    }, nb::arg("a").noconvert());
+
+    m.def("test_xtensor_column_major_noconvert_1d", [](const xt::xtensor<double, 1, xt::layout_type::column_major>& a) {
+        return a * 2.0;
+    }, nb::arg("a").noconvert());
+
+    m.def("test_xtensor_row_major_noconvert", [](const xt::xtensor<double, 2, xt::layout_type::row_major>& a) {
+        return a * 2.0;
+    }, nb::arg("a").noconvert());
+
+    m.def("test_xtensor_column_major_noconvert", [](const xt::xtensor<double, 2, xt::layout_type::column_major>& a) {
+        return a * 2.0;
+    }, nb::arg("a").noconvert());
+
+    m.def("test_xtensor_dynamic_noconvert", [](const xt::xtensor<double, 2, xt::layout_type::dynamic>& a) {
+        return a * 2.0;
+    }, nb::arg("a").noconvert());
+
+    m.def("test_xtensor_return_column_major", []() {
+        return xt::xtensor<double, 2, xt::layout_type::column_major>{{1.0, 2.0}, {3.0, 4.0}};
+    });
+
+    m.def("test_xtensor_mixed_layouts",
+        [](const xt::xtensor<double, 2, xt::layout_type::row_major>& a)
+              -> xt::xtensor<double, 2, xt::layout_type::column_major> {
+        return a;
+    });
+
+
+    // nb::xarray_view tests
+
+    m.def("test_xarray_view", [](const nb::xarray_view<double>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xarray_view_row_major", [](const nb::xarray_view<double, xt::layout_type::row_major>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xarray_view_column_major", [](const nb::xarray_view<double, xt::layout_type::column_major>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xarray_view_dynamic", [](const nb::xarray_view<double, xt::layout_type::dynamic>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xarray_view_zerocopy", [](const nb::xarray_view<double>& a) {
+        return a;
+    });
+
+    m.def("test_xarray_view_mutate", [](nb::xarray_view<double>& a) {
+        a(0) = 999.0;
+    });
+
+    m.def("test_xarray_view_strict_type", [](const nb::xarray_view<double>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xarray_view_type_overload", [](const nb::xarray_view<double>& a) {
+        return 2 * a;
+    });
+
+    m.def("test_xarray_view_type_overload", [](const nb::xarray_view<float>& a) {
+        return 3 * a;
+    });
+
+    m.def("test_xarray_view_template_func", [](const nb::xarray_view<double>& a) {
+        return array_multiply(a);
+    });
+
+    m.def("test_xarray_view_complex", [](const nb::xarray_view<complex_t>& a) {
+        return a + complex_t(1.0, 1.0);
+    });
+
+
+    // nb::xtensor_view tests
+
+    m.def("test_xtensor_view", [](const nb::xtensor_view<double, 2>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xtensor_view_row_major", [](const nb::xtensor_view<double, 2, xt::layout_type::row_major>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xtensor_view_column_major", [](const nb::xtensor_view<double, 2, xt::layout_type::column_major>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xtensor_view_dynamic", [](const nb::xtensor_view<double, 2, xt::layout_type::dynamic>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xtensor_view_zerocopy", [](const nb::xtensor_view<double, 2>& a) {
+        return a;
+    });
+
+    m.def("test_xtensor_view_mutate", [](nb::xtensor_view<double, 2>& a) {
+        a(0, 0) = 999.0;
+    });
+
+    m.def("test_xtensor_view_strict_type", [](const nb::xarray_view<double>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xtensor_view_type_overload", [](const nb::xtensor_view<double, 2>& a) {
+        return 2 * a;
+    });
+
+    m.def("test_xtensor_view_type_overload", [](const nb::xtensor_view<float, 2>& a) {
+        return 3 * a;
+    });
+
+    m.def("test_xtensor_view_template_func", [](const nb::xtensor_view<double, 2>& a) {
+        return array_multiply(a);
+    });
+
+    m.def("test_xtensor_view_complex", [](const nb::xtensor_view<complex_t, 2>& a) {
+        return a + complex_t(1.0, 1.0);
+    });
+
+
+    // vectorization tests
+
+    m.def("test_vectorize", nb::xvectorize(scalar_add));
+
+    m.def("test_vectorize_lambda", nb::xvectorize([](double x) {
+        return std::sin(x);
+    }));
+
+
+    // strided_view + adaptor tests
+
+    m.def("test_strided_view_return", []() {
+        return xt::strided_view(static_array, {xt::range(0, 3, 2)});
+    });
+
+    m.def("test_xarray_adaptor_return", []() {
+        static double buf[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+        std::vector<size_t> shape = {2, 3};
+        return xt::adapt(&buf[0], 6, xt::no_ownership(), shape);
+    });
+
+    m.def("test_xtensor_adaptor_return", []() {
+        static double buf[4] = {10.0, 20.0, 30.0, 40.0};
+        std::array<size_t, 2> shape = {2, 2};
+        return xt::adapt(&buf[0], shape);
+    });
+
+
+    // reference_internal tests
+
+    nb::class_<Owner>(m, "Owner")
+        .def(nb::init<>())
+        .def("get_array", &Owner::get_array, nb::rv_policy::reference_internal)
+        .def("get_tensor", &Owner::get_tensor, nb::rv_policy::reference_internal);
+}

--- a/tests/test_xtensor.cpp
+++ b/tests/test_xtensor.cpp
@@ -1,0 +1,234 @@
+#include <complex>
+#include <nanobind/nanobind.h>
+#include <nanobind/xtensor.h>
+#include <xtensor/core/xlayout.hpp>
+
+using complex_t = std::complex<double>;
+
+namespace nb = nanobind;
+
+static xt::xarray<double> static_array = {10.0, 20.0, 30.0};
+static xt::xtensor<double, 2> static_tensor = {{10.0, 20.0}, {30.0, 40.0}};
+
+double scalar_add(double a, double b) { return a + b; }
+
+template <typename E>
+inline auto array_multiply(E &&arr) {
+    return arr * 1234.0;
+}
+
+struct Owner {
+    xt::xarray<double> array = {1.0, 2.0, 3.0};
+    xt::xtensor<double, 2> tensor = {{1.0, 2.0}, {3.0, 4.0}};
+
+    xt::xarray<double>& get_array() { return array; }
+    xt::xtensor<double, 2>& get_tensor() { return tensor; }
+};
+
+NB_MODULE(test_xtensor_ext, m) {
+    // xt::xarray tests
+
+    m.def("test_xarray", [](const xt::xarray<double>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xarray_mutate", [](xt::xarray<double>& a) {
+        a(0) = 999.0;
+        return a;
+    });
+
+    m.def("test_xarray_return_by_value", []() {
+        return xt::xarray<double>{1.0, 2.0, 3.0};
+    });
+
+    m.def("test_xarray_return_by_ref", []() -> xt::xarray<double>& {
+        return static_array;
+    });
+
+    m.def("test_xarray_return_by_const_ref", []() -> const xt::xarray<double>& {
+        return static_array;
+    });
+
+    m.def("test_xarray_accept_column_major", [](const xt::xarray<double, xt::layout_type::column_major>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xarray_accept_custom_allocator", [](const xt::xarray<double, xt::layout_type::row_major, std::allocator<double>>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xarray_dynamic_type", [](const xt::xarray<double>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xarray_type_overload", [](const xt::xarray<double>& a) {
+        return 2.0 * a;
+    });
+
+    m.def("test_xarray_type_overload", [](const xt::xarray<float>& a) {
+        return 3.0 * a;
+    });
+
+    m.def("test_xarray_template_func", [](const xt::xarray<double>& a) {
+        return array_multiply(a);
+    });
+
+    m.def("test_xarray_complex", [](const xt::xarray<complex_t>& a, const xt::xarray<complex_t>& b) {
+        return a + b;
+    });
+
+
+    // xt::xtensor<> tests
+
+    m.def("test_xtensor", [](const xt::xtensor<double, 2>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xtensor_mutate", [](xt::xtensor<double, 2>& a) {
+        a(0, 0) = 999.0;
+        return a;
+    });
+
+    m.def("test_xtensor_return_by_value", []() {
+        return xt::xtensor<double, 2>{{1.0, 2.0}, {3.0, 4.0}};
+    });
+
+    m.def("test_xtensor_return_by_ref", []() -> xt::xtensor<double, 2>& {
+        return static_tensor;
+    });
+
+    m.def("test_xtensor_return_by_const_ref", []() -> const xt::xtensor<double, 2>& {
+        return static_tensor;
+    });
+
+    m.def("test_xtensor_accept_column_major", [](const xt::xtensor<double, 2, xt::layout_type::column_major>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xtensor_accept_custom_allocator", [](const xt::xtensor<double, 2, xt::layout_type::row_major, std::allocator<double>>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xtensor_dynamic_type", [](const xt::xtensor<double, 2>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xtensor_type_overload", [](const xt::xtensor<double, 2>& a) {
+        return 2 * a;
+    });
+
+    m.def("test_xtensor_type_overload", [](const xt::xtensor<float, 2>& a) {
+        return 3 * a;
+    });
+
+    m.def("test_xtensor_template_func", [](const xt::xtensor<double, 2>& a) {
+        return array_multiply(a);
+    });
+
+    m.def("test_xtensor_complex", [](const xt::xtensor<complex_t, 2>& a, const xt::xtensor<complex_t, 2>& b) {
+        return a + b;
+    });
+
+
+    // nb::xarray_view<> tests
+
+    m.def("test_xarray_view", [](const nb::xarray_view<double>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xarray_view_column_major", [](const nb::xarray_view<double, xt::layout_type::column_major>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xarray_view_dynamic", [](const nb::xarray_view<double, xt::layout_type::dynamic>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xarray_view_zerocopy", [](const nb::xarray_view<double>& a) {
+        return a;
+    });
+
+    m.def("test_xarray_view_mutate", [](nb::xarray_view<double>& a) {
+        a(0) = 999.0;
+    });
+
+    m.def("test_xarray_view_strict_type", [](const nb::xarray_view<double>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xarray_view_type_overload", [](const nb::xarray_view<double>& a) {
+        return 2 * a;
+    });
+
+    m.def("test_xarray_view_type_overload", [](const nb::xarray_view<float>& a) {
+        return 3 * a;
+    });
+
+    m.def("test_xarray_view_template_func", [](const nb::xarray_view<double>& a) {
+        return array_multiply(a);
+    });
+
+    m.def("test_xarray_view_complex", [](const nb::xarray_view<complex_t>& a) {
+        return a + complex_t(1.0, 1.0);
+    });
+
+
+    // nb::xtensor_view<> tests
+
+    m.def("test_xtensor_view", [](const nb::xtensor_view<double, 2>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xtensor_view_column_major", [](const nb::xtensor_view<double, 2, xt::layout_type::column_major>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xtensor_view_dynamic", [](const nb::xtensor_view<double, 2, xt::layout_type::dynamic>& a, const double& s, const double& t) {
+        return xt::sin(a) * s + t;
+    });
+
+    m.def("test_xtensor_view_zerocopy", [](const nb::xtensor_view<double, 2>& a) {
+        return a;
+    });
+
+    m.def("test_xtensor_view_mutate", [](nb::xtensor_view<double, 2>& a) {
+        a(0, 0) = 999.0;
+    });
+
+    m.def("test_xtensor_view_strict_type", [](const nb::xarray_view<double>& a) {
+        return a * 2.0;
+    });
+
+    m.def("test_xtensor_view_type_overload", [](const nb::xtensor_view<double, 2>& a) {
+        return 2 * a;
+    });
+
+    m.def("test_xtensor_view_type_overload", [](const nb::xtensor_view<float, 2>& a) {
+        return 3 * a;
+    });
+
+    m.def("test_xtensor_view_template_func", [](const nb::xtensor_view<double, 2>& a) {
+        return array_multiply(a);
+    });
+
+    m.def("test_xtensor_view_complex", [](const nb::xtensor_view<complex_t, 2>& a) {
+        return a + complex_t(1.0, 1.0);
+    });
+
+
+    // vectorization tests
+
+    m.def("test_vectorize", nb::xvectorize(scalar_add));
+
+    m.def("test_vectorize_lambda", nb::xvectorize([](double x) {
+        return std::sin(x);
+    }));
+
+
+    // reference_internal tests
+
+    nb::class_<Owner>(m, "Owner")
+        .def(nb::init<>())
+        .def("get_array", &Owner::get_array, nb::rv_policy::reference_internal)
+        .def("get_tensor", &Owner::get_tensor, nb::rv_policy::reference_internal);
+}

--- a/tests/test_xtensor.py
+++ b/tests/test_xtensor.py
@@ -1,0 +1,597 @@
+import pytest
+
+try:
+    import numpy as np
+    from numpy.testing import assert_array_equal, assert_array_almost_equal
+    import test_xtensor_ext as t
+    def needs_numpy_and_xtensor(x):
+        return x
+except:
+    needs_numpy_and_xtensor = pytest.mark.skip(reason="NumPy and xtensor are required")
+
+# xt::xarray tests
+
+@needs_numpy_and_xtensor
+def test_xarray():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_almost_equal(t.test_xarray(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_accepts_2d():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_almost_equal(t.test_xarray(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_not_contiguous():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b = a[::-2]
+    assert_array_almost_equal(t.test_xarray(b, 2.0, 3.0), np.sin(b) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_column_major():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_mutate():
+    a = np.array([1.0, 2.0, 3.0])
+    b = t.test_xarray_mutate(a)
+    assert_array_equal(b, [999.0, 2.0, 3.0])
+    assert_array_equal(a, [1.0, 2.0, 3.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_return_by_value():
+    result = t.test_xarray_return_by_value()
+    assert_array_equal(result, [1.0, 2.0, 3.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_return_by_ref():
+    result = t.test_xarray_return_by_ref()
+    assert_array_equal(result, [10.0, 20.0, 30.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_return_by_const_ref():
+    result = t.test_xarray_return_by_const_ref()
+    assert_array_equal(result, [10.0, 20.0, 30.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_accept_column_major():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_equal(t.test_xarray_accept_column_major(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_accept_custom_allocator():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_equal(t.test_xarray_accept_custom_allocator(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_dynamic_type():
+    a = np.array([1.0, 2.0, 3.0], dtype = np.float32)
+    b = np.array([4.0, 5.0, 6.0], dtype = np.float64)
+    assert_array_equal(t.test_xarray_dynamic_type(a), a * 2.0)
+    assert_array_equal(t.test_xarray_dynamic_type(b), b * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_type_overload():
+    a = np.array([1.0, 2.0, 3.0], dtype = np.float64)
+    b = np.array([4.0, 5.0, 6.0], dtype = np.float32)
+    assert_array_equal(t.test_xarray_type_overload(a), 2.0 * a)
+    assert_array_equal(t.test_xarray_type_overload(b), 3.0 * b)
+
+@needs_numpy_and_xtensor
+def test_xarray_template_func():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_equal(t.test_xarray_template_func(a), a * 1234.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_complex():
+    a = np.array([1 + 2j, 3 + 4j])
+    b = np.array([5 + 6j, 7 + 8j])
+    assert_array_equal(t.test_xarray_complex(a, b), a + b)
+
+@needs_numpy_and_xtensor
+def test_xarray_row_major_noconvert_accepts_column_major():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0, 4.0]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_equal(t.test_xarray_row_major_noconvert(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_row_major_noconvert_rejects_non_contiguous():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b = a[::2]
+    try:
+        t.test_xarray_row_major_noconvert(b)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xarray_column_major_noconvert_accepts_row_major():
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    assert a.flags["C_CONTIGUOUS"]
+    assert_array_equal(t.test_xarray_column_major_noconvert(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_column_major_noconvert_rejects_non_contiguous():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b = a[::2]
+    try:
+        t.test_xarray_column_major_noconvert(b)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xarray_dynamic_noconvert_accepts_row_major():
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    assert_array_equal(t.test_xarray_dynamic_noconvert(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_dynamic_noconvert_accepts_column_major():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0, 4.0]))
+    assert_array_equal(t.test_xarray_dynamic_noconvert(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_dynamic_noconvert_accepts_non_contiguous():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b = a[::2]
+    assert_array_equal(t.test_xarray_dynamic_noconvert(b), b * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_return_column_major():
+    out = t.test_xarray_return_column_major()
+    assert out.flags["F_CONTIGUOUS"]
+    assert_array_equal(out, [1.0, 2.0, 3.0, 4.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_mixed_layouts():
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    assert a.flags["C_CONTIGUOUS"]
+    out = t.test_xarray_mixed_layouts(a)
+    assert out.flags["F_CONTIGUOUS"]
+    assert_array_equal(out, a)
+
+
+# xt::xtensor tests
+
+@needs_numpy_and_xtensor
+def test_xtensor():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_almost_equal(t.test_xtensor(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_wrong_dimension():
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    try:
+        t.test_xtensor(a, 2.0, 3.0)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_not_contiguous():
+    a = np.arange(16.0).reshape(4, 4)
+    b = a[::2, ::2]
+    assert_array_almost_equal(t.test_xtensor(b, 2.0, 3.0), np.sin(b) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xtensor(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_mutate():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    b = t.test_xtensor_mutate(a)
+    assert_array_equal(b, [[999.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(a, [[1.0, 2.0], [3.0, 4.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_return_by_value():
+    result = t.test_xtensor_return_by_value()
+    assert_array_equal(result, [[1.0, 2.0], [3.0, 4.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_return_by_ref():
+    result = t.test_xtensor_return_by_ref()
+    assert_array_equal(result, [[10.0, 20.0], [30.0, 40.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_return_by_const_ref():
+    result = t.test_xtensor_return_by_const_ref()
+    assert_array_equal(result, [[10.0, 20.0], [30.0, 40.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_accept_column_major():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(t.test_xtensor_accept_column_major(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_accept_custom_allocator():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(t.test_xtensor_accept_custom_allocator(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_dynamic_type():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype = np.float32)
+    b = np.array([[5.0, 6.0], [7.0, 8.0]], dtype = np.float64)
+    assert_array_equal(t.test_xtensor_dynamic_type(a), a * 2.0)
+    assert_array_equal(t.test_xtensor_dynamic_type(b), b * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_type_overload():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype = np.float64)
+    b = np.array([[5.0, 6.0], [7.0, 8.0]], dtype = np.float32)
+    assert_array_equal(t.test_xtensor_type_overload(a), 2.0 * a)
+    assert_array_equal(t.test_xtensor_type_overload(b), 3.0 * b)
+
+@needs_numpy_and_xtensor
+def test_xtensor_template_func():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(t.test_xtensor_template_func(a), a * 1234.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_complex():
+    a = np.array([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]])
+    b = np.array([[5 + 5j, 6 + 6j], [7 + 7j, 8 + 8j]])
+    assert_array_equal(t.test_xtensor_complex(a, b), a + b)
+
+@needs_numpy_and_xtensor
+def test_xtensor_row_major_noconvert_1d():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0, 4.0]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_equal(t.test_xtensor_row_major_noconvert_1d(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_column_major_noconvert_1d():
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    assert a.flags["C_CONTIGUOUS"]
+    assert_array_equal(t.test_xtensor_column_major_noconvert_1d(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_row_major_noconvert_rejects_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert a.flags["F_CONTIGUOUS"]
+    try:
+        t.test_xtensor_row_major_noconvert(a)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_row_major_noconvert_rejects_non_contiguous():
+    a = np.arange(16.0).reshape(4, 4)
+    b = a[::2, ::2]
+    try:
+        t.test_xtensor_row_major_noconvert(b)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_column_major_noconvert_rejects_row_major():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a.flags["C_CONTIGUOUS"]
+    try:
+        t.test_xtensor_column_major_noconvert(a)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_column_major_noconvert_rejects_non_contiguous():
+    a = np.arange(16.0).reshape(4, 4)
+    b = a[::2, ::2]
+    try:
+        t.test_xtensor_column_major_noconvert(b)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_dynamic_noconvert_accepts_row_major():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(t.test_xtensor_dynamic_noconvert(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_dynamic_noconvert_accepts_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert_array_equal(t.test_xtensor_dynamic_noconvert(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_dynamic_noconvert_accepts_non_contiguous():
+    a = np.arange(16.0).reshape(4, 4)
+    b = a[::2, ::2]
+    assert_array_equal(t.test_xtensor_dynamic_noconvert(b), b * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_return_column_major():
+    out = t.test_xtensor_return_column_major()
+    assert out.flags["F_CONTIGUOUS"]
+    assert_array_equal(out, [[1.0, 2.0], [3.0, 4.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_mixed_layouts():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a.flags["C_CONTIGUOUS"]
+    out = t.test_xtensor_mixed_layouts(a)
+    assert out.flags["F_CONTIGUOUS"]
+    assert_array_equal(out, a)
+
+# nb::xarray_view tests
+
+@needs_numpy_and_xtensor
+def test_xarray_view():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_almost_equal(t.test_xarray_view(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_accepts_2d():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_almost_equal(t.test_xarray_view(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_row_major_accepts_column_major_1d():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_default_accepts_non_contiguous():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b = a[::-2]
+    assert_array_almost_equal(t.test_xarray_view(b, 2.0, 3.0), np.sin(b) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_row_major_rejects_non_contiguous():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b = a[::-2]
+    try:
+        t.test_xarray_view_row_major(b, 2.0, 3.0)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xarray_view_row_major_accepts_row_major():
+    a = np.array([1.0, 2.0, 3.0])
+    assert a.flags["C_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view_row_major(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_column_major():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view_column_major(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_column_major_accepts_row_major_1d():
+    a = np.array([1.0, 2.0, 3.0])
+    assert a.flags["C_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view_column_major(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_dynamic_row_major():
+    a = np.array([1.0, 2.0, 3.0])
+    assert a.flags["C_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view_dynamic(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_dynamic_column_major():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view_dynamic(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_dynamic_non_contiguous():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b = a[::-2]
+    assert_array_almost_equal(t.test_xarray_view_dynamic(b, 2.0, 3.0), np.sin(b) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_zerocopy():
+    a = np.array([1.0, 2.0, 3.0])
+    b = t.test_xarray_view_zerocopy(a)
+    a[0] = 1234.0
+    assert_array_equal(a, b)
+    b[0] = 5678.0
+    assert_array_equal(a, b)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_mutate():
+    a = np.array([1.0, 2.0, 3.0])
+    t.test_xarray_view_mutate(a)
+    assert_array_equal(a, [999.0, 2.0, 3.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_view_strict_type():
+    a = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    try:
+        t.test_xarray_view_strict_type(a)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xarray_view_type_overload():
+    a = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    b = np.array([4.0, 5.0, 6.0], dtype=np.float32)
+    assert_array_equal(t.test_xarray_view_type_overload(a), 2.0 * a)
+    assert_array_equal(t.test_xarray_view_type_overload(b), 3.0 * b)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_template_func():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_equal(t.test_xarray_view_template_func(a), a * 1234.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_complex():
+    a = np.array([1 + 1j, 2 + 2j, 3 + 3j])
+    assert_array_equal(t.test_xarray_view_complex(a), a + (1 + 1j))
+
+
+# nb::xtensor_view tests
+
+@needs_numpy_and_xtensor
+def test_xtensor_view():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_almost_equal(t.test_xtensor_view(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_wrong_dimension():
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    try:
+        t.test_xtensor_view(a, 2.0, 3.0)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_default_accepts_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xtensor_view(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_row_major_rejects_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert a.flags["F_CONTIGUOUS"]
+    try:
+        t.test_xtensor_view_row_major(a, 2.0, 3.0)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_row_major_accepts_row_major():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a.flags["C_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xtensor_view_row_major(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xtensor_view_column_major(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_column_major_rejects_row_major():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a.flags["C_CONTIGUOUS"]
+    try:
+        t.test_xtensor_view_column_major(a, 2.0, 3.0)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_dynamic_row_major():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a.flags["C_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xtensor_view_dynamic(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_dynamic_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xtensor_view_dynamic(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_dynamic_non_contiguous():
+    a = np.arange(16.0).reshape(4, 4)
+    b = a[::2, ::2]
+    assert_array_almost_equal(t.test_xtensor_view_dynamic(b, 2.0, 3.0), np.sin(b) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_zerocopy():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    b = t.test_xtensor_view_zerocopy(a)
+    a[0, 0] = 1234.0
+    assert_array_equal(a, b)
+    b[0, 0] = 5678.0
+    assert_array_equal(a, b)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_mutate():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    t.test_xtensor_view_mutate(a)
+    assert_array_equal(a, [[999.0, 2.0], [3.0, 4.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_strict_type():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    try:
+        t.test_xtensor_view_strict_type(a)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_type_overload():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+    b = np.array([[5.0, 6.0], [7.0, 8.0]], dtype=np.float32)
+    assert_array_equal(t.test_xtensor_view_type_overload(a), 2.0 * a)
+    assert_array_equal(t.test_xtensor_view_type_overload(b), 3.0 * b)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_template_func():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(t.test_xtensor_view_template_func(a), a * 1234.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_complex():
+    a = np.array([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]])
+    assert_array_equal(t.test_xtensor_view_complex(a), a + (1 + 1j))
+
+
+# vectorization tests
+
+@needs_numpy_and_xtensor
+def test_vectorize():
+    a = np.array([1.0, 2.0, 3.0])
+    b = np.array([4.0, 5.0, 6.0])
+    assert_array_equal(t.test_vectorize(a, b), a + b)
+
+@needs_numpy_and_xtensor
+def test_vectorize_lambda():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_almost_equal(t.test_vectorize_lambda(a), np.sin(a))
+
+
+# strided_view + adaptor tests
+
+@needs_numpy_and_xtensor
+def test_strided_view_return():
+    out = t.test_strided_view_return()
+    assert_array_equal(out, [10.0, 30.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_adaptor_return():
+    out = t.test_xarray_adaptor_return()
+    assert_array_equal(out, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_adaptor_return():
+    out = t.test_xtensor_adaptor_return()
+    assert_array_equal(out, [[10.0, 20.0], [30.0, 40.0]])
+
+
+# reference_internal tests
+
+@needs_numpy_and_xtensor
+def test_reference_internal_xarray():
+    owner = t.Owner()
+    a = owner.get_array()
+    assert_array_equal(a, [1.0, 2.0, 3.0])
+    a[0] = 999.0
+    assert_array_equal(owner.get_array(), [999.0, 2.0, 3.0])
+
+@needs_numpy_and_xtensor
+def test_reference_internal_xtensor():
+    owner = t.Owner()
+    a = owner.get_tensor()
+    assert_array_equal(a, [[1.0, 2.0], [3.0, 4.0]])
+    a[0, 0] = 999.0
+    assert_array_equal(owner.get_tensor(), [[999.0, 2.0], [3.0, 4.0]])

--- a/tests/test_xtensor.py
+++ b/tests/test_xtensor.py
@@ -1,0 +1,402 @@
+import pytest
+
+try:
+    import numpy as np
+    from numpy.testing import assert_array_equal, assert_array_almost_equal
+    import test_xtensor_ext as t
+    def needs_numpy_and_xtensor(x):
+        return x
+except:
+    needs_numpy_and_xtensor = pytest.mark.skip(reason="NumPy and xtensor are required")
+
+# xt::xarray<> tests
+
+@needs_numpy_and_xtensor
+def test_xarray():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_almost_equal(t.test_xarray(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_not_contiguous():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b = a[::-2]
+    assert_array_almost_equal(t.test_xarray(b, 2.0, 3.0), np.sin(b) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_column_major():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_mutate():
+    a = np.array([1.0, 2.0, 3.0])
+    b = t.test_xarray_mutate(a)
+    assert_array_equal(b, [999.0, 2.0, 3.0])
+    assert_array_equal(a, [1.0, 2.0, 3.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_return_by_value():
+    result = t.test_xarray_return_by_value()
+    assert_array_equal(result, [1.0, 2.0, 3.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_return_by_ref():
+    result = t.test_xarray_return_by_ref()
+    assert_array_equal(result, [10.0, 20.0, 30.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_return_by_const_ref():
+    result = t.test_xarray_return_by_const_ref()
+    assert_array_equal(result, [10.0, 20.0, 30.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_accept_column_major():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_equal(t.test_xarray_accept_column_major(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_accept_custom_allocator():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_equal(t.test_xarray_accept_custom_allocator(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_dynamic_type():
+    a = np.array([1.0, 2.0, 3.0], dtype = np.float32)
+    b = np.array([4.0, 5.0, 6.0], dtype = np.float64)
+    assert_array_equal(t.test_xarray_dynamic_type(a), a * 2.0)
+    assert_array_equal(t.test_xarray_dynamic_type(b), b * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_type_overload():
+    a = np.array([1.0, 2.0, 3.0], dtype = np.float64)
+    b = np.array([4.0, 5.0, 6.0], dtype = np.float32)
+    assert_array_equal(t.test_xarray_type_overload(a), 2.0 * a)
+    assert_array_equal(t.test_xarray_type_overload(b), 3.0 * b)
+
+@needs_numpy_and_xtensor
+def test_xarray_template_func():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_equal(t.test_xarray_template_func(a), a * 1234.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_complex():
+    a = np.array([1 + 2j, 3 + 4j])
+    b = np.array([5 + 6j, 7 + 8j])
+    assert_array_equal(t.test_xarray_complex(a, b), a + b)
+
+
+# xt::xtensor<> tests
+
+@needs_numpy_and_xtensor
+def test_xtensor():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_almost_equal(t.test_xtensor(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_wrong_dimension():
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    try:
+        t.test_xtensor(a, 2.0, 3.0)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_not_contiguous():
+    a = np.arange(16.0).reshape(4, 4)
+    b = a[::2, ::2]
+    assert_array_almost_equal(t.test_xtensor(b, 2.0, 3.0), np.sin(b) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xtensor(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_mutate():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    b = t.test_xtensor_mutate(a)
+    assert_array_equal(b, [[999.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(a, [[1.0, 2.0], [3.0, 4.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_return_by_value():
+    result = t.test_xtensor_return_by_value()
+    assert_array_equal(result, [[1.0, 2.0], [3.0, 4.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_return_by_ref():
+    result = t.test_xtensor_return_by_ref()
+    assert_array_equal(result, [[10.0, 20.0], [30.0, 40.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_return_by_const_ref():
+    result = t.test_xtensor_return_by_const_ref()
+    assert_array_equal(result, [[10.0, 20.0], [30.0, 40.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_accept_column_major():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(t.test_xtensor_accept_column_major(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_accept_custom_allocator():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(t.test_xtensor_accept_custom_allocator(a), a * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_dynamic_type():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype = np.float32)
+    b = np.array([[5.0, 6.0], [7.0, 8.0]], dtype = np.float64)
+    assert_array_equal(t.test_xtensor_dynamic_type(a), a * 2.0)
+    assert_array_equal(t.test_xtensor_dynamic_type(b), b * 2.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_type_overload():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype = np.float64)
+    b = np.array([[5.0, 6.0], [7.0, 8.0]], dtype = np.float32)
+    assert_array_equal(t.test_xtensor_type_overload(a), 2.0 * a)
+    assert_array_equal(t.test_xtensor_type_overload(b), 3.0 * b)
+
+@needs_numpy_and_xtensor
+def test_xtensor_template_func():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(t.test_xtensor_template_func(a), a * 1234.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_complex():
+    a = np.array([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]])
+    b = np.array([[5 + 5j, 6 + 6j], [7 + 7j, 8 + 8j]])
+    assert_array_equal(t.test_xtensor_complex(a, b), a + b)
+
+
+# nb::xarray_view<> tests
+
+@needs_numpy_and_xtensor
+def test_xarray_view():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_almost_equal(t.test_xarray_view(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_row_major_accepts_column_major_1d():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_rejects_non_contiguous():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b = a[::-2]
+    try:
+        t.test_xarray_view(b, 2.0, 3.0)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xarray_view_column_major():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view_column_major(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_column_major_accepts_row_major_1d():
+    a = np.array([1.0, 2.0, 3.0])
+    assert a.flags["C_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view_column_major(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_dynamic_row_major():
+    a = np.array([1.0, 2.0, 3.0])
+    assert a.flags["C_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view_dynamic(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_dynamic_column_major():
+    a = np.asfortranarray(np.array([1.0, 2.0, 3.0]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xarray_view_dynamic(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_dynamic_non_contiguous():
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    b = a[::-2]
+    assert_array_almost_equal(t.test_xarray_view_dynamic(b, 2.0, 3.0), np.sin(b) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_zerocopy():
+    a = np.array([1.0, 2.0, 3.0])
+    b = t.test_xarray_view_zerocopy(a)
+    a[0] = 1234.0
+    assert_array_equal(a, b)
+    b[0] = 5678.0
+    assert_array_equal(a, b)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_mutate():
+    a = np.array([1.0, 2.0, 3.0])
+    t.test_xarray_view_mutate(a)
+    assert_array_equal(a, [999.0, 2.0, 3.0])
+
+@needs_numpy_and_xtensor
+def test_xarray_view_strict_type():
+    a = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    try:
+        t.test_xarray_view_strict_type(a)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xarray_view_type_overload():
+    a = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    b = np.array([4.0, 5.0, 6.0], dtype=np.float32)
+    assert_array_equal(t.test_xarray_view_type_overload(a), 2.0 * a)
+    assert_array_equal(t.test_xarray_view_type_overload(b), 3.0 * b)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_template_func():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_equal(t.test_xarray_view_template_func(a), a * 1234.0)
+
+@needs_numpy_and_xtensor
+def test_xarray_view_complex():
+    a = np.array([1 + 1j, 2 + 2j, 3 + 3j])
+    assert_array_equal(t.test_xarray_view_complex(a), a + (1 + 1j))
+
+
+# nb::xtensor_view<> tests
+
+@needs_numpy_and_xtensor
+def test_xtensor_view():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_almost_equal(t.test_xtensor_view(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_wrong_dimension():
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    try:
+        t.test_xtensor_view(a, 2.0, 3.0)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_row_major_rejects_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert a.flags["F_CONTIGUOUS"]
+    try:
+        t.test_xtensor_view(a, 2.0, 3.0)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xtensor_view_column_major(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_column_major_rejects_row_major():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a.flags["C_CONTIGUOUS"]
+    try:
+        t.test_xtensor_view_column_major(a, 2.0, 3.0)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_dynamic_row_major():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert a.flags["C_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xtensor_view_dynamic(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_dynamic_column_major():
+    a = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert a.flags["F_CONTIGUOUS"]
+    assert_array_almost_equal(t.test_xtensor_view_dynamic(a, 2.0, 3.0), np.sin(a) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_dynamic_non_contiguous():
+    a = np.arange(16.0).reshape(4, 4)
+    b = a[::2, ::2]
+    assert_array_almost_equal(t.test_xtensor_view_dynamic(b, 2.0, 3.0), np.sin(b) * 2.0 + 3.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_zerocopy():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    b = t.test_xtensor_view_zerocopy(a)
+    a[0, 0] = 1234.0
+    assert_array_equal(a, b)
+    b[0, 0] = 5678.0
+    assert_array_equal(a, b)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_mutate():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    t.test_xtensor_view_mutate(a)
+    assert_array_equal(a, [[999.0, 2.0], [3.0, 4.0]])
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_strict_type():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    try:
+        t.test_xtensor_view_strict_type(a)
+        assert False, "should raise TypeError"
+    except TypeError:
+        pass
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_type_overload():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+    b = np.array([[5.0, 6.0], [7.0, 8.0]], dtype=np.float32)
+    assert_array_equal(t.test_xtensor_view_type_overload(a), 2.0 * a)
+    assert_array_equal(t.test_xtensor_view_type_overload(b), 3.0 * b)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_template_func():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    assert_array_equal(t.test_xtensor_view_template_func(a), a * 1234.0)
+
+@needs_numpy_and_xtensor
+def test_xtensor_view_complex():
+    a = np.array([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]])
+    assert_array_equal(t.test_xtensor_view_complex(a), a + (1 + 1j))
+
+
+# vectorization tests
+
+@needs_numpy_and_xtensor
+def test_vectorize():
+    a = np.array([1.0, 2.0, 3.0])
+    b = np.array([4.0, 5.0, 6.0])
+    assert_array_equal(t.test_vectorize(a, b), a + b)
+
+@needs_numpy_and_xtensor
+def test_vectorize_lambda():
+    a = np.array([1.0, 2.0, 3.0])
+    assert_array_almost_equal(t.test_vectorize_lambda(a), np.sin(a))
+
+
+# reference_internal tests
+
+@needs_numpy_and_xtensor
+def test_reference_internal_xarray():
+    owner = t.Owner()
+    a = owner.get_array()
+    assert_array_equal(a, [1.0, 2.0, 3.0])
+    a[0] = 999.0
+    assert_array_equal(owner.get_array(), [999.0, 2.0, 3.0])
+
+@needs_numpy_and_xtensor
+def test_reference_internal_xtensor():
+    owner = t.Owner()
+    a = owner.get_tensor()
+    assert_array_equal(a, [[1.0, 2.0], [3.0, 4.0]])
+    a[0, 0] = 999.0
+    assert_array_equal(owner.get_tensor(), [[999.0, 2.0], [3.0, 4.0]])


### PR DESCRIPTION
[xtensor](https://github.com/xtensor-stack/xtensor) is a header-only C++ library for multi-dimensional arrays and tensors with lazy evaluation semantics. It provides NumPy-like syntax for element-wise operations, broadcasting, and mathematical functions.

This PR adds native casters for xtensor types, enabling seamless interop between NumPy arrays and xtensor containers.

## Owning containers

`xt::xarray<T>` and `xt::xtensor<T, N>` are owning containers backed by contiguous storage. Since they must own their data, the caster copies from the NumPy buffer on input. The copy handles layout conversion transparently — a row-major function accepts Fortran-contiguous input and reorders during the copy. With `nb::arg().noconvert()`, mismatched layouts are rejected instead. On output, returning by value moves the container into a capsule for zero extra copy; `rv_policy::reference_internal` keeps the parent object alive when returning references from bound classes.

```cpp
m.def("compute", [](const xt::xarray<double>& a, const double& s, const double& t) {
    return xt::sin(a) * s + t;
});

m.def("compute", [](const xt::xtensor<double, 2>& a, const double& s, const double& t) {
    return xt::sin(a) * s + t;
});
```

## Zero-copy views

For performance-critical paths, `nb::xarray_view<T>` and `nb::xtensor_view<T, N>` wrap the NumPy buffer directly without copying:

```cpp
m.def("compute", [](const nb::xarray_view<double>& a, const double& s, const double& t) {
    return xt::sin(a) * s + t;
});

m.def("compute", [](const nb::xtensor_view<double, 2>& a, const double& s, const double& t) {
    return xt::sin(a) * s + t;
});
```

Views are layout-aware with a template parameter that defaults to `layout_type::dynamic`, which accepts any array (including non-contiguous slices) and detects the actual memory layout for optimized iteration. For maximum performance, views can be narrowed to `layout_type::row_major` or `layout_type::column_major`, which gives xtensor a compile-time contiguity guarantee and enables fast flat-pointer iteration. Since views point directly into the NumPy buffer, they do not support implicit type conversion and can mutate the source array in-place.

## Expression returns

Returning an xtensor expression (e.g., `xt::sin(a) * s + t`) produces a lazy expression tree. The `xexpression` caster matches any `xt::is_xexpression<T>` type — covering lazy expression templates, `xt::strided_view(...)`, and `xt::adapt(...)` — and evaluates it directly into a freshly allocated NumPy buffer, avoiding intermediate container materialization.

## Vectorization

`nb::xvectorize` wraps a scalar C++ function for element-wise application over arrays, analogous to `np.vectorize` but compiled:

```cpp
m.def("fast_abs", nb::xvectorize([](double x) -> double {
    return std::abs(x);
}));
```

## Scope

The entire implementation is ~500 lines (excluding tests), split across 6 headers under `include/nanobind/xtensor/`.

## Benchmark

A standalone benchmark suite is available at [keltecc/xtensor-nanobind-benchmark](https://github.com/keltecc/xtensor-nanobind-benchmark).

For API details, see the documentation in `xtensor.rst` and the test cases.