### PR TITLE
Accelerate thread-local variable access esp. on free-threaded Python

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -105,6 +105,15 @@ set(NB_OPT      $<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>> CACHE INTERNAL "")
 set(NB_OPT_SIZE $<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:RelWithDebInfo>> CACHE INTERNAL "")
 
 # ---------------------------------------------------------------------------
+# Probe for the faster TLSDESC thread-local storage ABI (Linux/x86_64)
+# ---------------------------------------------------------------------------
+
+if (NOT (MSVC OR WIN32 OR APPLE))
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-mtls-dialect=gnu2 NB_HAS_MTLS_GNU2)
+endif()
+
+# ---------------------------------------------------------------------------
 # Helper function to handle undefined CPython API symbols on macOS
 # ---------------------------------------------------------------------------
 
@@ -240,6 +249,11 @@ function (nanobind_build_library TARGET_NAME)
   else()
     # Generally needed to handle type punning in Python code
     target_compile_options(${TARGET_NAME} PRIVATE -fno-strict-aliasing)
+  endif()
+
+  # Use the faster TLSDESC model for libnanobind's thread_local accesses
+  if (NB_HAS_MTLS_GNU2)
+    target_compile_options(${TARGET_NAME} PRIVATE -mtls-dialect=gnu2)
   endif()
 
   if (WIN32)

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -13,6 +13,14 @@
 #include "nb_abi.h"
 #include <thread>
 
+#if defined(NB_FREE_THREADED)
+#  if defined(_WIN32)
+#    include <windows.h>
+#  else
+#    include <pthread.h>
+#  endif
+#endif
+
 #if defined(__GNUC__) && !defined(__clang__)
 #  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
@@ -163,6 +171,41 @@ void default_exception_translator(const std::exception_ptr &p, void *) {
 // Initialized once when the module is loaded, no locking needed
 nb_internals *internals = nullptr;
 PyTypeObject *nb_meta_cache = nullptr;
+
+#if defined(NB_FREE_THREADED)
+NB_THREAD_LOCAL nb_thread_state *nb_thread_state_tls = nullptr;
+
+// Reclaims a thread's state when it exits (the cleanup-key callback).
+static void nb_thread_state_destroy(void *p) noexcept {
+    nb_thread_state *ts = (nb_thread_state *) p;
+    if (!ts)
+        return;
+    nb_thread_state_tls = nullptr;
+    delete ts;
+}
+
+// Slow path for nb_thread_state_get(): allocate the per-thread state with a cleanup callback
+nb_thread_state *nb_thread_state_alloc() noexcept {
+#if defined(_WIN32)
+    DWORD key = internals->thread_state_key;
+    nb_thread_state *ts = (nb_thread_state *) FlsGetValue(key);
+    if (!ts) {
+        ts = new nb_thread_state();
+        check(FlsSetValue(key, ts), "nanobind: FlsSetValue() failed!");
+    }
+#else
+    pthread_key_t key = internals->thread_state_key;
+    nb_thread_state *ts = (nb_thread_state *) pthread_getspecific(key);
+    if (!ts) {
+        ts = new nb_thread_state();
+        check(pthread_setspecific(key, ts) == 0,
+              "nanobind: pthread_setspecific() failed!");
+    }
+#endif
+    nb_thread_state_tls = ts;
+    return ts;
+}
+#endif
 
 
 static const char* interned_c_strs[pyobj_name::string_count] {
@@ -505,6 +548,15 @@ NB_NOINLINE void nb_module_exec(const char *name, PyObject *) {
     shard_count *= 2;
     p->shards = new nb_shard[shard_count];
     p->shard_mask = shard_count - 1;
+
+    // Per-domain key for reclaiming nb_thread_state at thread exit
+#if defined(_WIN32)
+    p->thread_state_key = FlsAlloc((PFLS_CALLBACK_FUNCTION) nb_thread_state_destroy);
+    check(p->thread_state_key != FLS_OUT_OF_INDEXES, "nanobind: FlsAlloc() failed!");
+#else
+    check(pthread_key_create(&p->thread_state_key, nb_thread_state_destroy) == 0,
+          "nanobind: pthread_key_create() failed!");
+#endif
 #endif
     p->shard_count = shard_count;
 

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -14,7 +14,10 @@
 #include <nanobind/nanobind.h>
 #include <tsl/robin_map.h>
 #if defined(NB_FREE_THREADED)
-#include <atomic>
+#  include <atomic>
+#if !defined(_WIN32)
+#  include <pthread.h>
+#endif
 #endif
 #include <cstring>
 #include <string_view>
@@ -198,6 +201,25 @@ using nb_ptr_map  = tsl::robin_map<void *, void*, ptr_hash>;
 using nb_type_map_fast = nb_ptr_map;
 using nb_type_map_slow = tsl::robin_map<const std::type_info *, type_data *,
                                         std_typeinfo_hash, std_typeinfo_eq>;
+
+#if defined(NB_FREE_THREADED)
+// Per-thread state (currently just stores the C++ -> Python type cache)
+struct nb_thread_state {
+    nb_type_map_fast type_c2p_fast;
+};
+
+extern NB_THREAD_LOCAL nb_thread_state *nb_thread_state_tls;
+
+/// Slow path: allocate this thread's state and register a cleanup routine
+extern nb_thread_state *nb_thread_state_alloc() noexcept;
+
+NB_INLINE nb_thread_state *nb_thread_state_get() noexcept {
+    nb_thread_state *ts = nb_thread_state_tls;
+    if (NB_UNLIKELY(!ts))
+        ts = nb_thread_state_alloc();
+    return ts;
+}
+#endif
 
 /// Convenience functions to deal with the pointer encoding in 'internals.inst_c2p'
 
@@ -383,6 +405,15 @@ struct nb_internals {
 #else
     nb_shard shards[1];
     inline nb_shard &shard(void *) { return shards[0]; }
+#endif
+
+#if defined(NB_FREE_THREADED)
+    // Per-domain key for reclaiming nb_thread_state at thread exit
+#  if defined(_WIN32)
+    unsigned long thread_state_key;
+#  else
+    pthread_key_t thread_state_key;
+#  endif
 #endif
 
 #if !defined(NB_FREE_THREADED)

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -339,7 +339,7 @@ static void inst_dealloc(PyObject *self) {
 type_data *nb_type_c2p(nb_internals *internals_,
                        const std::type_info *type) {
 #if defined(NB_FREE_THREADED)
-    thread_local nb_type_map_fast type_c2p_fast;
+    nb_type_map_fast &type_c2p_fast = nb_thread_state_get()->type_c2p_fast;
 #else
     nb_type_map_fast &type_c2p_fast = internals_->type_c2p_fast;
 #endif


### PR DESCRIPTION
C++ provides the ``thread_local`` keyword to define per-thread variables aka. *thread-local storage* (TLS), which nanobind uses to maintain a per-thread cache of type data in free-threaded builds. Unfortunately, ``thread_local`` is extremely badly implemented by the current C++ ABI and compilers. A blog post by Yossi Kreinin [1] explains the problems at length.

On Linux/GCC, every access turns into a call to ``__tls_get_addr()``, which is shockingly expensive. For nontrivial types, the compiler inserts a *second* ``thread_local`` with its own ``__tls_get_addr()`` call just to see if the object is already initialized. Cross-TU dependences and declarations of TLS objects within functions exacerbate things further. nanobind made use of all of these features and paid for it: prior to this commit, the performance-critical ``nb_type_c2p()`` function that maps a Python type from C++ to Python altogether required 5 of these costly TLS ABI calls in sequence.

This commit bundles two changes:

1. It migrates TLS state into a single POD heap-allocated data structure, whose cleanup is done via OS APIs (``pthread_key`` / ``FlsAlloc``). This brings the number of ``__tls_get_addr()`` calls in ``nb_type_c2p()`` to 1.

2. A change in ``cmake/nanobind-config.cmake`` additionally opts ``libnanobind`` into the TLSDESC ABI (``-mtls-dialect=gnu2``) where supported, replacing the remaining ``__tls_get_addr()`` call with a lighter-weight TLS ABI. This mainly targets compilation on Linux/x86_64 via GCC, which represents an important case.

On a tight Python loop calling a nullary function that returns a bound object by value (one ``nb_type_c2p()`` lookup per call), TLS resolution falls from ~2.8% of runtime cost (5 calls) to ~0.9% (reorganized TLS state) to ~0.3% (TLSDESC). That benchmark represents the worst case, so code doing more work per call will see less of an improvement.

[1] https://yosefk.com/blog/cxx-thread-local-storage-performance.html