### PR TITLE
ci: replace deadsnakes with setup-python for free-threaded job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         python3 -m pytest
 
   free-threaded:
-    name: "Python 3.14-dev / ubuntu.latest [free-threaded]"
+    name: "Python 3.14t / ubuntu-latest [free-threaded]"
     runs-on: ubuntu-latest
 
     steps:
@@ -116,10 +116,10 @@ jobs:
       with:
         submodules: true
 
-    - uses: deadsnakes/action@v3.1.0
+    - name: Setup Python 3.14t (free-threaded)
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.14-dev
-        nogil: true
+        python-version: '3.14t'
 
     - name: Install the latest CMake
       uses: lukka/get-cmake@latest


### PR DESCRIPTION
## Summary

The `free-threaded` CI job was using `deadsnakes/action` to install
`3.14-dev` with `nogil: true`. Python 3.14 has since been released as a
stable version, and the free-threaded build is now distributed as `3.14t`
(the official CPython naming convention for free-threaded interpreters).

`actions/setup-python` v5 supports the `t`-suffixed free-threaded variants
natively, so `deadsnakes/action` is no longer needed for this job.

## What changed

| | Before | After |
|---|---|---|
| **Action** | `deadsnakes/action@v3.1.0` | `actions/setup-python@v5` |
| **Python version** | `3.14-dev` | `3.14t` |
| **Extra option** | `nogil: true` | *(not needed — implied by the `t` suffix)* |
| **Job name** | `Python 3.14-dev / ubuntu.latest [free-threaded]` | `Python 3.14t / ubuntu-latest [free-threaded]` |

## Why this matters

- **Correctness** — `3.14-dev` resolves to a pre-release dev build.
  Using the stable `3.14t` ensures CI tests against what users actually ship.
- **Fewer third-party dependencies** — `deadsnakes/action` is a third-party
  action that needed its own SHA-pinning and update cadence. Switching to
  `actions/setup-python` (a first-party GitHub action) reduces the supply
  chain surface area.
- **Consistency** — every other job in `ci.yml` already uses
  `actions/setup-python`. The `free-threaded` job now follows the same pattern.

## Related PRs

- [#1355](https://github.com/wjakob/nanobind/pull/1355) — SHA-pins all actions including `actions/setup-python`
- [#1354](https://github.com/wjakob/nanobind/pull/1354) — adds Dependabot to keep action versions current