### PR TITLE
Store ``nb::supplement<>`` outside of type instances

### DIFF
--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -73,7 +73,7 @@ enum class type_flags : uint32_t {
 /// for more efficient memory layout, but could move elsewhere if we run
 /// out of flags.
 enum class type_init_flags : uint32_t {
-    /// Is the 'supplement' field of the type_init_data structure set?
+    /// Is the 'supplement_size' field of the type_init_data structure set?
     has_supplement           = (1 << 19),
 
     /// Is the 'doc' field of the type_init_data structure set?
@@ -130,6 +130,8 @@ struct type_data {
     bool (*keep_shared_from_this_alive)(PyObject *) noexcept;
     uint32_t dictoffset;
     uint32_t weaklistoffset;
+    /// Out-of-line heap storage for an optional nb::supplement<T>
+    void *supplement;
 };
 
 /// Information about a type that is only relevant when it is being created
@@ -139,7 +141,7 @@ struct type_init_data : type_data {
     PyTypeObject *base_py;
     const char *doc;
     const PyType_Slot *type_slots;
-    size_t supplement;
+    size_t supplement_size;
 };
 
 NB_INLINE void type_extra_apply(type_init_data &t, const handle &h) {
@@ -195,7 +197,7 @@ NB_INLINE void type_extra_apply(type_init_data &t, supplement<T>) {
     static_assert(alignof(T) <= alignof(void *),
                   "The alignment requirement of the supplement is too high.");
     t.flags |= (uint32_t) type_init_flags::has_supplement | (uint32_t) type_flags::is_final;
-    t.supplement = sizeof(T);
+    t.supplement_size = sizeof(T);
 }
 
 enum class enum_flags : uint32_t {

--- a/src/nb_abi.h
+++ b/src/nb_abi.h
@@ -14,7 +14,7 @@
 
 /// Tracks the version of nanobind's internal data structures
 #ifndef NB_INTERNALS_VERSION
-#  define NB_INTERNALS_VERSION 19
+#  define NB_INTERNALS_VERSION 20
 #endif
 
 #if defined(__MINGW32__)

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -162,7 +162,6 @@ void default_exception_translator(const std::exception_ptr &p, void *) {
 
 // Initialized once when the module is loaded, no locking needed
 nb_internals *internals = nullptr;
-PyTypeObject *nb_meta_cache = nullptr;
 
 
 static const char* interned_c_strs[pyobj_name::string_count] {
@@ -222,17 +221,15 @@ static void init_internals(nb_internals *p) {
     p->nb_module = PyModule_NewObject(nb_name.ptr());
     new_object(p, p->nb_module);
 
+    // Construct nanobind's meta-meta class
     nb_meta_slots[0].pfunc = (PyObject *) &PyType_Type;
-    p->nb_meta = new_type(p, &nb_meta_spec);
-
-    p->nb_type_dict = PyDict_New();
-    new_object(p, p->nb_type_dict);
+    PyTypeObject *nb_meta = new_type(p, &nb_meta_spec);
 
     p->nb_func         = new_type(p, &nb_func_spec);
     p->nb_method       = new_type(p, &nb_method_spec);
     p->nb_bound_method = new_type(p, &nb_bound_method_spec);
 
-    check(p->nb_module && p->nb_meta && p->nb_type_dict && p->nb_func &&
+    check(p->nb_module && nb_meta && p->nb_func &&
               p->nb_method && p->nb_bound_method,
           "nanobind::detail::nb_module_exec(): initialization failed!");
 
@@ -262,11 +259,17 @@ static void init_internals(nb_internals *p) {
     };
 
     PyObject *dummy = PyType_FromMetaclass(
-        p->nb_meta, p->nb_module, &dummy_spec, nullptr);
+        nb_meta, p->nb_module, &dummy_spec, nullptr);
     p->type_data_offset =
-        (uint8_t *) PyObject_GetTypeData(dummy, p->nb_meta) - (uint8_t *) dummy;
+        (uint8_t *) PyObject_GetTypeData(dummy, nb_meta) - (uint8_t *) dummy;
     Py_DECREF(dummy);
 #endif
+
+    // Create the single metaclass shared by all bound types. This may
+    // access 'type_data_offset' defined just above.
+    p->nb_type = nb_type_create_metaclass(p, nb_meta);
+    check(p->nb_type, "nanobind::detail::nb_module_exec(): "
+                      "nb_type metaclass creation failed!");
 }
 
 void internals_inc_ref() {
@@ -282,15 +285,12 @@ void internals_dec_ref() {
     Py_CLEAR(p->lifeline);
 
     p->nb_module = nullptr;
-    p->nb_meta = nullptr;
-    p->nb_type_dict = nullptr;
+    p->nb_type = nullptr;
     p->nb_func = nullptr;
     p->nb_method = nullptr;
     p->nb_bound_method = nullptr;
     p->nb_static_property.store_release(nullptr);
     p->nb_ndarray.store_release(nullptr);
-
-    nb_meta_cache = nullptr;
 
     for (int i = 0; i < pyobj_name::total_count; ++i)
         static_pyobjects[i] = nullptr;
@@ -439,7 +439,6 @@ static void internals_cleanup() {
 
         delete p;
         internals = nullptr;
-        nb_meta_cache = nullptr;
     } else {
         if (print_leak_warnings) {
             fprintf(stderr, "nanobind: this is likely caused by a reference "
@@ -458,8 +457,6 @@ NB_NOINLINE void nb_module_exec(const char *name, PyObject *) {
     if (internals) {
         init_internals(internals);
         init_pyobjects(internals);
-        if (nb_meta_cache != internals->nb_meta)
-            nb_meta_cache = internals->nb_meta;
         internals_inc_ref();
         return;
     }
@@ -487,8 +484,6 @@ NB_NOINLINE void nb_module_exec(const char *name, PyObject *) {
 
         init_internals(internals);
         init_pyobjects(internals);
-        if (nb_meta_cache != internals->nb_meta)
-            nb_meta_cache = internals->nb_meta;
         internals_inc_ref();
 
         Py_DECREF(capsule);
@@ -512,8 +507,6 @@ NB_NOINLINE void nb_module_exec(const char *name, PyObject *) {
 
     init_internals(p);
     init_pyobjects(p);
-    if (nb_meta_cache != p->nb_meta)
-        nb_meta_cache = p->nb_meta;
 
 #if defined(NB_FREE_THREADED)
     p->nb_static_property_disabled = PyThread_tss_alloc();

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -291,15 +291,10 @@ struct nb_maybe_atomic {
  *
  * The following list clarifies locking semantics for each member.
  *
- * - `nb_module`, `nb_meta`, `nb_func`, `nb_method`, `nb_bound_method`,
+ * - `nb_module`, `nb_type`, `nb_func`, `nb_method`, `nb_bound_method`,
  *   `*_Type_tp_*`, `shard_count`, `is_alive_ptr`: these are initialized when
  *   loading the first nanobind extension within a domain, which happens within
  *   a critical section. They do not require locking.
- *
- * - `nb_type_dict`: created when the loading the first nanobind extension
- *   within a domain. While the dictionary itself is protected by its own
- *   lock, additional locking is needed to avoid races that create redundant
- *   entries. The `mutex` member is used for this.
  *
  * - `nb_static_property` and `nb_static_propert_descr_set`: created only once
  *   on demand, protected by `mutex`.
@@ -347,11 +342,8 @@ struct nb_internals {
     /// Internal nanobind module
     PyObject *nb_module;
 
-    /// Meta-metaclass of nanobind instances
-    PyTypeObject *nb_meta;
-
-    /// Dictionary with nanobind metaclass(es) for different payload sizes
-    PyObject *nb_type_dict;
+    /// The metaclass shared by every bound type
+    PyTypeObject *nb_type;
 
     /// Types of nanobind functions and methods
     PyTypeObject *nb_func, *nb_method, *nb_bound_method;
@@ -486,9 +478,12 @@ inline PyTypeObject *new_type(nb_internals *p, PyType_Spec *spec) {
 #endif
 
 extern nb_internals *internals;
-extern PyTypeObject *nb_meta_cache;
 
 extern char *type_name(const std::type_info *t);
+
+/// Construct 'nb_type' as an instance of the meta-metaclass 'nb_meta'
+extern PyTypeObject *nb_type_create_metaclass(nb_internals *p,
+                                              PyTypeObject *nb_meta) noexcept;
 
 // Forward declarations
 extern PyObject *inst_new_ext(PyTypeObject *tp, void *value);
@@ -505,16 +500,18 @@ NB_INLINE func_data *nb_func_data(void *o) {
     return (func_data *) (((char *) o) + sizeof(nb_func));
 }
 
-#if defined(Py_LIMITED_API)
-extern type_data *nb_type_data_static(PyTypeObject *o) noexcept;
-#endif
-
 /// Fetch the nanobind type record from a 'nb_type' instance
 NB_INLINE type_data *nb_type_data(PyTypeObject *o) noexcept{
     #if !defined(Py_LIMITED_API)
         return (type_data *) (((char *) o) + sizeof(PyHeapTypeObject));
     #else
-        return nb_type_data_static(o);
+        #if 1
+            // Fast path that can be inlines without spilling registers
+            return (type_data *) ((char *) o + internals->type_data_offset);
+        #else
+            // Equivalent non-inlined reference version:
+            return (type_data *) PyObject_GetTypeData((PyObject *) o, Py_TYPE((PyObject *) o));
+        #endif
     #endif
 }
 

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -438,6 +438,7 @@ static void nb_type_dealloc(PyObject *o) {
 
     bool initialized = t->name != nullptr;
     free((char *) t->name);
+    PyMem_Free(t->supplement);
     NB_SLOT(PyType_Type, tp_dealloc)(o);
 
     if (initialized)
@@ -489,6 +490,7 @@ static int nb_type_init(PyObject *self, PyObject *args, PyObject *kwds) {
     t->implicit.cpp = nullptr;
     t->implicit.py = nullptr;
     t->alias_chain = nullptr;
+    t->supplement = nullptr;
 
 #if defined(Py_LIMITED_API)
     t->vectorcall = nullptr;
@@ -927,74 +929,55 @@ static PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
     }
 }
 
-
-static PyTypeObject *nb_type_tp(size_t supplement) noexcept {
-    object key = steal(PyLong_FromSize_t(supplement));
-    nb_internals *internals_ = internals;
-
-    PyTypeObject *tp =
-        (PyTypeObject *) dict_get_item_ref_or_fail(internals_->nb_type_dict, key.ptr());
-
-    if (NB_UNLIKELY(!tp)) {
-        // Retry in critical section to avoid races that create the same nb_type
-        lock_internals guard(internals_);
-
-        tp = (PyTypeObject *) dict_get_item_ref_or_fail(internals_->nb_type_dict, key.ptr());
-        if (tp)
-            return tp;
-
+PyTypeObject *nb_type_create_metaclass(nb_internals *p,
+                                       PyTypeObject *nb_meta) noexcept {
 #if PY_VERSION_HEX >= 0x030C0000
-        int basicsize = -(int) (sizeof(type_data) + supplement),
-            itemsize = 0;
+    int basicsize = -(int) sizeof(type_data),
+        itemsize = 0;
 #else
-        int basicsize = (int) (PyType_Type.tp_basicsize + (sizeof(type_data) + supplement)),
-            itemsize = (int) PyType_Type.tp_itemsize;
+    int basicsize = (int) (PyType_Type.tp_basicsize + sizeof(type_data)),
+        itemsize = (int) PyType_Type.tp_itemsize;
 #endif
 
-        char name[17 + 20 + 1];
-        snprintf(name, sizeof(name), "nanobind.nb_type_%zu", supplement);
+    PyType_Slot slots[] = {
+        { Py_tp_base, &PyType_Type },
+        { Py_tp_dealloc, (void *) nb_type_dealloc },
+        { Py_tp_setattro, (void *) nb_type_setattro },
+        { Py_tp_init, (void *) nb_type_init },
+        { 0, nullptr },
+        { 0, nullptr }
+    };
 
-        PyType_Slot slots[] = {
-            { Py_tp_base, &PyType_Type },
-            { Py_tp_dealloc, (void *) nb_type_dealloc },
-            { Py_tp_setattro, (void *) nb_type_setattro },
-            { Py_tp_init, (void *) nb_type_init },
-            { 0, nullptr },
-            { 0, nullptr }
-        };
-
-        PyType_Spec spec = {
-            /* .name = */ name,
-            /* .basicsize = */ basicsize,
-            /* .itemsize = */ itemsize,
-            /* .flags = */ Py_TPFLAGS_DEFAULT | NB_TPFLAGS_IMMUTABLETYPE,
-            /* .slots = */ slots
-        };
+    PyType_Spec spec = {
+        /* .name = */ "nanobind.nb_type",
+        /* .basicsize = */ basicsize,
+        /* .itemsize = */ itemsize,
+        /* .flags = */ Py_TPFLAGS_DEFAULT | NB_TPFLAGS_IMMUTABLETYPE,
+        /* .slots = */ slots
+    };
 
 #if defined(Py_LIMITED_API)
-        PyMemberDef members[] = {
-            { "__vectorcalloffset__", Py_T_PYSSIZET, 0, Py_READONLY, nullptr },
-            { nullptr, 0, 0, 0, nullptr }
-        };
+    PyMemberDef members[] = {
+        { "__vectorcalloffset__", Py_T_PYSSIZET, 0, Py_READONLY, nullptr },
+        { nullptr, 0, 0, 0, nullptr }
+    };
 
-        // Workaround because __vectorcalloffset__ does not support Py_RELATIVE_OFFSET
-        members[0].offset = internals_->type_data_offset + offsetof(type_data, vectorcall);
+    // Workaround because __vectorcalloffset__ does not support Py_RELATIVE_OFFSET
+    members[0].offset = p->type_data_offset + offsetof(type_data, vectorcall);
 
-        if (NB_DYNAMIC_VERSION < 0x030E0000) {
-            slots[4] = { Py_tp_members, (void *) members };
-            spec.flags |= Py_TPFLAGS_HAVE_VECTORCALL;
-        }
+    if (NB_DYNAMIC_VERSION < 0x030E0000) {
+        slots[4] = { Py_tp_members, (void *) members };
+        spec.flags |= Py_TPFLAGS_HAVE_VECTORCALL;
+    }
 #endif
 
-        tp = (PyTypeObject *) nb_type_from_metaclass(
-            internals_->nb_meta, internals_->nb_module, &spec);
+    PyTypeObject *tp = (PyTypeObject *) nb_type_from_metaclass(
+        nb_meta, p->nb_module, &spec);
 
+    if (tp) {
         make_immortal((PyObject *) tp);
-
-        int rv = 1;
-        if (tp)
-            rv = PyDict_SetItem(internals_->nb_type_dict, key.ptr(), (PyObject *) tp);
-        check(rv == 0, "nb_type type creation failed!");
+        // Root the metaclass in the lifeline so it outlives every bound type.
+        new_object(p, (PyObject *) tp);
     }
 
     return tp;
@@ -1311,17 +1294,13 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
 
     *s++ = { 0, nullptr };
 
-    PyTypeObject *metaclass = nb_type_tp(has_supplement ? t->supplement : 0);
-
-    PyObject *result = nb_type_from_metaclass(metaclass, mod, &spec);
+    PyObject *result = nb_type_from_metaclass(internals_->nb_type, mod, &spec);
     if (!result) {
         python_error err;
         check(false,
               "nanobind::detail::nb_type_new(\"%s\"): type construction "
               "failed: %s!", t_name, err.what());
     }
-
-    Py_DECREF(metaclass);
 
     make_immortal(result);
     internals_inc_ref();
@@ -1358,6 +1337,16 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
     to->type_py = (PyTypeObject *) result;
     to->alias_chain = nullptr;
     to->init = nullptr;
+
+    if (has_supplement) {
+        to->supplement = PyMem_Malloc(t->supplement_size);
+        check(to->supplement,
+              "nanobind::detail::nb_type_new(\"%s\"): supplement allocation "
+              "failed!", t_name);
+        memset(to->supplement, 0, t->supplement_size);
+    } else {
+        to->supplement = nullptr;
+    }
 
     if (has_dynamic_attr)
         to->flags |= (uint32_t) type_flags::has_dynamic_attr;
@@ -2048,10 +2037,7 @@ PyObject *nb_type_lookup(const std::type_info *t) noexcept {
 }
 
 bool nb_type_check(PyObject *t) noexcept {
-    PyTypeObject *meta  = Py_TYPE(t),
-                 *meta2 = Py_TYPE((PyObject *) meta);
-
-    return meta2 == nb_meta_cache;
+    return internals->nb_type == Py_TYPE(t);
 }
 
 size_t nb_type_size(PyObject *t) noexcept {
@@ -2067,7 +2053,7 @@ const std::type_info *nb_type_info(PyObject *t) noexcept {
 }
 
 void *nb_type_supplement(PyObject *t) noexcept {
-    return nb_type_data((PyTypeObject *) t) + 1;
+    return nb_type_data((PyTypeObject *) t)->supplement;
 }
 
 PyObject *nb_inst_alloc(PyTypeObject *t) {
@@ -2230,12 +2216,6 @@ void nb_inst_replace_copy(PyObject *dst, const PyObject *src) noexcept {
     nb_inst_copy(dst, src);
     nbi->destruct = destruct;
 }
-
-#if defined(Py_LIMITED_API)
-type_data *nb_type_data_static(PyTypeObject *o) noexcept {
-    return (type_data *) PyObject_GetTypeData((PyObject *) o, Py_TYPE((PyObject *) o));
-}
-#endif
 
 PyObject *nb_type_name(PyObject *t) noexcept {
     error_scope s;


### PR DESCRIPTION
nanobind previously co-located the ``nb::supplement<T>`` data with the Python type object. That is nice in principle, but it also has costs

1. Complexity: nanobind must allocate a separate metaclass per supplement size

2. To reuse these metaclasses, they must be cached, which requires synchronization

3. The fact that nanobind types have different metaclasses makes ``nb_type_check()`` (which checks if a type is a nanobind type) more expensive. This function is on the critical path and adds latency to every binding call.

The supplement is a relatively niche feature, and I believe that those costs outweigh the (minor) benefit of co-location.

Changing this requires an ABI bump.