### PR TITLE
ndarray: export `Ze`, revert importing `E|F|D` buffer codes

### DIFF
--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -185,6 +185,7 @@ static int nb_ndarray_getbuffer(PyObject *self, Py_buffer *view, int) {
 
         case dlpack::dtype_code::Complex:
             switch (t.dtype.bits) {
+                case 32: format = "Ze"; break;
                 case 64: format = "Zf"; break;
                 case 128: format = "Zd"; break;
             }
@@ -407,9 +408,6 @@ static mt_unique_ptr_t make_mt_from_buffer_protocol(PyObject *o, bool ro) {
             case 'Q':
             case 'N': dt.code = (uint8_t) dlpack::dtype_code::UInt; break;
 
-            case 'E':
-            case 'F':
-            case 'D': is_complex = true; [[fallthrough]];
             case 'e':
             case 'f':
             case 'd': dt.code = (uint8_t) dlpack::dtype_code::Float; break;

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -539,7 +539,7 @@ def test27_python_array():
 def test27c_python_complex_array():
     import array
     try:
-        a = array.array('F', [1.0+2.0j, 3.0+4.0j])
+        a = array.array('Zf', [1.0+2.0j, 3.0+4.0j])
     except:
         pytest.skip('your python does not support complex arrays')
     assert t.check(a)


### PR DESCRIPTION
CPython 3.15 has changed its support for complex arrays.  The current status (for 3.15 beta 1) is as follows:

Python 3.14:
+ struct: `'F'`|`'D'`
+ array: none
+ memoryview: none
+ ctypes: `'F'`|`'D'`|`'G'`

Python 3.15:
+ struct: `'F'`|`'D'` and `'Zf'`|`'Zd'`
+ array: `'Zf'`|`'Zd'`
+ memoryview: `'Zf'`|`'Zd'`
+ ctypes: `'Zf'`|`'Zd'`|`'Zg'`

This follows NumPy's practice and improves compatibility with NumPy.  To my knowledge, nobody uses `'E'` or `'F'` or `'D'` as a buffer format code.  Accordingly, this PR reverts #1323

(If a release of nanobind is not imminent, it may be good to wait a week or two before merging this PR, just in case CPython makes further changes.)