### PR TITLE
Fix Clang implicit conversion warnings

### DIFF
--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -327,7 +327,7 @@ NB_INLINE void func_extra_apply(F &f, is_operator, size_t &) {
 
 template <typename F>
 NB_INLINE void func_extra_apply(F &f, rv_policy pol, size_t &) {
-    f.flags = (f.flags & ~0b111) | (uint16_t) pol;
+    f.flags = (f.flags & (uint32_t) ~0b111) | (uint16_t) pol;
 }
 
 template <typename F>

--- a/include/nanobind/nb_call.h
+++ b/include/nanobind/nb_call.h
@@ -60,7 +60,7 @@ NB_INLINE void call_init(PyObject **args, PyObject *kwnames, size_t &nargs,
 
     if constexpr (std::is_same_v<D, arg_v>) {
         args[kwargs_offset + nkwargs] = value.value.release().ptr();
-        NB_TUPLE_SET_ITEM(kwnames, nkwargs++,
+        NB_TUPLE_SET_ITEM(kwnames, (Py_ssize_t) nkwargs++,
                          PyUnicode_InternFromString(value.name_));
     } else if constexpr (std::is_same_v<D, args_proxy>) {
         for (size_t i = 0, l = len(value); i < l; ++i)
@@ -74,7 +74,7 @@ NB_INLINE void call_init(PyObject **args, PyObject *kwnames, size_t &nargs,
         while (PyDict_Next(value.ptr(), &pos, &key, &entry)) {
             Py_INCREF(key); Py_INCREF(entry);
             args[kwargs_offset + nkwargs] = entry;
-            NB_TUPLE_SET_ITEM(kwnames, nkwargs++, key);
+            NB_TUPLE_SET_ITEM(kwnames, (Py_ssize_t) nkwargs++, key);
         }
     } else {
         args[nargs++] =

--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -672,7 +672,7 @@ template <rv_policy policy = rv_policy::automatic, typename... Args>
 tuple make_tuple(Args &&...args) {
     tuple result = steal<tuple>(PyTuple_New((Py_ssize_t) sizeof...(Args)));
 
-    size_t nargs = 0;
+    Py_ssize_t nargs = 0;
     PyObject *o = result.ptr();
 
     (NB_TUPLE_SET_ITEM(o, nargs++,

--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -291,7 +291,7 @@ template <typename Scalar, size_t Dim, char Order> struct ndarray_view {
     }
 
     size_t ndim() const { return Dim; }
-    size_t shape(size_t i) const { return m_shape[i]; }
+    size_t shape(size_t i) const { return (size_t) m_shape[i]; }
     int64_t stride(size_t i) const { return m_strides[i]; }
     Scalar *data() const { return m_data; }
 
@@ -518,7 +518,7 @@ private:
             int64_t index = 0;
             ((index += int64_t(indices) * m_dltensor.strides[counter++]), ...);
 
-            return (int64_t) m_dltensor.byte_offset + index * sizeof(Scalar);
+            return (int64_t) m_dltensor.byte_offset + index * (int64_t) sizeof(Scalar);
         } else {
             return 0;
         }

--- a/include/nanobind/stl/bind_vector.h
+++ b/include/nanobind/stl/bind_vector.h
@@ -123,7 +123,7 @@ class_<Vector> bind_vector(handle scope, const char *name, Args &&...args) {
                 [](Vector &v, Py_ssize_t i) {
                     size_t index = detail::wrap(i, v.size());
                     Value result = std::move(v[index]);
-                    v.erase(v.begin() + index);
+                    v.erase(v.begin() + (ptrdiff_t) index);
                     return result;
                 },
                 arg("index") = -1,
@@ -153,7 +153,7 @@ class_<Vector> bind_vector(handle scope, const char *name, Args &&...args) {
 
           .def("__delitem__",
                [](Vector &v, Py_ssize_t i) {
-                   v.erase(v.begin() + detail::wrap(i, v.size()));
+                   v.erase(v.begin() + (ptrdiff_t) detail::wrap(i, (size_t) v.size()));
                })
 
           .def("__getitem__",
@@ -163,7 +163,7 @@ class_<Vector> bind_vector(handle scope, const char *name, Args &&...args) {
                    seq->reserve(length);
 
                    for (size_t i = 0; i < length; ++i) {
-                       seq->push_back(v[start]);
+                       seq->push_back(v[(size_t) start]);
                        start += step;
                    }
 
@@ -185,12 +185,12 @@ class_<Vector> bind_vector(handle scope, const char *name, Args &&...args) {
                    if (&value == &v) {
                        Vector copy(value);
                        for (size_t i = 0; i < length; ++i) {
-                           v[start] = copy[i];
+                           v[(size_t) start] = copy[i];
                            start += step;
                        }
                    } else {
                        for (size_t i = 0; i < length; ++i) {
-                           v[start] = value[i];
+                           v[(size_t) start] = value[i];
                            start += step;
                        }
                    }
@@ -202,7 +202,7 @@ class_<Vector> bind_vector(handle scope, const char *name, Args &&...args) {
                    if (length == 0)
                        return;
 
-                   stop = start + (length - 1) * step;
+                   stop = start + ((Py_ssize_t) length - 1) * step;
                    if (start > stop) {
                        std::swap(start, stop);
                        step = -step;

--- a/include/nanobind/stl/detail/nb_list.h
+++ b/include/nanobind/stl/detail/nb_list.h
@@ -58,7 +58,7 @@ template <typename List, typename Entry> struct list_caster {
 
     template <typename T>
     static handle from_cpp(T &&src, rv_policy policy, cleanup_list *cleanup) {
-        object ret = steal(PyList_New(src.size()));
+        object ret = steal(PyList_New((Py_ssize_t) src.size()));
 
         if (ret.is_valid()) {
             Py_ssize_t index = 0;

--- a/include/nanobind/stl/string.h
+++ b/include/nanobind/stl/string.h
@@ -31,7 +31,7 @@ template <> struct type_caster<std::string> {
 
     static handle from_cpp(const std::string &value, rv_policy,
                            cleanup_list *) noexcept {
-        return PyUnicode_FromStringAndSize(value.c_str(), value.size());
+        return PyUnicode_FromStringAndSize(value.c_str(), (Py_ssize_t) value.size());
     }
 };
 

--- a/include/nanobind/stl/string_view.h
+++ b/include/nanobind/stl/string_view.h
@@ -31,7 +31,7 @@ template <> struct type_caster<std::string_view> {
 
     static handle from_cpp(std::string_view value, rv_policy,
                            cleanup_list *) noexcept {
-        return PyUnicode_FromStringAndSize(value.data(), value.size());
+        return PyUnicode_FromStringAndSize(value.data(), (Py_ssize_t) value.size());
     }
 };
 

--- a/include/nanobind/stl/wstring.h
+++ b/include/nanobind/stl/wstring.h
@@ -32,7 +32,7 @@ template <> struct type_caster<std::wstring> {
 
     static handle from_cpp(const std::wstring &value, rv_policy,
                            cleanup_list *) noexcept {
-        return PyUnicode_FromWideChar(value.c_str(), value.size());
+        return PyUnicode_FromWideChar(value.c_str(), (Py_ssize_t) value.size());
     }
 };
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -136,7 +136,7 @@ public:
 
 private:
     NB_NOINLINE void expand(size_t minval = 2) {
-        size_t old_alloc_size = m_end - m_start,
+        size_t old_alloc_size = (size_t) (m_end - m_start),
                new_alloc_size = 2 * old_alloc_size + minval,
                used_size      = (size_t) (m_cur - m_start),
                copy_size      = used_size + 1;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -728,8 +728,7 @@ PyObject **seq_get(PyObject *seq, size_t *size_out, PyObject **temp_out) noexcep
         Py_ssize_t size_seq = PySequence_Length(seq);
 
         if (size_seq >= 0) {
-            result = (PyObject **) PyMem_Malloc(sizeof(PyObject *) *
-                                                (size_seq + 1));
+            result = (PyObject **) PyMem_Malloc(sizeof(PyObject *) * (size_t) (size_seq + 1));
 
             if (result) {
                 result[size_seq] = nullptr;
@@ -919,7 +918,7 @@ void property_install_static(PyObject *scope, const char *name,
 
 void tuple_check(PyObject *tuple, size_t nargs) {
     for (size_t i = 0; i < nargs; ++i) {
-        if (!NB_TUPLE_GET_ITEM(tuple, i))
+        if (!NB_TUPLE_GET_ITEM(tuple, (Py_ssize_t) i))
             raise_python_or_cast_error();
     }
 }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -20,10 +20,10 @@ create_exception(exception_type type, const char *fmt, va_list args_) {
     va_list args;
 
     va_copy(args, args_);
-    int size = vsnprintf(buf, sizeof(buf), fmt, args);
+    size_t size = (size_t) vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
 
-    if (size < (int) sizeof(buf)) {
+    if (size < sizeof(buf)) {
         return builtin_exception(type, buf);
     } else {
         scoped_pymalloc<char> temp(size + 1);

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -199,7 +199,7 @@ const char *python_error::what() const noexcept {
             buf.put("  File \"");
             buf.put_dstr(filename);
             buf.put("\", line ");
-            buf.put_uint32(PyFrame_GetLineNumber(frame));
+            buf.put_uint32((uint32_t) PyFrame_GetLineNumber(frame));
             buf.put(", in ");
             buf.put_dstr(name);
             buf.put('\n');

--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -109,7 +109,7 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
     t->name = strdup_check(ed->name);
     t->type = ed->type;
     t->type_py = (PyTypeObject *) result.ptr();
-    t->flags = ed->flags;
+    t->flags = ed->flags & 0xFFFFFF;
     t->enum_tbl.fwd = new enum_map();
     t->enum_tbl.rev = new enum_map();
     t->scope = ed->scope;

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -344,8 +344,8 @@ PyObject *nb_func_new(const func_data_prelim_base *f) noexcept {
         if (nb_func_prev->doc_uniform)
             prev_doc = prev->doc;
 
-        memcpy(cur, prev, sizeof(func_data) * prev_overloads);
-        memset(prev, 0, sizeof(func_data) * prev_overloads);
+        memcpy(cur, prev, sizeof(func_data) * (size_t) prev_overloads);
+        memset(prev, 0, sizeof(func_data) * (size_t) prev_overloads);
 
         ((PyVarObject *) func_prev)->ob_size = 0;
 
@@ -826,7 +826,7 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
                 for (size_t j = nargs_pos; j < nargs_in; ++j) {
                     PyObject *o = args_in[j];
                     Py_INCREF(o);
-                    NB_TUPLE_SET_ITEM(tuple, j - nargs_pos, o);
+                    NB_TUPLE_SET_ITEM(tuple, (Py_ssize_t) (j - nargs_pos), o);
                 }
 
                 args[nargs_pos] = tuple;
@@ -1310,7 +1310,7 @@ static PyObject *nb_bound_method_vectorcall(PyObject *self,
     } else {
         size_t size = nargs + 1;
         if (kwargs_in)
-            size += NB_TUPLE_GET_SIZE(kwargs_in);
+            size += (size_t) NB_TUPLE_GET_SIZE(kwargs_in);
 
         if (size < buf_size) {
             args = args_buf;
@@ -1671,7 +1671,7 @@ PyObject *nb_func_get_nb_signature(PyObject *self, void *) {
                 } else {
                     Py_INCREF(value);
                 }
-                NB_TUPLE_SET_ITEM(defaults, pos, value);
+                NB_TUPLE_SET_ITEM(defaults, (Py_ssize_t) pos, value);
                 pos++;
             }
 

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -564,10 +564,10 @@ nb_func_error_overload(PyObject *self, PyObject *const *args_in,
             buf.put(", ");
         buf.put("kwargs = { ");
 
-        size_t nkwargs_in = (size_t) NB_TUPLE_GET_SIZE(kwargs_in);
-        for (size_t j = 0; j < nkwargs_in; ++j) {
+        Py_ssize_t nkwargs_in = NB_TUPLE_GET_SIZE(kwargs_in);
+        for (Py_ssize_t j = 0; j < nkwargs_in; ++j) {
             PyObject *key   = NB_TUPLE_GET_ITEM(kwargs_in, j),
-                     *value = args_in[nargs_in + j];
+                     *value = args_in[nargs_in + (size_t) j];
 
             const char *key_cstr = PyUnicode_AsUTF8AndSize(key, nullptr);
             if (!key_cstr) {
@@ -677,7 +677,7 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
 #if !defined(PYPY_VERSION) && !defined(Py_LIMITED_API)
     bool kwnames_interned = true;
     for (size_t i = 0; i < nkwargs_in; ++i) {
-        PyObject *key = NB_TUPLE_GET_ITEM(kwargs_in, i);
+        PyObject *key = NB_TUPLE_GET_ITEM(kwargs_in, (Py_ssize_t) i);
         kwnames_interned &= ((PyASCIIObject *) key)->state.interned != 0;
     }
     if (kwargs_in && NB_LIKELY(kwnames_interned)) {
@@ -688,7 +688,7 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
 
     kwnames = (PyObject **) alloca(nkwargs_in * sizeof(PyObject *));
     for (size_t i = 0; i < nkwargs_in; ++i) {
-        PyObject *key = NB_TUPLE_GET_ITEM(kwargs_in, i);
+        PyObject *key = NB_TUPLE_GET_ITEM(kwargs_in, (Py_ssize_t) i);
         Py_INCREF(key);
 
         kwnames[i] = key;
@@ -810,7 +810,8 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
                     break;
 
                 // Implicit conversion only active in the 2nd pass
-                args_flags[i] = arg_flag & ~uint8_t(pass == 0);
+                // Have to cast to uint8_t because of integer promotion (uint8_t promoted to int before ~ and & operations)
+                args_flags[i] = (uint8_t) (arg_flag & ~uint8_t(pass == 0));
                 args[i] = arg;
             }
 
@@ -967,7 +968,8 @@ nb_func_vectorcall_medium_pos(PyObject *self, PyObject *const *args_in,
                              (arg_flag & cast_flags::accepts_none) == 0))
                     break;
 
-                args_flags[i] = arg_flag & ~uint8_t(pass == 0);
+                // Have to cast to uint8_t because of integer promotion (uint8_t promoted to int before ~ and & operations)
+                args_flags[i] = (uint8_t) (arg_flag & ~uint8_t(pass == 0));
                 args[i] = arg;
             }
 

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -312,7 +312,7 @@ static void init_internals(nb_internals *p) {
     PyObject *dummy = PyType_FromMetaclass(
         nb_meta, p->nb_module, &dummy_spec, nullptr);
     p->type_data_offset =
-        (uint8_t *) PyObject_GetTypeData(dummy, nb_meta) - (uint8_t *) dummy;
+        ((uint8_t *) PyObject_GetTypeData(dummy, nb_meta) - (uint8_t *) dummy);
     Py_DECREF(dummy);
 #endif
 

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -513,7 +513,7 @@ struct nb_internals {
     setattrofunc PyType_Type_tp_setattro;
     descrgetfunc PyProperty_Type_tp_descr_get;
     descrsetfunc PyProperty_Type_tp_descr_set;
-    size_t type_data_offset;
+    ptrdiff_t type_data_offset;
 #endif
 
 #if defined(NB_FREE_THREADED)

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -281,8 +281,8 @@ static void nb_ndarray_releasebuffer(PyObject *, Py_buffer *view) {
 
 // This function implements __dlpack__() for a nanobind.nb_ndarray.
 static PyObject *nb_ndarray_dlpack(PyObject *self, PyObject *const *args,
-                                   Py_ssize_t nargsf, PyObject *kwnames) {
-    if (PyVectorcall_NARGS(nargsf) != 0) {
+                                   Py_ssize_t nargs, PyObject *kwnames) {
+    if (nargs != 0) {
         PyErr_SetString(PyExc_TypeError,
                 "__dlpack__() does not accept positional arguments");
         return nullptr;

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -545,11 +545,11 @@ static mt_unique_ptr_t make_mt_from_buffer_protocol(PyObject *o, bool ro) {
     }
 
     static_assert(alignof(managed_dltensor_versioned) >= alignof(int64_t));
-    scoped_pymalloc<managed_dltensor_versioned> mt(1, 2 * sizeof(int64_t)*ndim);
+    scoped_pymalloc<managed_dltensor_versioned> mt(1, 2 * sizeof(int64_t) * (size_t) ndim);
     int64_t* shape = nullptr;
     int64_t* strides = nullptr;
     if (ndim > 0) {
-        shape = new ((void*) (mt.get() + 1)) int64_t[2 * ndim];
+        shape = new ((void*) (mt.get() + 1)) int64_t[2 * (size_t) ndim];
         strides = shape + ndim;
     }
 
@@ -630,7 +630,7 @@ ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
         capsule = borrow(src);
     } else {
         PyObject* args[] = {src, NB_INTERNED(dl_version_tpl)};
-        Py_ssize_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+        size_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
 
         // Call src.__dlpack__(): max_version_kw requests a versioned capsule
         // nullptr the cheaper unversioned one.
@@ -911,8 +911,9 @@ ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
         result->free_strides = true;
 
         scoped_pymalloc<int64_t> strides((size_t) t.ndim);
-        for (int64_t i = t.ndim - 1, accum = 1; i >= 0; --i) {
-            strides[i] = accum;
+        int64_t accum = 1;
+        for (int32_t i = t.ndim - 1; i >= 0; --i) {
+            strides[(size_t) i] = accum;
             accum *= t.shape[i];
         }
         t.strides = strides.release();
@@ -1199,7 +1200,7 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
             PyObject *export_fn = ndarray_export_fn(
                 internals_, copy ? nd_export_numpy_copy : nd_export_numpy_view);
             PyObject *stack[] = {nullptr, o.ptr()};
-            Py_ssize_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+            size_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
             return PyObject_Vectorcall(export_fn, stack + 1, nargsf, nullptr);
         } catch (const std::exception &e) {
             PyErr_Format(PyExc_TypeError,
@@ -1224,7 +1225,7 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
         if (slot != nd_export_count) {
             PyObject *export_fn = ndarray_export_fn(internals_, slot);
             PyObject *stack[] = {nullptr, o.ptr()};
-            Py_ssize_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+            size_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
             o = steal(PyObject_Vectorcall(export_fn, stack + 1, nargsf, nullptr));
             if (!o.is_valid())
                 return nullptr;

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -670,13 +670,13 @@ static int nb_type_init(PyObject *self, PyObject *args, PyObject *kwds) {
 
     *t = *t_b;
     t->flags |=  (uint32_t) type_flags::is_python_type;
-    t->flags &= ~((uint32_t) type_flags::has_implicit_conversions);
+    t->flags &= (~(uint32_t) type_flags::has_implicit_conversions) & 0xFFFFFF;
 
     // A Python subclass is always a GC heap type
-    t->flags |= (uint32_t) type_flags::has_gc;
+    t->flags |= ((uint32_t) type_flags::has_gc) & 0xFFFFFF;
 
     // Sublclasses do not inherit the pooling feature as a consequence
-    t->flags &= ~((uint32_t) type_flags::pooled);
+    t->flags &= ~((uint32_t) type_flags::pooled) & 0xFFFFFF;
     t->pool_capacity = 0;
 #if defined(NB_FREE_THREADED)
     t->pool_index = 0;
@@ -970,7 +970,7 @@ static PyObject *nb_type_from_metaclass(PyTypeObject *meta, PyObject *mod,
 
         if (slot == 0) {
             break;
-        } else if (slot * sizeof(nb_slot) <= (int) sizeof(type_slots)) {
+        } else if ((size_t) slot * sizeof(nb_slot) <= sizeof(type_slots)) {
             *(((void **) ht) + type_slots[slot - 1].direct) = ts->pfunc;
         } else {
             PyErr_Format(PyExc_RuntimeError,
@@ -1173,7 +1173,7 @@ PyTypeObject *nb_type_create_metaclass(nb_internals *p,
     int basicsize = -(int) sizeof(type_data),
         itemsize = 0;
 #else
-    int basicsize = (int) (PyType_Type.tp_basicsize + sizeof(type_data)),
+    int basicsize = (int) PyType_Type.tp_basicsize + (int) sizeof(type_data),
         itemsize = (int) PyType_Type.tp_itemsize;
 #endif
 
@@ -1202,7 +1202,7 @@ PyTypeObject *nb_type_create_metaclass(nb_internals *p,
     };
 
     // Workaround because __vectorcalloffset__ does not support Py_RELATIVE_OFFSET
-    members[0].offset = p->type_data_offset + offsetof(type_data, vectorcall);
+    members[0].offset = p->type_data_offset + (Py_ssize_t) offsetof(type_data, vectorcall);
 
     if (NB_DYNAMIC_VERSION < 0x030E0000) {
         slots[4] = { Py_tp_members, (void *) members };
@@ -1556,7 +1556,7 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
     type_data *to = nb_type_data((PyTypeObject *) result);
 
     *to = *t; // note: slices off _init parts
-    to->flags &= ~(uint32_t) type_init_flags::all_init_flags;
+    to->flags &= (~(uint32_t) type_init_flags::all_init_flags) & 0xFFFFFF;
 
     if (!intrusive_ptr && base_intrusive_ptr) {
         to->flags |= (uint32_t) type_flags::intrusive_ptr;
@@ -1624,10 +1624,10 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
     if (to->flags & (uint32_t) type_flags::pooled) {
 #if defined(PYPY_VERSION)
         // PyPy's cpyext object model is incompatible with park/revive step
-        to->flags &= ~(uint32_t) type_flags::pooled;
+        to->flags &= (~(uint32_t) type_flags::pooled) & 0xFFFFFF;
 #else
         if (t->pool_capacity == 0) {
-            to->flags &= ~(uint32_t) type_flags::pooled;
+            to->flags &= (~(uint32_t) type_flags::pooled) & 0xFFFFFF;
         } else {
             // Pooling requires a non-GC type
             bool eligible =

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1060,7 +1060,7 @@ nb_type_vectorcall_fixup(nb_func *func, PyObject *self, PyObject *const *args_in
 
     size_t size = (size_t) nargs + 1;
     if (kwargs_in)
-        size += NB_TUPLE_GET_SIZE(kwargs_in);
+        size += (size_t) NB_TUPLE_GET_SIZE(kwargs_in);
 
     if (size < buf_size) {
         args = buf;
@@ -1258,7 +1258,7 @@ NB_NOINLINE char *extract_name(const char *cmd, const char *prefix, const char *
     check((p2 == p || (p[0] != ' ' && p2[-1] != ' ')),
           "%s(): custom signature \"%s\" contains leading/trailing space around name!", cmd, s);
 
-    size_t size = p2 - p;
+    size_t size = (size_t) (p2 - p);
     char *result = (char *) malloc_check(size + 1);
     memcpy(result, p, size);
     result[size] = '\0';

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,12 @@ if (MSVC)
     add_compile_options(/W4)
   endif()
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU|IntelLLVM")
-  add_compile_options(-Wall -Wextra)
+  # Not enabling -Werror on CUDA compiler because of many visibility attribute warnings in tests
+  add_compile_options(
+      $<$<COMPILE_LANGUAGE:CXX>:-Werror>
+      # $<$<COMPILE_LANGUAGE:CUDA>:--compiler-options=-Werror>
+      -Wall -Wextra -Wconversion
+  )
 endif()
 
 if (UNIX AND (CMAKE_SIZEOF_VOID_P EQUAL 4) AND (CMAKE_SYSTEM_PROCESSOR STREQUAL i686))

--- a/tests/test_callbacks.cpp
+++ b/tests/test_callbacks.cpp
@@ -63,7 +63,7 @@ nb::dict cb_registry() {
 
 struct callback_data {
     struct py_hash {
-        size_t operator()(const nb::object& obj) const { return nb::hash(obj); }
+        size_t operator()(const nb::object& obj) const { return (size_t) nb::hash(obj); }
     };
     struct py_eq {
         bool operator()(const nb::object& a, const nb::object& b) const {

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -500,7 +500,7 @@ NB_MODULE(test_classes_ext, m) {
     struct Int {
         int i;
         Int operator+(Int o) const { return {i + o.i}; }
-        Int operator-(float j) const { return {int(i - j)}; }
+        Int operator-(float j) const { return {int((float)i - j)}; }
         bool operator==(Int o) const { return i == o.i; }
         Int &operator+=(Int o) {
             i += o.i;

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -841,13 +841,13 @@ NB_MODULE(test_classes_ext, m) {
         .def_ro("value", &NewDflt::value);
     nb::class_<NewStarPosOnly>(m, "NewStarPosOnly")
         .def(nb::new_([](nb::args a, int value) {
-            return NewStarPosOnly{nb::len(a) + value};
+            return NewStarPosOnly{nb::len(a) + (size_t) value};
         }),
             "args"_a, "value"_a = 42)
         .def_ro("value", &NewStarPosOnly::value);
     nb::class_<NewStar>(m, "NewStar")
         .def(nb::new_([](nb::args a, int value, nb::kwargs k) {
-            return NewStar{nb::len(a) + value + 10 * nb::len(k)};
+            return NewStar{nb::len(a) + (size_t) value + 10 * nb::len(k)};
         }),
             "args"_a, "value"_a = 42, "kwargs"_a)
         .def_ro("value", &NewStar::value);

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -32,7 +32,7 @@ struct example_policy {
     static inline std::vector<std::pair<nb::tuple, nb::object>> calls;
     static void precall(PyObject **args, size_t nargs,
                         nb::detail::cleanup_list *cleanup) {
-        PyObject* tup = PyTuple_New(nargs);
+        PyObject* tup = PyTuple_New((Py_ssize_t) nargs);
         for (size_t i = 0; i < nargs; ++i) {
             if (!PyUnicode_CheckExact(args[i])) {
                 Py_DECREF(tup);
@@ -44,7 +44,7 @@ struct example_policy {
                 cleanup->append(replacement.release().ptr());
             }
             Py_INCREF(args[i]);
-            PyTuple_SetItem(tup, i, args[i]);
+            PyTuple_SetItem(tup, (Py_ssize_t) i, args[i]);
         }
         calls.emplace_back(nb::steal<nb::tuple>(tup), nb::cast("<unfinished>"));
     }
@@ -263,7 +263,7 @@ NB_MODULE(test_functions_ext, m) {
     m.def("test_15_d", [](nb::bytes o) { return nb::bytes(o.data(), o.size()); });
     m.def("test_16",   [](const char *c) { return nb::bytes(c); });
     m.def("test_17",   [](nb::bytes c) { return c.size(); });
-    m.def("test_18",   [](const char *c, int size) { return nb::bytes(c, size); });
+    m.def("test_18",   [](const char *c, int size) { return nb::bytes(c, (size_t) size); });
 
     // Test int type
     m.def("test_19", [](nb::int_ i) { return i + nb::int_(123); });
@@ -511,11 +511,12 @@ NB_MODULE(test_functions_ext, m) {
 
     // Test bytearray type
     m.def("test_bytearray_new",     []() { return nb::bytearray(); });
-    m.def("test_bytearray_new",     [](const char *c, int size) { return nb::bytearray(c, size); });
+    m.def("test_bytearray_new",     [](const char *c, int size) { return nb::bytearray(c, (size_t) size); });
     m.def("test_bytearray_copy",    [](nb::bytearray o) { return nb::bytearray(o.c_str(), o.size()); });
     m.def("test_bytearray_c_str",   [](nb::bytearray o) -> const char * { return o.c_str(); });
     m.def("test_bytearray_size",    [](nb::bytearray o) { return o.size(); });
-    m.def("test_bytearray_resize",  [](nb::bytearray c, int size) { return c.resize(size); });
+    m.def("test_bytearray_resize",  [](nb::bytearray c, int size) { return c.resize((size_t) size);
+    });
 
     // Test call_policy feature
     m.def("test_call_policy",

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -223,7 +223,7 @@ NB_MODULE(test_stl_ext, m) {
         if (x.size() != 10)
             fail();
         for (int i = 0; i< 10; ++i)
-            if (x[i].value != i)
+            if (x[(size_t) i].value != i)
                 fail();
     });
 
@@ -232,7 +232,7 @@ NB_MODULE(test_stl_ext, m) {
         if (x.size() != 10)
             fail();
         for (int i = 0; i< 10; ++i)
-            if (x[i].value != i)
+            if (x[(size_t) i].value != i)
                 fail();
     });
 
@@ -241,7 +241,7 @@ NB_MODULE(test_stl_ext, m) {
         if (x.size() != 10)
             fail();
         for (int i = 0; i< 10; ++i)
-            if (x[i].value != i)
+            if (x[(size_t) i].value != i)
                 fail();
     });
 
@@ -250,7 +250,7 @@ NB_MODULE(test_stl_ext, m) {
         if (x.size() != 10)
             fail();
         for (int i = 0; i< 10; ++i)
-            if (x[i].value != i)
+            if (x[(size_t) i].value != i)
                 fail();
     });
 
@@ -258,7 +258,7 @@ NB_MODULE(test_stl_ext, m) {
         if (x.size() != 10)
             fail();
         for (int i = 0; i< 10; ++i)
-            if (x[i]->value != i)
+            if (x[(size_t) i]->value != i)
                 fail();
     });
 

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -87,7 +87,7 @@ NB_MODULE(test_thread_ext, m) {
         shared_ints.push_back(std::make_shared<AnInt>(i));
     }
     m.def("fetch_shared_int", [shared_ints](int i) {
-        return shared_ints.at(i);
+        return shared_ints.at((size_t) i);
     });
     m.def("consume_an_int", [](AnInt* p) { return p->value; });
 }


### PR DESCRIPTION
Hi,
This PR fixes the implicit conversion warnings raised by Clang, mainly regarding size_t to and from Py_ssize_t
After these changes nanobind builds warningless on Clang 22