### PR TITLE
cmake: report user error if Python Interpreter is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ endif()
 # Find the Python interpreter and development libraries
 # ---------------------------------------------------------------------------
 
-if (NOT TARGET Python::Module OR NOT TARGET Python::Interpreter)
+if (NOT TARGET Python::Module AND NOT TARGET Python::Interpreter)
   set(Python_FIND_FRAMEWORK LAST) # Prefer Brew/Conda to Apple framework python
 
   if (CMAKE_VERSION VERSION_LESS 3.18)

--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -1,6 +1,6 @@
 include_guard(GLOBAL)
 
-if (NOT TARGET Python::Module)
+if (NOT TARGET Python::Interpreter OR NOT TARGET Python::Module)
   message(FATAL_ERROR "You must invoke 'find_package(Python COMPONENTS Interpreter Development REQUIRED)' prior to including nanobind.")
 endif()
 


### PR DESCRIPTION
Fixes #1350, in which the module developer calls `find_package(Python)` without `COMPONENTS Interpreter REQUIRED`.
In this case, we will avoid calling `find_package(Python)` ourselves and instead cause a cmake fatal error.