### PR TITLE
stubgen: Allow module imports in patterns with a new directive

### DIFF
--- a/docs/typing.rst
+++ b/docs/typing.rst
@@ -714,6 +714,18 @@ you may use the special ``\from`` escape code to import them:
        def lookup(array: Array[T], index: Literal[0] = 0) -> _Opt[T]:
            \doc
 
+If a replacement rule instead refers to a *whole module* (for example because
+the only use of that module in the stub is a qualified attribute access),
+use the ``\import`` escape code. It mirrors Python's ``import`` statement and
+accepts a comma-separated list of modules, with an optional ``as`` alias:
+
+.. code-block:: text
+
+   my_ext.import_me:
+       \import logging
+       \import collections.abc as cabc
+       def import_me(arg: logging.Logger) -> cabc.Iterable[int]: ...
+
 You may also add free-form text the beginning or the end of the generated stub
 module or of a class. To do so, add an entry that matches on ``name.__prefix__``
 or ``name.__suffix__`` where ``name`` is the name of the module or class.

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -851,6 +851,19 @@ class StubGen:
                     import_as = item_list[1].strip() if len(item_list) > 1 else None
                     self.import_object(import_module, import_name, import_as)
                 continue
+            elif ls.startswith("\\import "):
+                # inline module imports like "\import A, B as b"
+                mod_list = ls[7:].split(",")
+                for mod in mod_list:
+                    items = mod.split(" as ")
+                    if len(items) == 1:
+                        modname, as_name = items[0].strip(), None
+                    elif len(items) == 2:
+                        modname, as_name = [i.strip() for i in items]
+                    else:
+                        raise RuntimeError(f"Could not parse import declaration {mod}")
+                    self.import_object(modname, None, as_name=as_name)
+                continue
 
             groups = match.groups()
             for i in reversed(range(len(groups))):

--- a/tests/pattern_file.nb
+++ b/tests/pattern_file.nb
@@ -8,6 +8,12 @@ tweak_me:
     def tweak_me(arg: int):
         \doc
 
+# Rewrite a signature with whole-module imports (both plain and with 'as' name)
+import_me:
+    \import logging
+    \import collections.abc as cabc
+    def import_me(arg: logging.Logger) -> cabc.Iterable[int]: ...
+
 # Apply a pattern to multiple places
 __(lt|gt)__:
     def __\1__(self, arg: int, /) -> bool: ...

--- a/tests/test_typing.cpp
+++ b/tests/test_typing.cpp
@@ -135,4 +135,5 @@ NB_MODULE(test_typing_ext, m) {
     // Some statements that will be modified by the pattern file
     m.def("remove_me", []{});
     m.def("tweak_me", [](nb::object o) { return o; }, "prior docstring\nremains preserved");
+    m.def("import_me", []{});
 }

--- a/tests/test_typing_ext.pyi.ref
+++ b/tests/test_typing_ext.pyi.ref
@@ -1,4 +1,6 @@
+import collections.abc as cabc
 from collections.abc import Iterable
+import logging
 import py_stub_test
 from typing import (
     Any,
@@ -89,5 +91,7 @@ def tweak_me(arg: int):
     prior docstring
     remains preserved
     """
+
+def import_me(arg: logging.Logger) -> cabc.Iterable[int]: ...
 
 # a suffix


### PR DESCRIPTION
Introduces the keyword `\import` to import a whole module used in a pattern file. This is necessary when a type hint introduced in the pattern file is the only usage of that particular module, and the module itself has to be imported instead of a member.

---------------------

Hey Wenzel, I'm currently writing bindings for duckDB, and I resorted to using a pattern file to handle the following case:

```python
def foo(self, a, b: bool = False) -> mod.A | mod.B: ...
```

where type `mod.A` is returned if `b is True`, and `mod.B` otherwise. I'm applying the following overload pattern:

```
foo:
    @overload
    def foo(self, a, b: Literal[True]) -> mod.A: ...
    @overload
    def foo(self, a, b: Literal[False] = False) -> mod.B: ...
    def foo(self, a, b: bool = False) -> mod.A | mod.B: ...
        \doc
```

Unfortunately, if `foo` is the only place in the stub where `mod` is used, `mod` will not be imported at the top, since `simplify_types` is not called on patterns. There is also no pre-existing pattern directive to import entire modules, with the  alternative being `\from mod import A, B`. Until now!

```
foo:
    \import mod [as mymod]  # optional as_name.
    @overload
    def foo(self, a, b: Literal[True]) -> mod.A: ...
    @overload
    def foo(self, a, b: Literal[False] = False) -> mod.B: ...
    def foo(self, a, b: bool = False) -> mod.A | mod.B: ...
        \doc
```

If this is acceptable for you, I will add the missing documentation to the pattern file docs. Thanks! 