### PR TITLE
Stubgen: Always preserve private typevars

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -900,12 +900,15 @@ class StubGen:
                 and (value.__name__ != name or value.__module__ != self.module.__name__)
             )
 
+            tp = type(value)
+
             # Ignore private members unless the user requests their inclusion
             if (
                 not self.include_private
                 and name
                 and not is_type_alias
                 and len(name) > 2
+                and not self.is_type_var(tp)
                 and (
                     (name[0] == "_" and name[1] != "_")
                     or (name[-1] == "_" and name[-2] != "_")
@@ -913,7 +916,6 @@ class StubGen:
             ):
                 return
 
-            tp = type(value)
             tp_mod, tp_name = tp.__module__, tp.__name__
 
             if ismodule(value):


### PR DESCRIPTION
Stubgen drops private variables (as identified by the `_` prefix) by default.

However, I think this is suboptimal when a `TypeVar` is used for a public interface. For example, consider the following:

```python
_InputT = TypeVar('_InputT', int, float)

def scale(x: _InputT) -> _InputT:
  return 2 * x
```

The public signature here uses the private TypeVar to indicate that the input and output type of the `scale` function are identical. This example is inspired by the real use in Dr.Jit: https://github.com/mitsuba-renderer/drjit/blob/master/drjit/nn.py#L32. 

Currently, stubgen will drop `_InputT`, leading to an error for type checking tools that then cannot find `_InputT`.

The current stubgen implementation already ensures that type aliases are always preserved. Therefore, preserving `TypeVar`s also seems to make sense.

