### PR TITLE
ndarray: add dtype_code enumeration `Bcomplex`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,9 @@ Unreleased
 - The implicit :cpp:func:`.none() <arg::none>` annotation now also applies to
   ``std::nullptr_t`` and ``std::monostate``-typed arguments
 
-Version 2.12.0 (Feb 25, 2025)
+- Added ndarray ``dtype_code`` enumeration ``Bcomplex`` for complex bfloat16.
+
+Version 2.12.0 (Feb 25, 2026)
 -----------------------------
 
 - Added :cpp:class:`nb::memoryview` that wraps the Python ``memoryview`` type.

--- a/docs/ndarray.rst
+++ b/docs/ndarray.rst
@@ -541,12 +541,12 @@ Nonstandard arithmetic types
 ----------------------------
 
 Low or extended-precision arithmetic types (e.g., ``int128``, ``float16``,
-``bfloat16``) are sometimes used but don't have standardized C++ equivalents.
+``bfloat16``) are sometimes used, though they are not standardized in C++17.
 If you wish to exchange arrays based on such types, you must register a partial
 overload of ``nanobind::detail::dtype_traits`` to inform nanobind about it.
 
 You are expressively allowed to create partial overloads of this class despite
-it being in the ``nanobind::detail`` namespace.
+its being in the ``nanobind::detail`` namespace.
 
 For example, the following snippet makes ``_Float16`` (half-precision type that
 is natively supported on some hardware) available by providing
@@ -561,11 +561,35 @@ is natively supported on some hardware) available by providing
            static constexpr dlpack::dtype value {
                (uint8_t) dlpack::dtype_code::Float, // type code
                16, // size in bits
-               1   // lanes (simd), usually set to 1
+               1   // lanes (simd), usually always set to 1
            };
            static constexpr auto name = const_name("float16");
        };
    }
+
+For complex numbers, nanobind assumes the ``T`` in ``std::complex<T>`` is an
+IEEE floating-point type.  Thus, above, it is not also necessary to specialize
+``dtype_traits<std::complex<_Float16>>``.
+
+To use ``bfloat16`` complex numbers, specialize ``dtype_traits`` for both the
+real and complex C++ types:
+
+.. code-block:: cpp
+
+   namespace nanobind::detail {
+   template<> struct dtype_traits<__bf16> {
+       static constexpr dlpack::dtype value{
+               /*code=*/static_cast<uint8_t>(dlpack::dtype_code::Bfloat),
+               /*bits=*/16, /*lanes=*/1};
+       static constexpr auto name = const_name("bfloat16");
+   };
+   template<> struct dtype_traits<std::complex<__bf16>> {
+       static constexpr dlpack::dtype value{
+               /*code=*/static_cast<uint8_t>(dlpack::dtype_code::Bcomplex),
+               /*bits=*/32, /*lanes=*/1};
+       static constexpr auto name = const_name("bcomplex32");
+   };
+   }  // namespace nanobind::detail
 
 .. _ndarray-views:
 

--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -27,7 +27,8 @@ enum class dtype_code : uint8_t {
     Float8_E4M3FN = 10, Float8_E4M3FNUZ = 11, Float8_E5M2 = 12,
     Float8_E5M2FNUZ = 13, Float8_E8M0FNU = 14,
     Float6_E2M3FN = 15, Float6_E3M2FN = 16,
-    Float4_E2M1FN = 17
+    Float4_E2M1FN = 17,
+    Bcomplex = 18
 };
 
 struct device {

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -503,6 +503,11 @@ bool ndarray_check(PyObject *o) noexcept {
     return result;
 }
 
+// Helper function reports whether `code` represents a complex number.
+static NB_INLINE bool dtype_code_is_complex(uint8_t code) {
+    return code == (uint8_t) dlpack::dtype_code::Complex ||
+           code == (uint8_t) dlpack::dtype_code::Bcomplex;
+}
 
 ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
                                bool convert, cleanup_list *cleanup) noexcept {
@@ -661,9 +666,8 @@ ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
 
     // Do not convert shape and do not convert complex numbers to non-complex.
     convert &= pass_shape &
-               !(t.dtype.code == (uint8_t) dlpack::dtype_code::Complex
-                 && has_dtype
-                 && c->dtype.code != (uint8_t) dlpack::dtype_code::Complex);
+               !(dtype_code_is_complex(t.dtype.code) &&
+                 has_dtype && !dtype_code_is_complex(c->dtype.code));
 
     // Support implicit conversion of dtype and order.
     if (convert && (!pass_dtype || !pass_order) && !src_is_pycapsule) {
@@ -679,7 +683,7 @@ ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
         if (dt.lanes != 1)
             return nullptr;
 
-        char dtype[11];
+        char dtype[12];
         if (dt.code == (uint8_t) dlpack::dtype_code::Bool) {
             std::strcpy(dtype, "bool");
         } else {
@@ -699,6 +703,9 @@ ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
                     break;
                 case (uint8_t) dlpack::dtype_code::Complex:
                     prefix = "complex";
+                    break;
+                case (uint8_t) dlpack::dtype_code::Bcomplex:
+                    prefix = "bcomplex";
                     break;
                 default:
                     return nullptr;


### PR DESCRIPTION
The `dlpack::dtype_code` enumeration `Complex = 5` is for complex numbers that use IEEE floating point, i.e., `std::complex<float>`, `std::complex<double>`, and `std::complex<std::float16_t>`.  Other floating-point types (e.g., those having fewer bits that are used for machine learning) will need new enumerations if complex numbers of these real types are found to be useful.

This PR adds support for `std::complex<std::bfloat16_t>` if the module developer writes something like the following:
```
namespace nanobind::detail {
template<> struct dtype_traits<__bf16> {
    static constexpr dlpack::dtype value{
            /*code=*/static_cast<uint8_t>(dlpack::dtype_code::Bfloat),
            /*bits=*/16, /*lanes=*/1};
    static constexpr auto name = const_name("bfloat16");
};
template<> struct dtype_traits<std::complex<__bf16>> {
    static constexpr dlpack::dtype value{
            /*code=*/static_cast<uint8_t>(dlpack::dtype_code::Bcomplex),
            /*bits=*/32, /*lanes=*/1};
    static constexpr auto name = const_name("bcomplex32");
};
}  // namespace nanobind::detail
```
BTW, `std::complex<std::float128_t>` is a separate problem since `uint8_t bits = 256` may not meet expectations.

See also: https://github.com/numpy/numpy/issues/19808#issuecomment-4332750485

Note that the PR to add `kDLBcomplex = 18U` to upstream DLPack has not yet been merged, so I'm marking this as a draft.  (I'll need to step away from here for a week or two, then I'll have time to follow up.)