### PR TITLE
Skip refcounting of immortal objects on free-threaded builds

### DIFF
--- a/src/nb_enum.cpp
+++ b/src/nb_enum.cpp
@@ -30,7 +30,7 @@ PyObject *enum_create(enum_init_data *ed) noexcept {
                              "nanobind: type '%s' was already registered!\n",
                              ed->name);
             PyObject *tp = (PyObject *) it->second->type_py;
-            Py_INCREF(tp);
+            NB_INCREF_ENUM(tp);
             return tp;
         }
     }

--- a/src/nb_ft.h
+++ b/src/nb_ft.h
@@ -9,6 +9,28 @@
 
 #pragma once
 
+/* Nanobind immortalizes type objects, enums, and function objects on FT builds.
+   Reference counting operations on these can be completely skipped when it is
+   known that the target object is immortal. On non-FT builds, these forward
+   to Py_{INC,DEC}REF/Py_CLEAR */
+#if defined(Py_GIL_DISABLED)
+#  define NB_INCREF_TYPE(o) ((void) (o))
+#  define NB_DECREF_TYPE(o) ((void) (o))
+#  define NB_INCREF_ENUM(o) ((void) (o))
+#  define NB_DECREF_ENUM(o) ((void) (o))
+#  define NB_INCREF_FUNC(o) ((void) (o))
+#  define NB_DECREF_FUNC(o) ((void) (o))
+#  define NB_CLEAR_FUNC(o) ((o) = nullptr)
+#else
+#  define NB_INCREF_TYPE(o) Py_INCREF(o)
+#  define NB_DECREF_TYPE(o) Py_DECREF(o)
+#  define NB_INCREF_ENUM(o) Py_INCREF(o)
+#  define NB_DECREF_ENUM(o) Py_DECREF(o)
+#  define NB_INCREF_FUNC(o) Py_INCREF(o)
+#  define NB_DECREF_FUNC(o) Py_DECREF(o)
+#  define NB_CLEAR_FUNC(o) Py_CLEAR(o)
+#endif
+
 #if !defined(Py_GIL_DISABLED)
 /// Trivial implementations for non-free-threaded Python
 inline void make_immortal(PyObject *) noexcept { }

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -144,7 +144,7 @@ int nb_bound_method_clear(PyObject *self) {
 void nb_bound_method_dealloc(PyObject *self) {
     nb_bound_method *mb = (nb_bound_method *) self;
     PyObject_GC_UnTrack(self);
-    Py_DECREF((PyObject *) mb->func);
+    NB_DECREF_FUNC((PyObject *) mb->func);
     Py_DECREF(mb->self);
     PyObject_GC_Del(self);
 }
@@ -254,9 +254,9 @@ PyObject *nb_func_new(const func_data_prelim_base *f) noexcept {
                 /* Never append a method to an overload chain of a parent class;
                    instead, hide the parent's overloads in this case */
                 if (fp->scope != f->scope)
-                    Py_CLEAR(func_prev);
+                    NB_CLEAR_FUNC(func_prev);
             } else if (name_cstr[0] == '_') {
-                Py_CLEAR(func_prev);
+                NB_CLEAR_FUNC(func_prev);
             } else {
                 check(false,
                       "nb::detail::nb_func_new(\"%s\"): cannot overload "
@@ -340,7 +340,7 @@ PyObject *nb_func_new(const func_data_prelim_base *f) noexcept {
               "nanobind::detail::nb_func_new(): internal update failed (1)!");
 #endif
 
-        Py_CLEAR(func_prev);
+        NB_CLEAR_FUNC(func_prev);
     }
 
     func->max_nargs = max_nargs;
@@ -498,7 +498,7 @@ PyObject *nb_func_new(const func_data_prelim_base *f) noexcept {
     if (return_ref) {
         return (PyObject *) func;
     } else {
-        Py_DECREF(func);
+        NB_DECREF_FUNC(func);
         return nullptr;
     }
 }
@@ -1190,12 +1190,12 @@ PyObject *nb_method_descr_get(PyObject *self, PyObject *inst, PyObject *) {
         mb->self = inst;
         mb->vectorcall = nb_bound_method_vectorcall;
 
-        Py_INCREF(self);
+        NB_INCREF_FUNC(self);
         Py_INCREF(inst);
 
         return (PyObject *) mb;
     } else {
-        Py_INCREF(self);
+        NB_INCREF_FUNC(self);
         return self;
     }
 }

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -90,7 +90,7 @@ PyObject *inst_new_int(PyTypeObject *tp, PyObject * /* args */,
             nb_enable_try_inc_ref((PyObject *) self);
 
             // The revived object must hold a reference to its type object
-            Py_INCREF((PyObject *) tp);
+            NB_INCREF_TYPE((PyObject *) tp);
 
             return (PyObject *) self;
         }
@@ -341,7 +341,7 @@ static void inst_dealloc(PyObject *self) {
             // There is space in the pool. Stash the object and release its
             // reference to the type object.
             pool->slots[pool->count++] = inst;
-            Py_DECREF(tp);
+            NB_DECREF_TYPE(tp);
             return;
         }
 
@@ -466,7 +466,7 @@ static void inst_dealloc(PyObject *self) {
     else
         PyObject_Free(self);
 
-    Py_DECREF(tp);
+    NB_DECREF_TYPE(tp);
 }
 
 
@@ -1222,7 +1222,7 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
                              "nanobind: type '%s' was already registered!\n",
                              t_name);
             PyObject *tp = (PyObject *) it->second->type_py;
-            Py_INCREF(tp);
+            NB_INCREF_TYPE(tp);
             if (has_signature)
                 free((char *) t_name);
             return tp;


### PR DESCRIPTION
On free-threaded builds, nanobind immortalizes type objects, enums, and function objects. Reference counting operations on immortal objects are already cheap and uncontended, but they are not entirely free. Since the target is known to be immortal, these operations can be skipped outright.

Introduce `NB_{INC,DEC}REF_{TYPE,ENUM,FUNC}` and `NB_CLEAR_FUNC` macros that compile to no-ops when `Py_GIL_DISABLED` is set, and forward to the usual `Py_{INC,DEC}REF/Py_CLEAR` otherwise. Replace the relevant refcount calls on type/enum/function objects in `nb_type.cpp`, `nb_enum.cpp`, and `nb_func.cpp` with these macros.