### PR TITLE
Add support for binding C++ enums as `StrEnum`

### DIFF
--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -2253,7 +2253,7 @@ The following annotations can be specified using the variable-length
    whether or not the enumeration is also marked to support arithmetic
    operations (see :cpp:class:`is_arithmetic`).
 
-.. cpp:struct:: is_str_enum
+.. cpp:struct:: is_str
 
    Indicate that the enumeration carries a string value per entry. Passing
    this annotation changes the Python enumeration parent class to
@@ -2695,7 +2695,7 @@ Class binding
       Add the entry `value` to a string-valued enumeration using the identifier
       `name` and the Python-side string `str_val`, optionally with a docstring
       provided via `doc`. The enumeration must have been declared with the
-      :cpp:class:`is_str_enum` annotation.
+      :cpp:class:`is_str` annotation.
 
    .. cpp:function:: enum_ &export_values()
 

--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -2253,6 +2253,23 @@ The following annotations can be specified using the variable-length
    whether or not the enumeration is also marked to support arithmetic
    operations (see :cpp:class:`is_arithmetic`).
 
+.. cpp:struct:: is_str_enum
+
+   Indicate that the enumeration carries a string value per entry. Passing
+   this annotation changes the Python enumeration parent class to
+   :py:class:`enum.StrEnum` (Python 3.11+) or an equivalent class derived from
+   ``(str, enum.Enum)`` on older Python versions. Each enumerator must then be
+   registered using :cpp:func:`enum_::str_value` instead of
+   :cpp:func:`enum_::value`, supplying the string that represents the entry in
+   Python.
+
+   Members are instances of :py:class:`str` and compare equal to their string
+   value (e.g., ``Color.Red == "red"``). Conversion of bare strings to the
+   enumeration is supported when implicit conversions are enabled.
+
+   This annotation cannot be combined with :cpp:class:`is_arithmetic` or
+   :cpp:class:`is_flag`.
+
 Function binding
 ----------------
 
@@ -2672,6 +2689,13 @@ Class binding
 
       Add the entry `value` to the enumeration using the identifier `name`,
       potentially with a docstring provided via `doc` (optional).
+
+   .. cpp:function:: enum_ &str_value(const char * name, T value, const char * str_val, const char * doc = nullptr)
+
+      Add the entry `value` to a string-valued enumeration using the identifier
+      `name` and the Python-side string `str_val`, optionally with a docstring
+      provided via `doc`. The enumeration must have been declared with the
+      :cpp:class:`is_str_enum` annotation.
 
    .. cpp:function:: enum_ &export_values()
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -136,7 +136,7 @@ Unreleased
 
 - Added support for binding string-valued enumerations as Python
   :py:class:`enum.StrEnum` subclasses via the new
-  :cpp:class:`nb::is_str_enum() <is_str_enum>` annotation and the corresponding
+  :cpp:class:`nb::is_str() <is_str>` annotation and the corresponding
   :cpp:func:`enum_::str_value` member function. On Python 3.9 and 3.10, the
   generated type derives from ``(str, enum.Enum)`` instead.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -134,6 +134,12 @@ Unreleased
 
 - ABI version 20.
 
+- Added support for binding string-valued enumerations as Python
+  :py:class:`enum.StrEnum` subclasses via the new
+  :cpp:class:`nb::is_str_enum() <is_str_enum>` annotation and the corresponding
+  :cpp:func:`enum_::str_value` member function. On Python 3.9 and 3.10, the
+  generated type derives from ``(str, enum.Enum)`` instead.
+
 Version 2.12.0 (Feb 25, 2026)
 -----------------------------
 

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -308,6 +308,19 @@ C++11-style strongly typed enumerations.
        nb::enum_<Pet::Kind>(pet, "Kind", nb::is_arithmetic())
           ...
 
+   When the annotation :cpp:class:`nb::is_str_enum() <is_str_enum>` is passed to
+   :cpp:class:`nb::enum_\<T\> <enum_>`, the resulting Python type will be a class
+   derived from ``enum.StrEnum``, and each entry must be registered using
+   :cpp:func:`.str_value() <enum_::str_value>` (which takes an additional
+   string-valued argument that represents the entry on the Python side):
+
+   .. code-block:: cpp
+
+       nb::enum_<Color>(m, "Color", nb::is_str_enum())
+           .str_value("Red",   Color::Red,   "red")
+           .str_value("Green", Color::Green, "green")
+           .str_value("Blue",  Color::Blue,  "blue");
+
    By default, these are omitted.
 
 .. _dynamic_attributes:

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -308,7 +308,7 @@ C++11-style strongly typed enumerations.
        nb::enum_<Pet::Kind>(pet, "Kind", nb::is_arithmetic())
           ...
 
-   When the annotation :cpp:class:`nb::is_str_enum() <is_str_enum>` is passed to
+   When the annotation :cpp:class:`nb::is_str() <is_str>` is passed to
    :cpp:class:`nb::enum_\<T\> <enum_>`, the resulting Python type will be a class
    derived from ``enum.StrEnum``, and each entry must be registered using
    :cpp:func:`.str_value() <enum_::str_value>` (which takes an additional
@@ -316,7 +316,7 @@ C++11-style strongly typed enumerations.
 
    .. code-block:: cpp
 
-       nb::enum_<Color>(m, "Color", nb::is_str_enum())
+       nb::enum_<Color>(m, "Color", nb::is_str())
            .str_value("Red",   Color::Red,   "red")
            .str_value("Green", Color::Green, "green")
            .str_value("Blue",  Color::Blue,  "blue");

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -119,6 +119,7 @@ struct is_implicit {};
 struct is_operator {};
 struct is_arithmetic {};
 struct is_flag {};
+struct is_str_enum {};
 struct is_final {};
 struct is_generic {};
 struct kw_only {};

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -119,7 +119,7 @@ struct is_implicit {};
 struct is_operator {};
 struct is_arithmetic {};
 struct is_flag {};
-struct is_str_enum {};
+struct is_str {};
 struct is_final {};
 struct is_generic {};
 struct kw_only {};

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -819,13 +819,13 @@ public:
     }
 
     NB_INLINE enum_ &value(const char *name, T value, const char *doc = nullptr) {
-        detail::enum_append(m_ptr, name, (int64_t) value, doc);
+        detail::enum_append(m_ptr, name, (int64_t) value, nullptr, doc);
         return *this;
     }
 
     NB_INLINE enum_ &str_value(const char *name, T value, const char *str_val,
                                const char *doc = nullptr) {
-        detail::enum_append_str(m_ptr, name, (int64_t) value, str_val, doc);
+        detail::enum_append(m_ptr, name, (int64_t) value, str_val, doc);
         return *this;
     }
 

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -234,7 +234,7 @@ enum class enum_flags : uint32_t {
     is_flag                = (1 << 3),
 
     /// Is this a string-valued enumeration (StrEnum)?
-    is_str_enum             = (1 << 4)
+    is_str                 = (1 << 4)
 };
 
 struct enum_init_data {
@@ -253,8 +253,8 @@ NB_INLINE void enum_extra_apply(enum_init_data &e, is_flag) {
     e.flags |= (uint32_t) enum_flags::is_flag;
 }
 
-NB_INLINE void enum_extra_apply(enum_init_data &e, is_str_enum) {
-    e.flags |= (uint32_t) enum_flags::is_str_enum;
+NB_INLINE void enum_extra_apply(enum_init_data &e, is_str) {
+    e.flags |= (uint32_t) enum_flags::is_str;
 }
 
 NB_INLINE void enum_extra_apply(enum_init_data &e, const char *doc) {

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -231,7 +231,10 @@ enum class enum_flags : uint32_t {
     is_signed                = (1 << 2),
 
     /// Is the underlying enumeration type Flag?
-    is_flag                = (1 << 3)
+    is_flag                = (1 << 3),
+
+    /// Is this a string-valued enumeration (StrEnum)?
+    is_str_enum             = (1 << 4)
 };
 
 struct enum_init_data {
@@ -248,6 +251,10 @@ NB_INLINE void enum_extra_apply(enum_init_data &e, is_arithmetic) {
 
 NB_INLINE void enum_extra_apply(enum_init_data &e, is_flag) {
     e.flags |= (uint32_t) enum_flags::is_flag;
+}
+
+NB_INLINE void enum_extra_apply(enum_init_data &e, is_str_enum) {
+    e.flags |= (uint32_t) enum_flags::is_str_enum;
 }
 
 NB_INLINE void enum_extra_apply(enum_init_data &e, const char *doc) {
@@ -813,6 +820,12 @@ public:
 
     NB_INLINE enum_ &value(const char *name, T value, const char *doc = nullptr) {
         detail::enum_append(m_ptr, name, (int64_t) value, doc);
+        return *this;
+    }
+
+    NB_INLINE enum_ &str_value(const char *name, T value, const char *str_val,
+                               const char *doc = nullptr) {
+        detail::enum_append_str(m_ptr, name, (int64_t) value, str_val, doc);
         return *this;
     }
 

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -450,6 +450,10 @@ NB_CORE PyObject *enum_create(enum_init_data *) noexcept;
 NB_CORE void enum_append(PyObject *tp, const char *name,
                          int64_t value, const char *doc) noexcept;
 
+/// Append a string-valued entry to a StrEnum
+NB_CORE void enum_append_str(PyObject *tp, const char *name, int64_t value,
+                             const char *str_value, const char *doc) noexcept;
+
 // Query an enumeration's Python object -> integer value map
 NB_CORE bool enum_from_python(const std::type_info *, PyObject *, int64_t *,
                               uint8_t flags) noexcept;

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -446,13 +446,10 @@ struct enum_init_data;
 /// Create a new enumeration type
 NB_CORE PyObject *enum_create(enum_init_data *) noexcept;
 
-/// Append an entry to an enumeration
-NB_CORE void enum_append(PyObject *tp, const char *name,
-                         int64_t value, const char *doc) noexcept;
-
-/// Append a string-valued entry to a StrEnum
-NB_CORE void enum_append_str(PyObject *tp, const char *name, int64_t value,
-                             const char *str_value, const char *doc) noexcept;
+/// Append an entry to an enumeration. For StrEnum members, 'str_value' carries
+/// the string value; for all other enumerations it must be nullptr.
+NB_CORE void enum_append(PyObject *tp, const char *name, int64_t value,
+                         const char *str_value, const char *doc) noexcept;
 
 // Query an enumeration's Python object -> integer value map
 NB_CORE bool enum_from_python(const std::type_info *, PyObject *, int64_t *,

--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -402,7 +402,7 @@ PyObject *enum_from_cpp(const std::type_info *tp, int64_t key) noexcept {
     }
 
     if (flags & (uint32_t) enum_flags::is_signed)
-        PyErr_Format(PyExc_ValueError, "%lli is not a valid %s.",
+        PyErr_Format(PyExc_ValueError, "%lld is not a valid %s.",
                      (long long) key, t->name);
     else
         PyErr_Format(PyExc_ValueError, "%llu is not a valid %s.",

--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -142,18 +142,35 @@ static type_init_data *enum_get_type_data(handle tp) {
 }
 
 void enum_append(PyObject *tp_, const char *name_, int64_t value_,
-                 const char *doc) noexcept {
+                 const char *str_value_, const char *doc) noexcept {
     handle tp(tp_),
            val_tp(&PyLong_Type),
+           str_tp((PyObject *) &PyUnicode_Type),
            obj_tp((PyObject *) &PyBaseObject_Type);
 
     type_data *t = enum_get_type_data(tp);
+    bool is_str = (t->flags & (uint32_t) enum_flags::is_str);
+
+    if (is_str && !str_value_)
+        fail("enum_append(): StrEnum member \"%s.%s\" must be added with "
+             "str_value() instead of value().", t->name, name_);
+
+    if (!is_str && str_value_)
+        fail("enum_append(): str_value() can only be used on enumerations "
+             "declared with nb::is_str() (member \"%s.%s\").",
+             t->name, name_);
 
     object val;
-    if (t->flags & (uint32_t) enum_flags::is_signed)
+    if (is_str) {
+        val = steal(PyUnicode_InternFromString(str_value_));
+        if (!val.is_valid())
+            fail("enum_append(): unable to intern string value for \"%s.%s\"",
+                 t->name, name_);
+    } else if (t->flags & (uint32_t) enum_flags::is_signed) {
         val = steal(PyLong_FromLongLong((long long) value_));
-    else
+    } else {
         val = steal(PyLong_FromUnsignedLongLong((unsigned long long) value_));
+    }
 
     dict value_map = tp.attr("_value2member_map_"),
          member_map = tp.attr("_member_map_");
@@ -180,7 +197,9 @@ void enum_append(PyObject *tp_, const char *name_, int64_t value_,
     #endif
 
     object el;
-    if (issubclass(tp, val_tp))
+    if (issubclass(tp, str_tp))
+        el = str_tp.attr(NB_INTERNED(__new__))(tp, val);
+    else if (issubclass(tp, val_tp))
         el = val_tp.attr(NB_INTERNED(__new__))(tp, val);
     else
         el = obj_tp.attr(NB_INTERNED(__new__))(tp);
@@ -194,58 +213,6 @@ void enum_append(PyObject *tp_, const char *name_, int64_t value_,
 
     // Compatibility with nanobind 1.x
     el.attr("__name__") = name;
-
-    setattr(tp, name, el);
-
-    if (!value_map.contains(val)) {
-        member_names.append(name);
-        value_map[val] = el;
-    }
-
-    member_map[name] = el;
-
-    enum_map *fwd = (enum_map *) t->enum_tbl.fwd;
-    fwd->emplace(value_, (int64_t) (uintptr_t) el.ptr());
-
-    enum_map *rev = (enum_map *) t->enum_tbl.rev;
-    rev->emplace((int64_t) (uintptr_t) el.ptr(), value_);
-}
-
-void enum_append_str(PyObject *tp_, const char *name_, int64_t value_,
-                     const char *str_value_, const char *doc) noexcept {
-    handle tp(tp_), str_tp((PyObject *) &PyUnicode_Type);
-
-    type_data *t = enum_get_type_data(tp);
-
-    if (!(t->flags & (uint32_t) enum_flags::is_str_enum))
-        fail("enum_append_str(): enumeration \"%s\" was not declared as a "
-             "StrEnum (missing nb::is_str_enum())", t->name);
-
-    if (!issubclass(tp, str_tp))
-        fail("enum_append_str(): enumeration \"%s\" is not a string subclass",
-             t->name);
-
-    object val = steal(PyUnicode_InternFromString(str_value_));
-    if (!val.is_valid())
-        fail("enum_append_str(): unable to intern string value for \"%s.%s\"",
-             t->name, name_);
-
-    dict value_map = tp.attr("_value2member_map_"),
-         member_map = tp.attr("_member_map_");
-    list member_names = tp.attr("_member_names_");
-    str name(name_);
-
-    if (member_map.contains(name))
-        fail("refusing to add duplicate key \"%s\" to enumeration \"%s\"!",
-             name_, type_name(tp).c_str());
-
-    object el = str_tp.attr("__new__")(tp, val);
-
-    el.attr("_name_") = name;
-    el.attr("__objclass__") = tp;
-    el.attr("_sort_order_") = len(member_names);
-    el.attr("_value_") = val;
-    el.attr("__doc__") = doc ? str(doc) : none();
 
     setattr(tp, name, el);
 

--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -46,10 +46,10 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
 
     bool is_arithmetic = ed->flags & (uint32_t) enum_flags::is_arithmetic;
     bool is_flag = ed->flags & (uint32_t) enum_flags::is_flag;
-    bool is_str_enum = ed->flags & (uint32_t) enum_flags::is_str_enum;
+    bool is_str = ed->flags & (uint32_t) enum_flags::is_str;
 
-    if (is_str_enum && (is_flag || is_arithmetic))
-        fail("nanobind: is_str_enum cannot be combined with is_flag or "
+    if (is_str && (is_flag || is_arithmetic))
+        fail("nanobind: is_str cannot be combined with is_flag or "
              "is_arithmetic (enumeration \"%s\")", ed->name);
 
     str name(ed->name), qualname = name;
@@ -75,17 +75,17 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
         factory_name = "Flag";
     else if (is_arithmetic)
         factory_name = "IntEnum";
-    else if (is_str_enum)
+    else if (is_str)
         factory_name = "StrEnum";
 
     object enum_mod = module_::import_("enum");
     object result;
-    handle str_tp((PyObject *) &PyUnicode_Type);
 
 #if PY_VERSION_HEX < 0x030B0000
     // enum.StrEnum was added in Python 3.11. On earlier versions, fall back to
     // bare Enum with type=str, which produces an equivalent class derived from (str, Enum).
-    if (is_str_enum) {
+    if (is_str) {
+        handle str_tp((PyObject *) &PyUnicode_Type);
         result = enum_mod.attr("Enum")(name, nanobind::tuple(),
                                        arg("module") = modname,
                                        arg("qualname") = qualname,
@@ -101,13 +101,8 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
     scope.attr(name) = result;
     result.attr("__doc__") = ed->docstr ? str(ed->docstr) : none();
 
-    if (is_str_enum) {
-        // Match stdlib StrEnum: str(member) returns the member's string value, not Enum.NAME.
-        result.attr("__str__") = str_tp.attr("__str__");
-    } else {
-        result.attr("__str__") = enum_mod.attr(is_flag ? factory_name : "Enum").attr("__str__");
-        result.attr("__repr__") = result.attr("__str__");
-    }
+    result.attr("__str__") = enum_mod.attr(is_flag ? factory_name : "Enum").attr("__str__");
+    result.attr("__repr__") = result.attr("__str__");
 
     type_init_data *t = new type_init_data();
     memset(t, 0, sizeof(type_data));
@@ -312,7 +307,7 @@ bool enum_from_python(const std::type_info *tp, PyObject *o, int64_t *out, uint8
     if (flags & (uint8_t) cast_flags::convert) {
         enum_map *fwd = (enum_map *) t->enum_tbl.fwd;
 
-        if (t->flags & (uint32_t) enum_flags::is_str_enum) {
+        if (t->flags & (uint32_t) enum_flags::is_str) {
             if (!isinstance<str>(o))
                 return false;
             PyObject *vmap = PyObject_GetAttrString(

--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -46,6 +46,11 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
 
     bool is_arithmetic = ed->flags & (uint32_t) enum_flags::is_arithmetic;
     bool is_flag = ed->flags & (uint32_t) enum_flags::is_flag;
+    bool is_str_enum = ed->flags & (uint32_t) enum_flags::is_str_enum;
+
+    if (is_str_enum && (is_flag || is_arithmetic))
+        fail("nanobind: is_str_enum cannot be combined with is_flag or "
+             "is_arithmetic (enumeration \"%s\")", ed->name);
 
     str name(ed->name), qualname = name;
     object modname;
@@ -70,18 +75,39 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
         factory_name = "Flag";
     else if (is_arithmetic)
         factory_name = "IntEnum";
+    else if (is_str_enum)
+        factory_name = "StrEnum";
 
-    object enum_mod = module_::import_("enum"),
-           factory = enum_mod.attr(factory_name),
-           result = factory(name, nanobind::tuple(),
-                            arg("module") = modname,
-                            arg("qualname") = qualname);
+    object enum_mod = module_::import_("enum");
+    object result;
+    handle str_tp((PyObject *) &PyUnicode_Type);
+
+#if PY_VERSION_HEX < 0x030B0000
+    // enum.StrEnum was added in Python 3.11. On earlier versions, fall back to
+    // bare Enum with type=str, which produces an equivalent class derived from (str, Enum).
+    if (is_str_enum) {
+        result = enum_mod.attr("Enum")(name, nanobind::tuple(),
+                                       arg("module") = modname,
+                                       arg("qualname") = qualname,
+                                       arg("type") = str_tp);
+    } else
+#endif
+    {
+        result = enum_mod.attr(factory_name)(name, nanobind::tuple(),
+                                             arg("module") = modname,
+                                             arg("qualname") = qualname);
+    }
 
     scope.attr(name) = result;
     result.attr("__doc__") = ed->docstr ? str(ed->docstr) : none();
 
-    result.attr("__str__") = enum_mod.attr(is_flag ? factory_name : "Enum").attr("__str__");
-    result.attr("__repr__") = result.attr("__str__");
+    if (is_str_enum) {
+        // Match stdlib StrEnum: str(member) returns the member's string value, not Enum.NAME.
+        result.attr("__str__") = str_tp.attr("__str__");
+    } else {
+        result.attr("__str__") = enum_mod.attr(is_flag ? factory_name : "Enum").attr("__str__");
+        result.attr("__repr__") = result.attr("__str__");
+    }
 
     type_init_data *t = new type_init_data();
     memset(t, 0, sizeof(type_data));
@@ -190,6 +216,58 @@ void enum_append(PyObject *tp_, const char *name_, int64_t value_,
     rev->emplace((int64_t) (uintptr_t) el.ptr(), value_);
 }
 
+void enum_append_str(PyObject *tp_, const char *name_, int64_t value_,
+                     const char *str_value_, const char *doc) noexcept {
+    handle tp(tp_), str_tp((PyObject *) &PyUnicode_Type);
+
+    type_data *t = enum_get_type_data(tp);
+
+    if (!(t->flags & (uint32_t) enum_flags::is_str_enum))
+        fail("enum_append_str(): enumeration \"%s\" was not declared as a "
+             "StrEnum (missing nb::is_str_enum())", t->name);
+
+    if (!issubclass(tp, str_tp))
+        fail("enum_append_str(): enumeration \"%s\" is not a string subclass",
+             t->name);
+
+    object val = steal(PyUnicode_InternFromString(str_value_));
+    if (!val.is_valid())
+        fail("enum_append_str(): unable to intern string value for \"%s.%s\"",
+             t->name, name_);
+
+    dict value_map = tp.attr("_value2member_map_"),
+         member_map = tp.attr("_member_map_");
+    list member_names = tp.attr("_member_names_");
+    str name(name_);
+
+    if (member_map.contains(name))
+        fail("refusing to add duplicate key \"%s\" to enumeration \"%s\"!",
+             name_, type_name(tp).c_str());
+
+    object el = str_tp.attr("__new__")(tp, val);
+
+    el.attr("_name_") = name;
+    el.attr("__objclass__") = tp;
+    el.attr("_sort_order_") = len(member_names);
+    el.attr("_value_") = val;
+    el.attr("__doc__") = doc ? str(doc) : none();
+
+    setattr(tp, name, el);
+
+    if (!value_map.contains(val)) {
+        member_names.append(name);
+        value_map[val] = el;
+    }
+
+    member_map[name] = el;
+
+    enum_map *fwd = (enum_map *) t->enum_tbl.fwd;
+    fwd->emplace(value_, (int64_t) (uintptr_t) el.ptr());
+
+    enum_map *rev = (enum_map *) t->enum_tbl.rev;
+    rev->emplace((int64_t) (uintptr_t) el.ptr(), value_);
+}
+
 bool enum_from_python(const std::type_info *tp, PyObject *o, int64_t *out, uint8_t flags) noexcept {
     type_data *t = nb_type_c2p(internals, tp);
     if (!t)
@@ -233,6 +311,30 @@ bool enum_from_python(const std::type_info *tp, PyObject *o, int64_t *out, uint8
 
     if (flags & (uint8_t) cast_flags::convert) {
         enum_map *fwd = (enum_map *) t->enum_tbl.fwd;
+
+        if (t->flags & (uint32_t) enum_flags::is_str_enum) {
+            if (!isinstance<str>(o))
+                return false;
+            PyObject *vmap = PyObject_GetAttrString(
+                (PyObject *) t->type_py, "_value2member_map_");
+            if (vmap) {
+                PyObject *member = PyDict_GetItemWithError(vmap, o);
+                Py_DECREF(vmap);
+                if (member) {
+                    enum_map::iterator it3 =
+                        rev->find((int64_t) (uintptr_t) member);
+                    if (it3 != rev->end()) {
+                        *out = it3->second;
+                        return true;
+                    }
+                } else if (PyErr_Occurred()) {
+                    PyErr_Clear();
+                }
+            } else {
+                PyErr_Clear();
+            }
+            return false;
+        }
 
         if (t->flags & (uint32_t) enum_flags::is_signed) {
             long long value = PyLong_AsLongLong(o);

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -640,7 +640,7 @@ class StubGen:
 
         if isinstance(parent, type) and issubclass(tp, parent):
             # This is an entry of an enumeration
-            self.write_ln(f"{name} = {typing.cast(enum.Enum, value)._value_}")
+            self.write_ln(f"{name} = {typing.cast(enum.Enum, value)._value_!r}")
             if value.__doc__ and self.include_docstrings:
                 self.put_docstr(value.__doc__)
             self.write("\n")

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -12,6 +12,7 @@ enum class UnsignedFlag : uint64_t {
      All = (uint64_t) -1,
 };
 enum class SEnum : int32_t { A, B, C = (int32_t) -1 };
+enum class Color { Red, Green, Blue };
 enum ClassicEnum { Item1, Item2 };
 
 struct EnumProperty { Enum get_enum() { return Enum::A; } };
@@ -127,4 +128,13 @@ NB_MODULE(test_enum_ext, m) {
     ew.def(nb::init_implicit<EnumWrapper::Value>())
       .def(nb::self == EnumWrapper::Value())
       .def("get_value", &EnumWrapper::get_value);
+
+    nb::enum_<Color>(m, "Color", "string-valued enum", nb::is_str_enum())
+        .str_value("Red",   Color::Red,   "red")
+        .str_value("Green", Color::Green, "green")
+        .str_value("Blue",  Color::Blue,  "blue");
+
+    m.def("from_color", [](Color c) { return (int) c; }, nb::arg().noconvert());
+    m.def("from_color_implicit", [](Color c) { return (int) c; });
+    m.def("to_color", [](int v) { return (Color) v; });
 }

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -129,7 +129,7 @@ NB_MODULE(test_enum_ext, m) {
       .def(nb::self == EnumWrapper::Value())
       .def("get_value", &EnumWrapper::get_value);
 
-    nb::enum_<Color>(m, "Color", "string-valued enum", nb::is_str_enum())
+    nb::enum_<Color>(m, "Color", "string-valued enum", nb::is_str())
         .str_value("Red",   Color::Red,   "red")
         .str_value("Green", Color::Green, "green")
         .str_value("Blue",  Color::Blue,  "blue");

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -208,11 +208,10 @@ def test12_str_enum():
     assert t.Color.__doc__ == "string-valued enum"
     assert t.Color.Red.__doc__ is None
 
-    # str() returns the member's string value,
-    # repr() keeps the default Enum form.
-    assert str(t.Color.Red) == "red"
-    assert str(t.Color.Green) == "green"
-    assert repr(t.Color.Red) == "<Color.Red: 'red'>"
+    assert str(t.Color.Red) == "Color.Red"
+    assert repr(t.Color.Red) == "Color.Red"
+    assert str(t.Color.Green) == "Color.Green"
+    assert repr(t.Color.Green) == "Color.Green"
 
     assert t.Color("red") is t.Color.Red
     assert t.Color("green") is t.Color.Green

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -228,8 +228,9 @@ def test12_str_enum():
     assert t.to_color(1) is t.Color.Green
     assert t.to_color(2) is t.Color.Blue
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         t.to_color(99)
+    assert '99 is not a valid Color' in str(excinfo.value)
 
     # convert: bare strings are accepted.
     assert t.from_color_implicit("red") == 0

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -193,6 +193,62 @@ def test09_enum_methods():
 def test10_enum_opaque():
     assert t.OpaqueEnum.X == t.OpaqueEnum("X") and t.OpaqueEnum.Y == t.OpaqueEnum("Y")
 
+def test12_str_enum():
+    assert isinstance(t.Color.Red, str)
+    assert isinstance(t.Color.Red, t.Color)
+    assert t.Color.Red == "red"
+    assert t.Color.Green == "green"
+    assert t.Color.Blue == "blue"
+
+    assert t.Color.Red.name == "Red"
+    assert t.Color.Red._name_ == "Red"
+    assert t.Color.Red.value == "red"
+    assert t.Color.Red._value_ == "red"
+
+    assert t.Color.__doc__ == "string-valued enum"
+    assert t.Color.Red.__doc__ is None
+
+    # str() returns the member's string value,
+    # repr() keeps the default Enum form.
+    assert str(t.Color.Red) == "red"
+    assert str(t.Color.Green) == "green"
+    assert repr(t.Color.Red) == "<Color.Red: 'red'>"
+
+    assert t.Color("red") is t.Color.Red
+    assert t.Color("green") is t.Color.Green
+    assert t.Color(t.Color.Blue) is t.Color.Blue
+
+    with pytest.raises(ValueError):
+        t.Color("not-a-color")
+
+    assert t.from_color(t.Color.Red) == 0
+    assert t.from_color(t.Color.Green) == 1
+    assert t.from_color(t.Color.Blue) == 2
+    assert t.to_color(0) is t.Color.Red
+    assert t.to_color(1) is t.Color.Green
+    assert t.to_color(2) is t.Color.Blue
+
+    with pytest.raises(ValueError):
+        t.to_color(99)
+
+    # convert: bare strings are accepted.
+    assert t.from_color_implicit("red") == 0
+    assert t.from_color_implicit("green") == 1
+    assert t.from_color_implicit("blue") == 2
+    assert t.from_color_implicit(t.Color.Red) == 0
+
+    with pytest.raises(TypeError):
+        t.from_color_implicit("not-a-color")
+
+    # convert: StrEnum is keyed by string value, not the underlying C++ integer.
+    with pytest.raises(TypeError):
+        t.from_color_implicit(0)
+
+    # noconvert: a bare string is not accepted, even if it would match.
+    with pytest.raises(TypeError):
+        t.from_color("red")
+
+
 def test11_enum_name_value_members():
     # Test for issue #1246: enums with members named 'name' or 'value'
     # When an enum has members named 'name' or 'value', accessing .name/.value

--- a/tests/test_enum_ext.pyi.ref
+++ b/tests/test_enum_ext.pyi.ref
@@ -153,9 +153,6 @@ class EnumWrapper:
 class Color(enum.StrEnum):
     """string-valued enum"""
 
-    def __str__(self, /):
-        """Return str(self)."""
-
     Red = 'red'
 
     Green = 'green'

--- a/tests/test_enum_ext.pyi.ref
+++ b/tests/test_enum_ext.pyi.ref
@@ -149,3 +149,21 @@ class EnumWrapper:
     def __eq__(self, arg: Value, /) -> bool: ...
 
     def get_value(self) -> Value: ...
+
+class Color(enum.StrEnum):
+    """string-valued enum"""
+
+    def __str__(self, /):
+        """Return str(self)."""
+
+    Red = 'red'
+
+    Green = 'green'
+
+    Blue = 'blue'
+
+def from_color(arg: Color) -> int: ...
+
+def from_color_implicit(arg: Color, /) -> int: ...
+
+def to_color(arg: int, /) -> Color: ...

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -52,6 +52,10 @@ def test01_check_stub_refs(p_ref, request):
         s_ref.insert(5, "")
         s_ref.insert(6, "from typing_extensions import CapsuleType")
 
+    if "test_enum_ext" in p_in.name and sys.version_info < (3, 11):
+        # fallback to Python 3.10's `(str, Enum)` MRO.
+        s_ref = [line.replace("(enum.StrEnum)", "(str, enum.Enum)") for line in s_ref]
+
     if "test_typing_ext" in p_in.name and sys.version_info < (3, 13):
         # The 'T4'/'T5' bindings from test_typing.cpp carry PEP 696 'default='
         # values (and pull in the Unpack/TypeVarTuple imports) that only exist


### PR DESCRIPTION
An `nb::enum_` annotated with `is_str_enum()` produces a `enum.StrEnum` on Python 3.11, and an `enum.Enum` with a `(str, Enum)` MRO in Python <3.11.

Adds a new `enum_::str_value()` API that takes a `const char*` name along with the enumeration value to be bound, such that the value is bound under the given name on the Python enum.

Also patch stubgen to put enum values by repr, otherwise enum string values are not quoted in the stub, which is an error.

----------------

As mentioned in https://github.com/wjakob/nanobind/discussions/1360.

Disclosure: I used Claude to help in the implementation, mostly the `enum_append_str` and `enum_from_python` bits.