### PR TITLE
Fix polymorphic deallocation

### DIFF
--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -122,6 +122,7 @@ struct type_data {
     void (*destruct)(void *);
     void (*copy)(void *, const void *);
     void (*move)(void *, void *) noexcept;
+    void (*dealloc)(void *) noexcept = nullptr;
     union {
         implicit_t implicit;  // for C++ type bindings
         enum_tbl_t enum_tbl;  // for enumerations
@@ -248,6 +249,10 @@ template <typename T> void wrap_move(void *dst, void *src) noexcept {
 
 template <typename T> void wrap_destruct(void *value) noexcept {
     ((T *) value)->~T();
+}
+
+template <typename T> void wrap_delete(void *value) noexcept {
+    delete (T *) value;
 }
 
 template <typename, template <typename, typename> typename, typename...>
@@ -597,6 +602,10 @@ public:
             if constexpr (!std::is_trivially_destructible_v<T>) {
                 d.flags |= (uint32_t) detail::type_flags::has_destruct;
                 d.destruct = detail::wrap_destruct<T>;
+            }
+
+            if constexpr (std::has_virtual_destructor_v<T> || std::is_final_v<T>) {
+                d.dealloc = detail::wrap_delete<T>;
             }
         }
 

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -239,19 +239,23 @@ static void inst_dealloc(PyObject *self) {
     nb_inst *inst = (nb_inst *) self;
     void *p = inst_ptr(inst);
 
-    if (inst->destruct) {
-        check(t->flags & (uint32_t) type_flags::is_destructible,
-              "nanobind::detail::inst_dealloc(\"%s\"): attempted to call "
-              "the destructor of a non-destructible type!", t->name);
-        if (t->flags & (uint32_t) type_flags::has_destruct)
-            t->destruct(p);
-    }
+    if (inst->cpp_delete && t->dealloc) {
+        t->dealloc(p);
+    } else {
+        if (inst->destruct) {
+            check(t->flags & (uint32_t) type_flags::is_destructible,
+                  "nanobind::detail::inst_dealloc(\"%s\"): attempted to call "
+                  "the destructor of a non-destructible type!", t->name);
+            if (t->flags & (uint32_t) type_flags::has_destruct)
+                t->destruct(p);
+        }
 
-    if (inst->cpp_delete) {
-        if (NB_LIKELY(t->align <= (uint32_t) __STDCPP_DEFAULT_NEW_ALIGNMENT__))
-            operator delete(p);
-        else
-            operator delete(p, std::align_val_t(t->align));
+        if (inst->cpp_delete) {
+            if (NB_LIKELY(t->align <= (uint32_t) __STDCPP_DEFAULT_NEW_ALIGNMENT__))
+                operator delete(p);
+            else
+                operator delete(p, std::align_val_t(t->align));
+        }
     }
 
     nb_weakref_seq *wr_seq = nullptr;


### PR DESCRIPTION
Hi,
Recently, I ran into an allocator mismatch crash during cleanup (specifically during Python garbage collection) when working with Mitsuba:
1. A dynamic subclass like `PrincipledBsdf` is compiled with `alignas(16)` for SIMD operations.
2. But its memory lifetime is handed over to Python as a raw, base `Bsdf*` pointer (so that Python takes over and deallocates it).

Since the current deallocator in nanobind does placement destructors + raw `operator delete(void*)` on base pointers, standard C++ dynamic delete routing seems to be bypassed during cleanup. On cleanup, this unfortunately crashes with a mismatched free in our internal build configuration where the default compiler alignment is 8.

I've worked on a fix that has been working for us internally as it reverts to standard type-safe deallocations when classes have virtual destructors. 

To be honest, I'm not 100% sure this is the best fix for this niche problem, but it was the only way I could find to keep the allocators happy.

Let me know what you think or if you have a better alternative!
Best,
Philippe
