### PR TITLE
stubgen: simplify nested type names inside enclosing class bodies

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -740,7 +740,21 @@ class StubGen:
                 return cls_name if cls_name != "NoneType" else "None"
             if full_name.startswith(self.module.__name__ + "."):
                 # Strip away the module prefix for local classes
-                return full_name[len(self.module.__name__) + 1 :]
+                result = full_name[len(self.module.__name__) + 1 :]
+                # When inside a class body, also strip the enclosing class
+                # prefix so that e.g. "ErrorEnum.Value" becomes just "Value"
+                # when we are already inside class ErrorEnum.
+                scope = self.prefix[len(self.module.__name__) + 1 :]
+                if scope:
+                    # scope is like "ErrorEnum.Foo" or "ErrorEnum.__init__";
+                    # walk up the dotted path to find an enclosing class match
+                    parts = scope.split(".")
+                    for i in range(len(parts) - 1, 0, -1):
+                        candidate = ".".join(parts[:i])
+                        if result.startswith(candidate + "."):
+                            result = result[len(candidate) + 1 :]
+                            break
+                return result
             elif mod_name in ("typing", "typing_extensions", "collections.abc"):
                 # Import frequently-occurring typing classes and ABCs directly
                 return self.import_object(mod_name, cls_name)

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -22,6 +22,22 @@ NB_MAKE_OPAQUE(OpaqueEnum)
 // Enum with members named 'name' and 'value' to test stubgen (issue #1246)
 enum class Item { name, value, extra };
 
+// Wrapper class with nested enum (diplomat pattern) to test stubgen
+// simplification of self-referencing types inside class bodies.
+class EnumWrapper {
+public:
+    enum Value { Alpha = 0, Beta = 1, Gamma = 2 };
+
+    EnumWrapper() : value(Alpha) {}
+    constexpr EnumWrapper(Value v) : value(v) {}
+    constexpr operator Value() const { return value; }
+    explicit operator bool() const = delete;
+
+    Value get_value() const { return value; }
+private:
+    Value value;
+};
+
 NB_MODULE(test_enum_ext, m) {
     nb::enum_<Enum>(m, "Enum", "enum-level docstring")
         .value("A", Enum::A, "Value A")
@@ -96,4 +112,19 @@ NB_MODULE(test_enum_ext, m) {
         .value("extra", Item::extra);
 
     m.def("item_to_int", [](Item i) { return (int) i; }, nb::arg("item") = Item::name);
+
+    // Wrapper class with nested enum — tests that stubgen uses short names
+    // (e.g. "Value" not "EnumWrapper.Value") inside the class body.
+    nb::class_<EnumWrapper> ew(m, "EnumWrapper");
+
+    nb::enum_<EnumWrapper::Value> ew_enum(ew, "Value");
+    ew_enum
+        .value("Alpha", EnumWrapper::Alpha)
+        .value("Beta", EnumWrapper::Beta)
+        .value("Gamma", EnumWrapper::Gamma)
+        .export_values();
+
+    ew.def(nb::init_implicit<EnumWrapper::Value>())
+      .def(nb::self == EnumWrapper::Value())
+      .def("get_value", &EnumWrapper::get_value);
 }

--- a/tests/test_enum_ext.pyi.ref
+++ b/tests/test_enum_ext.pyi.ref
@@ -129,3 +129,23 @@ class Item(enum.Enum):
     extra = 2
 
 def item_to_int(item: Item = Item.name) -> int: ...
+
+class EnumWrapper:
+    def __init__(self, arg: Value, /) -> None: ...
+
+    class Value(enum.Enum):
+        Alpha = 0
+
+        Beta = 1
+
+        Gamma = 2
+
+    Alpha: Value = Value.Alpha
+
+    Beta: Value = Value.Beta
+
+    Gamma: Value = Value.Gamma
+
+    def __eq__(self, arg: Value, /) -> bool: ...
+
+    def get_value(self) -> Value: ...


### PR DESCRIPTION
When a class contains a nested type (e.g. an `nb::enum_` inside an `nb::class_`), stubgen previously emitted the fully-qualified name in type annotations within the class body:

```python
    class EnumWrapper:
        Alpha: EnumWrapper.Value = EnumWrapper.Value.Alpha
```

Type checkers cannot resolve `EnumWrapper.Value` inside the EnumWrapper class body because the class isn't fully defined yet. This produces `Unknown` typing

With this fix, stubgen strips the enclosing class prefix when emitting types that refer to nested members of the current class:

```python
    class EnumWrapper:
        Alpha: Value = Value.Alpha
```

The nested name `Value` is directly visible in the class scope, so type checkers resolve it correctly.

Note if you care - I used AI to support finding, debugigng, and fixing this issue, but I am a human and here to answer questions or work through feedback!

Fixes #1333