### PR TITLE
security: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,18 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
 
     - name: Setup Python ${{ matrix.python }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python }}
         cache: 'pip'
 
     - name: Install the latest CMake
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
 
     - name: Install Eigen
       if: matrix.os == 'ubuntu-latest'
@@ -86,7 +86,7 @@ jobs:
     - name: Install dependencies
       run: apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y cmake git python3-dev python3-pytest python3-pip libeigen3-dev python3-typing-extensions python3-numpy
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
 
@@ -112,17 +112,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
 
-    - uses: deadsnakes/action@v3.1.0
+    - uses: deadsnakes/action@6c8b9b82fe0b4344f4b98f2775fcc395df45e494 # v3.1.0
       with:
         python-version: 3.14-dev
         nogil: true
 
     - name: Install the latest CMake
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
 
     - name: Install PyTest
       run: |
@@ -155,18 +155,18 @@ jobs:
         python: ['3.12']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
 
     - name: Setup Python ${{ matrix.python }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python }}
         cache: 'pip'
 
     - name: Setup MSYS2 (MINGW64)
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2
       with:
         msystem: MINGW64
         install: >-
@@ -218,19 +218,19 @@ jobs:
         python: ['3.12']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
 
     - name: Setup Python ${{ matrix.python }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python }}
         cache: 'pip'
 
     - name: Cache Intel oneAPI
       id: cache-oneapi
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: /opt/intel/oneapi
         key: install-${{ runner.os }}-intel-oneapi-compiler-2025.2
@@ -255,7 +255,7 @@ jobs:
         sudo rm -rf /opt/intel/oneapi/compiler/*/linux/lib/oclfpga
 
     - name: Install the latest CMake
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
 
     - name: Install PyTest
       run: |

--- a/.github/workflows/nvcc-win.yml
+++ b/.github/workflows/nvcc-win.yml
@@ -9,17 +9,17 @@ jobs:
     name: "Python 3.12.7 / NVCC (CUDA 12.5.0) / windows-latest"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
 
-    - uses: Jimver/cuda-toolkit@v0.2.17
+    - uses: Jimver/cuda-toolkit@dc581bec6470cf161025608f13d71b3c00c2c0b7 # v0.2.17
       id: cuda-toolkit
       with:
         cuda: '12.5.0'
 
     - name: Setup Python 3.12.5
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: 3.12.5
         cache: 'pip'


### PR DESCRIPTION
## Summary

Pin every `uses:` reference in `.github/workflows/ci.yml` and
`.github/workflows/nvcc-win.yml` from mutable version tags to immutable
commit SHAs, while keeping the human-readable version as a trailing comment.

## Why mutable tags are a supply-chain risk

GitHub Actions run with the repository's full token permissions. A `uses:` line
that references a mutable ref — a floating tag like `@v4` or `@latest`, or a
branch name — resolves to whatever commit that ref points to **at the time the
workflow runs**, not at the time it was written.

This means an action author (or an attacker who has compromised an action
author's account) can push new code to an existing tag, and every repository
that references that tag will silently execute the new code on the next CI run —
with access to `GITHUB_TOKEN`, repository secrets, and the runner filesystem.

**This attack has happened in production.** The
[tj-actions/changed-files incident (March 2025)](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3)
compromised the `@v35` tag and exfiltrated secrets from thousands of CI runs
before it was detected. The
[reviewdog/action-setup compromise](https://github.com/advisories/GHSA-qmg3-hpqr-gqvc)
followed the same pattern days later.

A commit SHA, by contrast, is cryptographically bound to the exact tree of
code that was reviewed. Pushing new commits to a tag does not change what a
SHA-pinned workflow executes.

## What changed

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4` |
| `actions/setup-python` | `@v5` | `@a26af69be951a213d495a4c3e4e4022e16d87065 # v5` |
| `actions/cache` | `@v4` | `@0057852bfaa89a56745cba8c7296529d2fc39830 # v4` |
| `lukka/get-cmake` | `@latest` | `@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3` |
| `deadsnakes/action` | `@v3.1.0` | `@6c8b9b82fe0b4344f4b98f2775fcc395df45e494 # v3.1.0` |
| `msys2/setup-msys2` | `@v2` | `@e9898307ac31d1a803454791be09ab9973336e1c # v2` |
| `Jimver/cuda-toolkit` | `@v0.2.17` | `@dc581bec6470cf161025608f13d71b3c00c2c0b7 # v0.2.17` |

`lukka/get-cmake@latest` was the highest-risk reference: `@latest` is a
branch-like pointer that resolves to the tip of whatever the author decides,
with no version semantics at all. It is now pinned to the `v4.3.3` release commit.

## Keeping pins up to date

SHA pins create a maintenance burden if not automated. A companion PR
[#1354](https://github.com/wjakob/nanobind/pull/1354) configures
Dependabot to open monthly PRs that update both the SHA and the version
comment in lockstep, so the pins stay current without manual work.

## No functional change

All SHAs correspond exactly to the same releases previously referenced by the
mutable tags. CI behaviour is unchanged.