### PR TITLE
ci: add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # Cooldown prevents Dependabot from raising a PR the moment a new release
+    # lands. Fresh releases occasionally carry regressions; waiting a short
+    # period lets the ecosystem surface issues before we adopt them.
+    # Major bumps get a longer window because they are more likely to require
+    # manual migration work and should be adopted deliberately.
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

This PR adds `.github/dependabot.yml` so that Dependabot automatically opens
pull requests when new versions of the GitHub Actions used in our workflows are
released.

### Why Dependabot for Actions?

GitHub Actions are executed with the repository's full permissions. An action
pinned only to a mutable tag (e.g. `@v4`, `@latest`) will silently pick up any
commit the action author pushes to that tag — including malicious ones. The
[tj-actions/changed-files supply-chain incident (2025)](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3)
demonstrated this: a compromised action tag exfiltrated secrets from thousands
of CI runs before it was detected. Keeping action versions current reduces
exposure to known CVEs and ensures we are using releases that have been
reviewed by the community.

### Why monthly with a cooldown?

- **Monthly interval** avoids a constant drip of single-dependency PRs and
  batches updates into a predictable review window.
- **`cooldown.default-days: 7`** — Dependabot waits 7 days after a release
  before opening a PR. This filters out releases that are quickly followed by
  a patch for a regression. Downstream consumers of nanobind (including ONNX)
  benefit because the CI environment they observe is more stable.
- **`cooldown.semver-major-days: 30`** — major version bumps get a 30-day
  window. They are more likely to require manual migration (changed inputs,
  removed outputs, different runner requirements) and should be adopted
  deliberately rather than automatically.
- **`open-pull-requests-limit: 5`** — caps concurrent Dependabot PRs so the
  review queue stays manageable.

### Interaction with the SHA-pinning PR

A companion PR [#1355](https://github.com/wjakob/nanobind/pull/1355) pins every action to its commit
SHA. Once both are merged, Dependabot will open PRs that update the SHA **and**
the human-readable version comment in lockstep, which is the recommended
workflow for maintaining SHA-pinned actions.

## Test plan

- [ ] Confirm `.github/dependabot.yml` is valid YAML (no parse errors)
- [ ] After merge, verify Dependabot is listed under
  *Insights → Dependency graph → Dependabot* for this repository
- [ ] On the next monthly schedule (or via *Insights → Dependabot → "Check for
  updates"*) confirm a PR is opened for at least one action