### PR TITLE
stubgen: Increment pattern match count on success

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -851,6 +851,7 @@ class StubGen:
             self.write_ln(line)
 
         # Success, pattern was applied
+        pattern.matches += 1
         return True
 
     def put(self, value: object, name: Optional[str] = None, parent: Optional[object] = None) -> None:


### PR DESCRIPTION
In a project, I kept trying to debug a pattern file with "no matches found" warnings for all patterns, before I found that the patterns were actually applied all along. Turns out the pattern application counter was never incremented.