### PR TITLE
Performance optimization of nanobind's critical path

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -318,10 +318,12 @@ function(nanobind_opt_size name)
 endfunction()
 
 function(nanobind_disable_stack_protector name)
-  if (NOT MSVC)
-    # The stack protector affects binding size negatively (+8% on Linux in my
-    # benchmarks). Protecting from stack smashing in a Python VM seems in any
-    # case futile, so let's get rid of it by default in optimized modes.
+  # Drop the stack protector in optimized builds (it adds ~9-12% binary size
+  # and 1-2% runtime overheads, see docs/api_cmake.rst for the rationale).
+  # Pass PROTECT_STACK to opt out.
+  if (MSVC)
+    target_compile_options(${name} PRIVATE $<${NB_OPT}:$<$<COMPILE_LANGUAGE:CXX>:/GS->>)
+  else()
     target_compile_options(${name} PRIVATE $<${NB_OPT}:-fno-stack-protector>)
   endif()
 endfunction()
@@ -414,6 +416,12 @@ function(nanobind_add_module name)
     set(libname "${libname}-ft")
   endif()
 
+  # The stack protector changes how libnanobind is compiled, so the protected
+  # variant needs its own library (like -abi3 / -ft).
+  if (ARG_PROTECT_STACK)
+    set(libname "${libname}-ps")
+  endif()
+
   if (ARG_NB_DOMAIN AND ARG_NB_SHARED)
     set(libname ${libname}-${ARG_NB_DOMAIN})
   endif()
@@ -443,6 +451,7 @@ function(nanobind_add_module name)
 
   if (NOT ARG_PROTECT_STACK)
     nanobind_disable_stack_protector(${name})
+    nanobind_disable_stack_protector(${libname})
   endif()
 
   if (NOT ARG_NOMINSIZE)

--- a/docs/api_cmake.rst
+++ b/docs/api_cmake.rst
@@ -91,7 +91,8 @@ The high-level interface consists of just one CMake command:
           raises the warning level via flags like ``-pedantic``, ``-Wcast-qual``,
           ``-Wsign-conversion``.
       * - ``PROTECT_STACK``
-        - Don't remove stack smashing-related protections.
+        - Keep the stack protector enabled (for both the extension and
+          nanobind's core library).
       * - ``LTO``
         - Perform link time optimization.
       * - ``NOMINSIZE``
@@ -172,13 +173,22 @@ The high-level interface consists of just one CMake command:
      Size optimizations can be disabled by specifying the optional
      ``NOMINSIZE`` argument, though doing so is not recommended.
 
-   - ``nanobind_add_module()`` also disables stack-smashing protections
-     (i.e., it specifies ``-fno-stack-protector`` to Clang/GCC).
-     Protecting against such vulnerabilities in a Python VM seems futile,
-     and it adds non-negligible extra cost (+8% binary size in
-     benchmarks). This behavior can be disabled by specifying the optional
-     ``PROTECT_STACK`` flag. Either way, is not recommended that you use
-     nanobind in a setting where it presents an attack surface.
+   - On Linux, GCC normally compiles code with ``-fstack-protector-strong``,
+     which inserts stack canaries to defend against attacks where a buffer
+     overflow writes past a stack buffer into the saved return address.
+
+     This defense is especially costly for nanobind-based bindings, where it
+     instruments every function binding wrapper and all ndarray-related code.
+     In the test suite, it increases binary size by ~9-12% while adding 1-2%
+     runtime cost. The thread model is questionable in this context, since
+     the arrays being processed are either controlled by Python or validated
+     by nanobind.
+
+     The build system therefore disables the stack protector for both the user
+     extension and ``libnanobind`` (``-fno-stack-protector`` on Clang/GCC,
+     ``/GS-`` on MSVC). To opt out of this feature, pass ``PROTECT_STACK`` to
+     :cmake:command:`nanobind_add_module`, which reverts to the compiler's
+     default behavior.
 
    - It sets the default symbol visibility to ``hidden`` so that only functions
      and types specifically marked for export generate symbols in the resulting
@@ -327,10 +337,11 @@ The various commands are described below:
 
 .. cmake:command:: nanobind_disable_stack_protector
 
-   The stack protector affects the binary size of bindings negatively (+8%
-   on Linux in benchmarks). Protecting from stack smashing in a Python VM
-   seems in any case futile, so this function disables it for the specified
-   target when performing a build with optimizations. Use it as follows:
+   Disables the stack-smashing protector for the specified target in optimized
+   builds. The canary guards against stack buffer overflows, but nanobind's hot
+   path has only fixed-size stack arrays indexed by the validated argument
+   count, so it is pure overhead there (+8% binary size on Linux). Use it as
+   follows:
 
    .. code-block:: cmake
 

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -214,7 +214,11 @@ enum cast_flags : uint8_t {
     // This implies that objects added to the cleanup list may be
     // released immediately after the caster's final output value is
     // obtained, i.e., before it is used.
-    manual = (1 << 3)
+    manual = (1 << 3),
+
+    /// Indicate that a type is being constructed by nb_type_vectorcall. The
+    /// call dispatcher uses this hint to avoid type-checking ``self``
+    trusted = (1 << 4)
 };
 
 

--- a/include/nanobind/nb_attr.h
+++ b/include/nanobind/nb_attr.h
@@ -210,15 +210,19 @@ enum cast_flags : uint8_t {
     // Indicates that the function dispatcher should accept 'None' arguments
     accepts_none = (1 << 2),
 
+    /// The target binds the value by reference or value (not as a pointer), so
+    /// a 'None' argument has no valid mapping.
+    none_disallowed = (1 << 3),
+
     // Indicates that this cast is performed by nb::cast or nb::try_cast.
     // This implies that objects added to the cleanup list may be
     // released immediately after the caster's final output value is
     // obtained, i.e., before it is used.
-    manual = (1 << 3),
+    manual = (1 << 4),
 
     /// Indicate that a type is being constructed by nb_type_vectorcall. The
     /// call dispatcher uses this hint to avoid type-checking ``self``
-    trusted = (1 << 4)
+    trusted = (1 << 5)
 };
 
 

--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -269,7 +269,7 @@ template <> struct type_caster<bool> {
     }
 
     static handle from_cpp(bool src, rv_policy, cleanup_list *) noexcept {
-        return handle(src ? Py_True : Py_False).inc_ref();
+        return src ? true_ref() : false_ref();
     }
 
     NB_TYPE_CASTER(bool, const_name("bool"))
@@ -294,11 +294,8 @@ template <> struct type_caster<char> {
 
     static handle from_cpp(const char *value, rv_policy,
                            cleanup_list *) noexcept {
-        if (value == nullptr) {
-            PyObject* result = Py_None;
-            Py_INCREF(result);
-            return result;
-        }
+        if (value == nullptr)
+            return none_ref();
         return PyUnicode_FromString(value);
     }
 

--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -75,6 +75,13 @@ using precise_cast_t =
                        std::conditional_t<std::is_rvalue_reference_v<T>,
                                           intrinsic_t<T> &&, intrinsic_t<T> &>>;
 
+/// Type trait to detect arguments where a value/reference cast excludes ``None``
+template <typename T>
+inline constexpr uint8_t none_disallowed_flag =
+    (is_base_caster_v<make_caster<T>> &&
+     !std::is_pointer_v<std::remove_reference_t<T>>)
+        ? (uint8_t) cast_flags::none_disallowed : 0;
+
 /// Many type casters delegate to another caster using the pattern:
 /// ~~~ .cc
 /// bool from_python(handle src, uint8_t flags, cleanup_list *cl) noexcept {
@@ -105,6 +112,7 @@ NB_INLINE uint8_t flags_for_local_caster(uint8_t flags) noexcept {
             if (flags & ((uint8_t) cast_flags::manual))
                 flags &= ~((uint8_t) cast_flags::convert);
         }
+        flags |= none_disallowed_flag<T>;
     } else {
         /* Any pointer produced by a non-base caster will generally point
            into storage owned by the caster, which won't live long enough.
@@ -509,16 +517,9 @@ template <typename Type_> struct type_caster_base : type_caster_base_tag {
     }
 
     operator Type*() { return value; }
-
-    operator Type&() {
-        raise_next_overload_if_null(value);
-        return *value;
-    }
-
-    operator Type&&() {
-        raise_next_overload_if_null(value);
-        return (Type &&) *value;
-    }
+    // Code using this cast operator must ensure it is safe (see none_disallowed)
+    operator Type&() { return *value; }
+    operator Type&&() { return (Type &&) *value; }
 
 private:
     Type *value;

--- a/include/nanobind/nb_cast.h
+++ b/include/nanobind/nb_cast.h
@@ -324,6 +324,12 @@ template <typename T> struct type_caster<pointer_and_handle<T>> {
     NB_TYPE_CASTER(T2, Caster::Name)
 
     bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+        // Fast path for implicit ``self`` argument from ``nb_type_vectorcall()``
+        if (flags & (uint8_t) cast_flags::trusted) {
+            value.h = src;
+            value.p = (T *) nb_inst_ptr(src.ptr());
+            return true;
+        }
         Caster c;
         if (!c.from_python(src, flags_for_local_caster<T*>(flags), cleanup) ||
             !c.template can_cast<T*>())
@@ -463,6 +469,10 @@ template <typename Type_> struct type_caster_base : type_caster_base_tag {
 
     NB_INLINE bool from_python(handle src, uint8_t flags,
                                cleanup_list *cleanup) noexcept {
+        // The 'trusted' fast path lives in the pointer_and_handle caster (the
+        // only one that is ever trusted) and, as a fallback, in nb_type_get.
+        // The generic base caster therefore need not test for it here, which
+        // would only add a never-taken branch to every bound-type argument.
         return nb_type_get(&typeid(Type), src.ptr(), flags, cleanup,
                            (void **) &value);
     }

--- a/include/nanobind/nb_class.h
+++ b/include/nanobind/nb_class.h
@@ -21,6 +21,9 @@ enum class type_flags : uint32_t {
     /// Does the type provide a C++ move constructor?
     is_move_constructible    = (1 << 2),
 
+    /// Cached copy of Py_TPFLAGS_HAVE_GC
+    has_gc                   = (1 << 3),
+
     /// Is the 'destruct' field of the type_data structure set?
     has_destruct             = (1 << 4),
 

--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -87,6 +87,13 @@
 #  define NB_TYPING_CAPSULE "types.CapsuleType"
 #endif
 
+// Singletons (True, False, None) are immortal on 3.12+ / 3.12 stable ABI
+#if defined(Py_LIMITED_API) || PY_VERSION_HEX >= 0x030C0000
+#  define NB_IMMORTAL_SINGLETONS 1
+#else
+#  define NB_IMMORTAL_SINGLETONS 0
+#endif
+
 #if defined(Py_LIMITED_API)
 #  if PY_VERSION_HEX < 0x030C0000 || defined(PYPY_VERSION)
 #    error "nanobind can target Python's limited API, but this requires CPython >= 3.12"

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -277,8 +277,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
 #else
             cap->func(in.template get<Is>().operator cast_t<Args>()...);
 #endif
-            result = Py_None;
-            Py_INCREF(result);
+            result = none_ref();
         } else {
 #if defined(_WIN32) && !defined(__CUDACC__) // temporary workaround for an internal compiler error in MSVC
             result = cast_out::from_cpp(

--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -332,6 +332,18 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
                      (uint8_t) cast_flags::accepts_none, true)), ...);
     }
 
+    // Record 'none_disallowed' (nonzero only for value/reference bound-type
+    // targets) in the per-argument flag at bind time. The dispatcher carries
+    // it into the call via 'args_flags', so the heavily-inlined function
+    // trampoline need not OR it in at every from_python() invocation. Simple
+    // overloads ignore the per-argument flags but reject 'None' up front, so
+    // the bit is only consulted where 'None' can actually reach a caster.
+    if constexpr (has_arg_annotations) {
+        ((void)(Is >= (size_t)is_method_det &&
+                (f.args[Is - is_method_det].flag |=
+                     none_disallowed_flag<Args>, true)), ...);
+    }
+
     return nb_func_new(&f);
 }
 

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -108,9 +108,6 @@ NB_CORE void fail(const char *fmt, ...) noexcept;
 /// Raise nanobind::python_error after an error condition was found
 [[noreturn]] NB_CORE void raise_python_error();
 
-/// Raise nanobind::next_overload
-NB_CORE void raise_next_overload_if_null(void *p);
-
 /// Raise nanobind::cast_error
 [[noreturn]] NB_CORE void raise_python_or_cast_error();
 

--- a/include/nanobind/nb_lib.h
+++ b/include/nanobind/nb_lib.h
@@ -581,6 +581,10 @@ NB_CORE int dict_get_item_ref(PyObject *d, PyObject *k, PyObject **value);
 
 NB_CORE const char *abi_tag();
 
+NB_INLINE PyObject *none_ref() noexcept { Py_RETURN_NONE; }
+NB_INLINE PyObject *true_ref() noexcept { Py_RETURN_TRUE; }
+NB_INLINE PyObject *false_ref() noexcept { Py_RETURN_FALSE; }
+
 NAMESPACE_END(detail)
 
 using detail::raise;

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -395,7 +395,8 @@ class bool_ : public object {
         : object(detail::bool_from_obj(h.ptr()), detail::borrow_t{}) { }
 
     explicit bool_(bool value)
-        : object(value ? Py_True : Py_False, detail::borrow_t{}) { }
+        : object(value ? detail::true_ref() : detail::false_ref(),
+                 detail::steal_t{}) { }
 
     explicit operator bool() const {
         return m_ptr == Py_True;

--- a/include/nanobind/stl/pair.h
+++ b/include/nanobind/stl/pair.h
@@ -41,8 +41,8 @@ template <typename T1, typename T2> struct type_caster<std::pair<T1, T2>> {
         temp_ref = steal(temp);
 
         return o &&
-               caster1.from_python(o[0], flags, cleanup) &&
-               caster2.from_python(o[1], flags, cleanup);
+               caster1.from_python(o[0], flags_for_local_caster<T1>(flags), cleanup) &&
+               caster2.from_python(o[1], flags_for_local_caster<T2>(flags), cleanup);
     }
 
     template <typename T>

--- a/include/nanobind/stl/tuple.h
+++ b/include/nanobind/stl/tuple.h
@@ -49,7 +49,8 @@ template <typename... Ts> struct type_caster<std::tuple<Ts...>> {
         temp_ref = steal(temp);
 
         return (o && ... &&
-                std::get<Is>(casters).from_python(o[Is], flags, cleanup));
+                std::get<Is>(casters).from_python(
+                    o[Is], flags_for_local_caster<Ts>(flags), cleanup));
     }
 
     template <typename T>

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -108,11 +108,6 @@ void raise_python_error() {
     throw python_error();
 }
 
-void raise_next_overload_if_null(void *p) {
-    if (NB_UNLIKELY(!p))
-        throw next_overload();
-}
-
 void raise_python_or_cast_error() {
     if (PyErr_Occurred())
         throw python_error();

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -318,8 +318,10 @@ PyObject *nb_func_new(const func_data_prelim_base *f) noexcept {
         if (has_args) {
             for (size_t i = is_method; i < f->nargs; ++i) {
                 arg_data &a = args_in[i - is_method];
+                uint8_t dispatch_flags =
+                    a.flag & ~(uint8_t) cast_flags::none_disallowed;
                 medium_call |= a.name != nullptr || a.value != nullptr ||
-                               a.flag != cast_flags::convert;
+                               dispatch_flags != cast_flags::convert;
             }
         }
 

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -1596,8 +1596,7 @@ static PyObject *nb_func_get_qualname(PyObject *self) {
             return PyUnicode_FromString(f->name);
         }
     } else {
-        Py_INCREF(Py_None);
-        return Py_None;
+        return none_ref();
     }
 }
 
@@ -1608,8 +1607,7 @@ static PyObject *nb_func_get_module(PyObject *self) {
                                                ? NB_INTERNED(__name__)
                                                : NB_INTERNED(__module__));
     } else {
-        Py_INCREF(Py_None);
-        return Py_None;
+        return none_ref();
     }
 }
 

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -1188,9 +1188,10 @@ static PyObject *nb_func_vectorcall_simple_1(PyObject *self,
     if (kwargs_in == nullptr && nargs_in == 1 && args_in[0] != Py_None) {
         PyObject *arg = args_in[0];
         cleanup_list cleanup(is_method ? arg : nullptr);
-        uint8_t args_flags[1] = {
-            (uint8_t) (is_constructor ? (1 | (uint8_t) cast_flags::construct) : 1)
-        };
+        uint8_t self_flag = 1 | (uint8_t) cast_flags::construct;
+        if (nargsf & NB_VECTORCALL_TRUSTED_SELF)
+            self_flag |= (uint8_t) cast_flags::trusted;
+        uint8_t args_flags[1] = { (uint8_t) (is_constructor ? self_flag : 1) };
 
         try {
             result = fr->impl((void *) fr->capture, (PyObject **) args_in,
@@ -1247,8 +1248,11 @@ static PyObject *nb_func_vectorcall_simple_2(PyObject *self,
     if (kwargs_in == nullptr && nargs_in == 2 &&
         args_in[0] != Py_None && args_in[1] != Py_None) {
         cleanup_list cleanup(is_method ? args_in[0] : nullptr);
+        uint8_t self_flag = 1 | (uint8_t) cast_flags::construct;
+        if (nargsf & NB_VECTORCALL_TRUSTED_SELF)
+            self_flag |= (uint8_t) cast_flags::trusted;
         uint8_t args_flags[2] = {
-            (uint8_t) (is_constructor ? (1 | (uint8_t) cast_flags::construct) : 1),
+            (uint8_t) (is_constructor ? self_flag : 1),
             1
         };
 

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -631,7 +631,7 @@ static PyObject *nb_func_vectorcall_complex(PyObject *self,
                                             size_t nargsf,
                                             PyObject *kwargs_in) noexcept {
     const size_t count      = (size_t) Py_SIZE(self),
-                 nargs_in   = (size_t) PyVectorcall_NARGS(nargsf),
+                 nargs_in   = (size_t) NB_VECTORCALL_NARGS(nargsf),
                  nkwargs_in = kwargs_in ? (size_t) NB_TUPLE_GET_SIZE(kwargs_in) : 0;
 
     func_data *fr = nb_func_data(self);
@@ -914,7 +914,7 @@ static NB_NOINLINE PyObject *
 nb_func_vectorcall_medium_pos(PyObject *self, PyObject *const *args_in,
                               size_t nargsf, PyObject *kwargs_in) noexcept {
     const size_t count    = (size_t) Py_SIZE(self),
-                 nargs_in = (size_t) PyVectorcall_NARGS(nargsf);
+                 nargs_in = (size_t) NB_VECTORCALL_NARGS(nargsf);
 
     func_data *fr = nb_func_data(self);
 
@@ -1045,7 +1045,7 @@ static PyObject *nb_func_vectorcall_simple(PyObject *self,
     func_data *fr = nb_func_data(self);
 
     const size_t count         = (size_t) Py_SIZE(self),
-                 nargs_in      = (size_t) PyVectorcall_NARGS(nargsf);
+                 nargs_in      = (size_t) NB_VECTORCALL_NARGS(nargsf);
 
     const bool is_method      = fr->flags & (uint32_t) func_flags::is_method,
                is_constructor = fr->flags & (uint32_t) func_flags::is_constructor;
@@ -1135,7 +1135,7 @@ static PyObject *nb_func_vectorcall_simple_0(PyObject *self,
                                              size_t nargsf,
                                              PyObject *kwargs_in) noexcept {
     func_data *fr = nb_func_data(self);
-    const size_t nargs_in = (size_t) PyVectorcall_NARGS(nargsf);
+    const size_t nargs_in = (size_t) NB_VECTORCALL_NARGS(nargsf);
 
     // Handler routine that will be invoked in case of an error condition
     PyObject *(*error_handler)(PyObject *, PyObject *const *, size_t,
@@ -1175,7 +1175,7 @@ static PyObject *nb_func_vectorcall_simple_1(PyObject *self,
                                              size_t nargsf,
                                              PyObject *kwargs_in) noexcept {
     func_data *fr = nb_func_data(self);
-    const size_t nargs_in = (size_t) PyVectorcall_NARGS(nargsf);
+    const size_t nargs_in = (size_t) NB_VECTORCALL_NARGS(nargsf);
     const bool is_method      = fr->flags & (uint32_t) func_flags::is_method,
                is_constructor = fr->flags & (uint32_t) func_flags::is_constructor;
 
@@ -1234,7 +1234,7 @@ static PyObject *nb_func_vectorcall_simple_2(PyObject *self,
                                              size_t nargsf,
                                              PyObject *kwargs_in) noexcept {
     func_data *fr = nb_func_data(self);
-    const size_t nargs_in = (size_t) PyVectorcall_NARGS(nargsf);
+    const size_t nargs_in = (size_t) NB_VECTORCALL_NARGS(nargsf);
     const bool is_method      = fr->flags & (uint32_t) func_flags::is_method,
                is_constructor = fr->flags & (uint32_t) func_flags::is_constructor;
 
@@ -1293,7 +1293,7 @@ static PyObject *nb_bound_method_vectorcall(PyObject *self,
                                             size_t nargsf,
                                             PyObject *kwargs_in) noexcept {
     nb_bound_method *mb = (nb_bound_method *) self;
-    size_t nargs = (size_t) PyVectorcall_NARGS(nargsf);
+    size_t nargs = (size_t) NB_VECTORCALL_NARGS(nargsf);
     const size_t buf_size = 5;
     PyObject **args, *args_buf[buf_size], *temp = nullptr, *result;
     bool alloc = false;

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -34,6 +34,12 @@
 #  define NB_THREAD_LOCAL __thread
 #endif
 
+// Decodes the call argument count to avoid all use of ``PyVectorcall_NARGS()``.
+// The latter requires an indirect PLT call in the stable ABI, which is
+// unnecessary as its behavior is fully frozen by the stable ABI contract.
+#define NB_VECTORCALL_NARGS(n)                                                  \
+    ((Py_ssize_t) ((n) & ~PY_VECTORCALL_ARGUMENTS_OFFSET))
+
 #if PY_VERSION_HEX >= 0x030A0000
 #  define NB_TPFLAGS_IMMUTABLETYPE Py_TPFLAGS_IMMUTABLETYPE
 #else

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -34,11 +34,18 @@
 #  define NB_THREAD_LOCAL __thread
 #endif
 
-// Decodes the call argument count to avoid all use of ``PyVectorcall_NARGS()``.
-// The latter requires an indirect PLT call in the stable ABI, which is
-// unnecessary as its behavior is fully frozen by the stable ABI contract.
+// When forwarding vector calls between functions that are known to be implemented by
+// nanobind, it uses an extended ABI that may set one additional bit to communicate
+// that the implicit 'self' argument is trusted and does not need to be type-checked.
+#define NB_VECTORCALL_TRUSTED_SELF (PY_VECTORCALL_ARGUMENTS_OFFSET >> 1)
+
+// Decodes the call argument count to avoid all use of ``PyVectorcall_NARGS()``
+// in nanobind. The an official function requires a (costly) indirect PLT call
+// in the stable ABI, which is unnecessary as its behavior is fully frozen by
+// the stable ABI contract.
 #define NB_VECTORCALL_NARGS(n)                                                  \
-    ((Py_ssize_t) ((n) & ~PY_VECTORCALL_ARGUMENTS_OFFSET))
+    ((Py_ssize_t) ((n) & ~(PY_VECTORCALL_ARGUMENTS_OFFSET |                     \
+                           NB_VECTORCALL_TRUSTED_SELF)))
 
 #if PY_VERSION_HEX >= 0x030A0000
 #  define NB_TPFLAGS_IMMUTABLETYPE Py_TPFLAGS_IMMUTABLETYPE

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1035,6 +1035,53 @@ static PyObject *nb_type_from_metaclass(PyTypeObject *meta, PyObject *mod,
 
 extern int nb_type_setattro(PyObject* obj, PyObject* name, PyObject* value);
 
+// Fallback path for nb_type_vectorcall (caller did not provision space)
+NB_NOINLINE static PyObject *
+nb_type_vectorcall_fixup(nb_func *func, PyObject *self, PyObject *const *args_in,
+                         Py_ssize_t nargs, PyObject *kwargs_in,
+                         bool is_init) noexcept {
+    const size_t buf_size = 5;
+    PyObject **args, *buf[buf_size];
+    bool alloc = false;
+
+    size_t size = (size_t) nargs + 1;
+    if (kwargs_in)
+        size += NB_TUPLE_GET_SIZE(kwargs_in);
+
+    if (size < buf_size) {
+        args = buf;
+    } else {
+        args = (PyObject **) PyMem_Malloc(size * sizeof(PyObject *));
+        if (!args) {
+            if (is_init)
+                Py_DECREF(self);
+            return PyErr_NoMemory();
+        }
+        alloc = true;
+    }
+
+    memcpy(args + 1, args_in, sizeof(PyObject *) * (size - 1));
+    args[0] = self;
+
+    PyObject *rv = func->vectorcall((PyObject *) func, args,
+                                    (size_t) (nargs + 1), kwargs_in);
+
+    if (NB_UNLIKELY(alloc))
+        PyMem_Free(args);
+
+    if (is_init) {
+        if (!rv) {
+            Py_DECREF(self);
+            return nullptr;
+        }
+#if !NB_IMMORTAL_SINGLETONS
+        Py_DECREF(rv);
+#endif
+        return self;
+    }
+    return rv;
+}
+
 // Implements the vector call protocol directly on type objects to construct
 // instances more efficiently.
 static PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
@@ -1068,42 +1115,18 @@ static PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
         return func->vectorcall((PyObject *) func, nullptr, 0, nullptr);
     }
 
-    const size_t buf_size = 5;
-    PyObject **args, *buf[buf_size], *temp = nullptr;
-    bool alloc = false;
+    if (NB_UNLIKELY(!(nargsf & PY_VECTORCALL_ARGUMENTS_OFFSET)))
+        return nb_type_vectorcall_fixup(func, self, args_in, nargs, kwargs_in,
+                                        is_init);
 
-    if (NB_LIKELY(nargsf & PY_VECTORCALL_ARGUMENTS_OFFSET)) {
-        args = (PyObject **) (args_in - 1);
-        temp = args[0];
-    } else {
-        size_t size = nargs + 1;
-        if (kwargs_in)
-            size += NB_TUPLE_GET_SIZE(kwargs_in);
-
-        if (size < buf_size) {
-            args = buf;
-        } else {
-            args = (PyObject **) PyMem_Malloc(size * sizeof(PyObject *));
-            if (!args) {
-                if (is_init)
-                    Py_DECREF(self);
-                return PyErr_NoMemory();
-            }
-            alloc = true;
-        }
-
-        memcpy(args + 1, args_in, sizeof(PyObject *) * (size - 1));
-    }
-
+    PyObject **args = (PyObject **) (args_in - 1);
+    PyObject *temp = args[0];
     args[0] = self;
 
     PyObject *rv =
         func->vectorcall((PyObject *) func, args, nargs + 1, kwargs_in);
 
     args[0] = temp;
-
-    if (NB_UNLIKELY(alloc))
-        PyMem_Free(args);
 
     if (NB_LIKELY(is_init)) {
         if (!rv) {

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1112,7 +1112,9 @@ static PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
         }
 
         // __init__ constructor: 'rv' is None
+#if !NB_IMMORTAL_SINGLETONS
         Py_DECREF(rv);
+#endif
         return self;
     } else {
         // __new__ constructor
@@ -1787,8 +1789,7 @@ static PyObject *keep_alive_callback(PyObject *self, PyObject *const *args,
           "nanobind::detail::keep_alive_callback(): invalid input!");
     Py_DECREF(args[0]); // self
     Py_DECREF(self); // patient
-    Py_INCREF(Py_None);
-    return Py_None;
+    return none_ref();
 }
 
 static PyMethodDef keep_alive_callback_def = {
@@ -1976,10 +1977,8 @@ PyObject *nb_type_put(const std::type_info *cpp_type,
                       cleanup_list *cleanup,
                       bool *is_new) noexcept {
     // Convert nullptr -> None
-    if (!value) {
-        Py_INCREF(Py_None);
-        return Py_None;
-    }
+    if (!value)
+        return none_ref();
 
     nb_internals *internals_ = internals;
     type_data *td = nullptr;
@@ -2052,10 +2051,8 @@ PyObject *nb_type_put_p(const std::type_info *cpp_type,
                         cleanup_list *cleanup,
                         bool *is_new) noexcept {
     // Convert nullptr -> None
-    if (!value) {
-        Py_INCREF(Py_None);
-        return Py_None;
-    }
+    if (!value)
+        return none_ref();
 
     // Check if the instance is already registered with nanobind
     nb_internals *internals_ = internals;

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1044,7 +1044,7 @@ static PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
     type_data *td = nb_type_data(tp);
     nb_func *func = (nb_func *) td->init;
     bool is_init = (td->flags & (uint32_t) type_flags::has_new) == 0;
-    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    Py_ssize_t nargs = NB_VECTORCALL_NARGS(nargsf);
 
     if (NB_UNLIKELY(!func)) {
         PyErr_Format(PyExc_TypeError, "%s: no constructor defined!", td->name);

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1063,8 +1063,12 @@ nb_type_vectorcall_fixup(nb_func *func, PyObject *self, PyObject *const *args_in
     memcpy(args + 1, args_in, sizeof(PyObject *) * (size - 1));
     args[0] = self;
 
-    PyObject *rv = func->vectorcall((PyObject *) func, args,
-                                    (size_t) (nargs + 1), kwargs_in);
+    size_t call_nargsf = (size_t) (nargs + 1);
+    if (is_init)
+        call_nargsf |= NB_VECTORCALL_TRUSTED_SELF;
+
+    PyObject *rv =
+        func->vectorcall((PyObject *) func, args, call_nargsf, kwargs_in);
 
     if (NB_UNLIKELY(alloc))
         PyMem_Free(args);
@@ -1123,8 +1127,12 @@ static PyObject *nb_type_vectorcall(PyObject *self, PyObject *const *args_in,
     PyObject *temp = args[0];
     args[0] = self;
 
+    size_t call_nargsf = (size_t) (nargs + 1);
+    if (NB_LIKELY(is_init))
+        call_nargsf |= NB_VECTORCALL_TRUSTED_SELF;
+
     PyObject *rv =
-        func->vectorcall((PyObject *) func, args, nargs + 1, kwargs_in);
+        func->vectorcall((PyObject *) func, args, call_nargsf, kwargs_in);
 
     args[0] = temp;
 
@@ -1745,6 +1753,13 @@ bool nb_type_get(const std::type_info *cpp_type, PyObject *src, uint8_t flags,
     // Convert None -> nullptr
     if (src == Py_None) {
         *out = nullptr;
+        return true;
+    }
+
+    // Trusted 'self' from nb_type_vectorcall: a freshly allocated instance of
+    // exactly this type, so skip verification and read the pointer directly.
+    if (NB_UNLIKELY(flags & (uint8_t) cast_flags::trusted)) {
+        *out = inst_ptr((nb_inst *) src);
         return true;
     }
 

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1750,8 +1750,11 @@ bool nb_type_get(const std::type_info *cpp_type, PyObject *src, uint8_t flags,
                   "this function is optimized assuming that "
                   "cast_flags::construct == nb_inst_state::state_ready");
 
-    // Convert None -> nullptr
-    if (src == Py_None) {
+    // Convert None -> nullptr, unless the target binds by value/reference and
+    // therefore has no valid mapping for None (then reject -> next overload).
+    if (NB_UNLIKELY(src == Py_None)) {
+        if (flags & (uint8_t) cast_flags::none_disallowed)
+            return false;
         *out = nullptr;
         return true;
     }

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -61,13 +61,25 @@ static int inst_init(PyObject *self, PyObject *, PyObject *) {
     return -1;
 }
 
+/// Function to check (in the fastest manner) if a nb_type is garbage-collected.
+static NB_INLINE bool nb_type_has_gc(PyTypeObject *tp, uint32_t flags) {
+#if defined(Py_LIMITED_API)
+    (void) tp;
+    return flags & (uint32_t) type_flags::has_gc;
+#else
+    (void) flags;
+    return PyType_HasFeature(tp, Py_TPFLAGS_HAVE_GC);
+#endif
+}
+
 /// Allocate memory for a nb_type instance with internal storage
 PyObject *inst_new_int(PyTypeObject *tp, PyObject * /* args */,
                        PyObject * /*kwd */) {
     const type_data *t = nb_type_data(tp);
+    uint32_t flags = t->flags;
 
     // Instance pool fast path
-    if (NB_LIKELY(t->flags & (uint32_t) type_flags::pooled)) {
+    if (NB_LIKELY(flags & (uint32_t) type_flags::pooled)) {
         nb_inst_pool *pool = nb_pool_lookup((type_data *) t);
         if (pool && pool->count) {
             nb_inst *self = pool->slots[--pool->count];
@@ -99,7 +111,7 @@ PyObject *inst_new_int(PyTypeObject *tp, PyObject * /* args */,
         }
     }
 
-    bool gc = PyType_HasFeature(tp, Py_TPFLAGS_HAVE_GC);
+    bool gc = nb_type_has_gc(tp, flags);
 
     nb_inst *self;
     if (NB_LIKELY(!gc))
@@ -109,7 +121,7 @@ PyObject *inst_new_int(PyTypeObject *tp, PyObject * /* args */,
 
     if (NB_LIKELY(self)) {
         uint32_t align = (uint32_t) t->align;
-        bool intrusive = t->flags & (uint32_t) type_flags::intrusive_ptr;
+        bool intrusive = flags & (uint32_t) type_flags::intrusive_ptr;
 
         uintptr_t payload = (uintptr_t) (self + 1);
 
@@ -147,7 +159,9 @@ PyObject *inst_new_int(PyTypeObject *tp, PyObject * /* args */,
 /// 'inst_new_int()', this does not yet register the instance in the internal
 /// data structures. The function 'inst_register()' must be used to do so.
 PyObject *inst_new_ext(PyTypeObject *tp, void *value) {
-    bool gc = PyType_HasFeature(tp, Py_TPFLAGS_HAVE_GC);
+    const type_data *t = nb_type_data(tp);
+    uint32_t flags = t->flags;
+    bool gc = nb_type_has_gc(tp, flags);
 
     nb_inst *self;
     if (NB_LIKELY(!gc)) {
@@ -188,8 +202,7 @@ PyObject *inst_new_ext(PyTypeObject *tp, void *value) {
         offset = (int32_t) sizeof(nb_inst);
     }
 
-    const type_data *t = nb_type_data(tp);
-    bool intrusive = t->flags & (uint32_t) type_flags::intrusive_ptr;
+    bool intrusive = flags & (uint32_t) type_flags::intrusive_ptr;
 
     self->offset = offset;
 
@@ -347,6 +360,7 @@ static void inst_dealloc(PyObject *self) {
     PyTypeObject *tp = Py_TYPE(self);
     const type_data *t = nb_type_data(tp);
     nb_inst *inst = (nb_inst *) self;
+    uint32_t flags = t->flags;
 
     // Fast path: run the C++ destructor, then put the mapped object in the pool
     // for reuse. The guard below admits only "clean" instances:
@@ -357,10 +371,10 @@ static void inst_dealloc(PyObject *self) {
     //
     // The remaining special cases cannot apply because pooling does not accept
     // GCed or intrusively counted types.
-    if (NB_LIKELY((t->flags & (uint32_t) type_flags::pooled) &&
+    if (NB_LIKELY((flags & (uint32_t) type_flags::pooled) &&
                   inst->state.internal && !inst->state.clear_keep_alive &&
                   inst->state.state != nb_inst_state::state_relinquished)) {
-        if (inst->state.destruct && (t->flags & (uint32_t) type_flags::has_destruct))
+        if (inst->state.destruct && (flags & (uint32_t) type_flags::has_destruct))
             t->destruct(inst_ptr(inst));
 
         // Look up the pool or create it
@@ -380,18 +394,18 @@ static void inst_dealloc(PyObject *self) {
         inst->state.destruct = 0;
     }
 
-    bool gc = PyType_HasFeature(tp, Py_TPFLAGS_HAVE_GC);
+    bool gc = nb_type_has_gc(tp, flags);
     if (NB_UNLIKELY(gc)) {
         PyObject_GC_UnTrack(self);
 
-        if (t->flags & (uint32_t) type_flags::has_dynamic_attr) {
+        if (flags & (uint32_t) type_flags::has_dynamic_attr) {
             PyObject **dict = nb_dict_ptr(self, tp);
             if (dict)
                 Py_CLEAR(*dict);
         }
     }
 
-    if (t->flags & (uint32_t) type_flags::is_weak_referenceable &&
+    if (flags & (uint32_t) type_flags::is_weak_referenceable &&
         nb_weaklist_ptr(self, tp) != nullptr) {
 #if defined(PYPY_VERSION)
         PyObject **weaklist = nb_weaklist_ptr(self, tp);
@@ -405,10 +419,10 @@ static void inst_dealloc(PyObject *self) {
     void *p = inst_ptr(inst);
 
     if (inst->state.destruct) {
-        check(t->flags & (uint32_t) type_flags::is_destructible,
+        check(flags & (uint32_t) type_flags::is_destructible,
               "nanobind::detail::inst_dealloc(\"%s\"): attempted to call "
               "the destructor of a non-destructible type!", t->name);
-        if (t->flags & (uint32_t) type_flags::has_destruct)
+        if (flags & (uint32_t) type_flags::has_destruct)
             t->destruct(p);
     }
 
@@ -495,7 +509,7 @@ static void inst_dealloc(PyObject *self) {
     // Release the type reference acquired at allocation. On free-threaded
     // builds, nanobind types are immortal but Python subclasses are not.
 #if defined(Py_GIL_DISABLED)
-    if (t->flags & (uint32_t) type_flags::is_python_type)
+    if (flags & (uint32_t) type_flags::is_python_type)
         Py_DECREF(tp);
 #else
     Py_DECREF(tp);
@@ -658,15 +672,15 @@ static int nb_type_init(PyObject *self, PyObject *args, PyObject *kwds) {
     t->flags |=  (uint32_t) type_flags::is_python_type;
     t->flags &= ~((uint32_t) type_flags::has_implicit_conversions);
 
-    // Python subclasses are GC heap types with their own layout; they must not
-    // share or inherit the base type's instance pool.
+    // A Python subclass is always a GC heap type
+    t->flags |= (uint32_t) type_flags::has_gc;
+
+    // Sublclasses do not inherit the pooling feature as a consequence
     t->flags &= ~((uint32_t) type_flags::pooled);
     t->pool_capacity = 0;
 #if defined(NB_FREE_THREADED)
     t->pool_index = 0;
 #else
-    // Clear the inlined pool copied from the base type_data (above), so the
-    // subclass never touches the base's 'slots' array.
     t->pool = nb_inst_pool{};
 #endif
 
@@ -1590,6 +1604,13 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
     to->dictoffset = (uint32_t) dictoffset;
     to->weaklistoffset = (uint32_t) weaklistoffset;
 
+    // Cache the type's GC-ness (also covers GC-ness inherited from a base) so
+    // the allocation/deallocation hot paths avoid a PyType_GetFlags() call.
+    bool have_gc =
+        PyType_HasFeature((PyTypeObject *) result, Py_TPFLAGS_HAVE_GC);
+    if (have_gc)
+        to->flags |= (uint32_t) type_flags::has_gc;
+
     // Instance pool setup + eligibility check (nb::pooled). Decide once here
     // so the hot paths can trust the 'pooled' flag alone.
     to->pool_capacity = 0;
@@ -1608,7 +1629,7 @@ PyObject *nb_type_new(const type_init_data *t) noexcept {
         } else {
             // Pooling requires a non-GC type
             bool eligible =
-                !PyType_HasFeature((PyTypeObject *) result, Py_TPFLAGS_HAVE_GC) &&
+                !have_gc &&
                 !(to->flags & (uint32_t) type_flags::intrusive_ptr);
             if (!eligible)
                 fail("nanobind: type '%s' requested instance pooling "

--- a/src/trampoline.cpp
+++ b/src/trampoline.cpp
@@ -141,8 +141,7 @@ static void trampoline_enter_internal(void **data, size_t size,
                 goto fail;
             }
 
-            Py_INCREF(Py_None);
-            key = Py_None;
+            key = none_ref();
         }
 
         data[2 * offset + 1] = (void *) name;


### PR DESCRIPTION
This PR bundles several optimizations that accelerate the critical path of a simple microbenchmark that repeatedly runs
```
Number(1) + Number(2)
```
millions of times. This code calls the constructor twice, a method once, and destructs 3 instances. The microbenchmark uses the new pooling optimization, though most of the improvements apply to the general case too.

Following this set of changes, performance changes as follows:
```
native:  79.7 ->  74.8 ns/op (-6.2% rel)
  abi3:  96.1 ->  80.3 ns/op (-16.4% rel)
```
where "native" refers to regular unstable ABI builds. In other words, the stable ABI interface is now nearly essentially as fast as the regular compilation path prior to the change!

The commits include stats on the individual improvement of each change. Here is a high level summary:

1. Use inline-able variants of `PyVectorcall_NARGS()` and `PyType_HasFeature()` to avoid costly indirect PLT calls causing spills in function dispatchers and allocation routines.
2. Skip reference counting for immortal singletons (notably the `None` returned by `void` methods).
3. Outline the cold path of `nb_type_vectorcall` to improve the generated code.
4. Introduce a internal extended ABI that permits constructors to skip a superfluous type check.
5. Move the rejection of `None` arguments from binding trampolines into `nb_type_get`.
6. Disable the GCC stack protector for `libnanobind`. The CMake build system already did this for extension builds but forgot to do so for the `libnanobind` component. The security benefit of the stack protector is highly dubious for nanobind and comes at a substantial cost.