### PR TITLE
Optimize the critical path of ndarray

### DIFF
--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -328,6 +328,7 @@ private:
 template <typename... Args> class ndarray {
 public:
     template <typename...> friend class ndarray;
+    template <typename, typename> friend struct detail::type_caster;
 
     using Config = detail::ndarray_config_t<int, Args...>;
     using Scalar = typename Config::Scalar;
@@ -572,11 +573,15 @@ template <typename... Args> struct type_caster<ndarray<Args...>> {
             (void) shape_buf;
         }
 
-        value = Value(ndarray_import(src.ptr(), &config,
-                                     flags & (uint8_t) cast_flags::convert,
-                                     cleanup));
+        detail::ndarray_handle *h = ndarray_import(
+            src.ptr(), &config, flags & (uint8_t) cast_flags::convert, cleanup);
 
-        return value.is_valid();
+        if (NB_UNLIKELY(value.m_handle))
+            detail::ndarray_dec_ref(value.m_handle);
+        if (NB_LIKELY(h))
+            value.m_dltensor = *detail::ndarray_inc_ref(h);
+        value.m_handle = h;
+        return h != nullptr;
     }
 
     static handle from_cpp(const ndarray<Args...> &tensor, rv_policy policy,

--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -409,16 +409,16 @@ public:
     }
 
     ndarray(ndarray &&t) noexcept : m_handle(t.m_handle), m_dltensor(t.m_dltensor) {
+        // Only reset m_handle, it's safe to leave m_dltensor as-is
         t.m_handle = nullptr;
-        t.m_dltensor = dlpack::dltensor();
     }
 
     ndarray &operator=(ndarray &&t) noexcept {
         detail::ndarray_dec_ref(m_handle);
         m_handle = t.m_handle;
         m_dltensor = t.m_dltensor;
+        // Only reset t.m_handle, it's safe to leave t.m_dltensor as-is
         t.m_handle = nullptr;
-        t.m_dltensor = dlpack::dltensor();
         return *this;
     }
 

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -244,8 +244,6 @@ static void init_pyobjects(nb_internals *p) {
     for (int i = 0; i < pyobj_name::string_count; ++i)
         new_constant(p, i, PyUnicode_InternFromString(interned_c_strs[i]));
 
-    new_constant(p, pyobj_name::interned_copy_tpl,
-                 PyTuple_Pack(1, NB_INTERNED(copy)));
     new_constant(p, pyobj_name::interned_max_version_tpl,
                  PyTuple_Pack(1, NB_INTERNED(max_version)));
 

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -244,19 +244,19 @@ static void init_pyobjects(nb_internals *p) {
     for (int i = 0; i < pyobj_name::string_count; ++i)
         new_constant(p, i, PyUnicode_InternFromString(interned_c_strs[i]));
 
-    new_constant(p, pyobj_name::copy_tpl,
+    new_constant(p, pyobj_name::interned_copy_tpl,
                  PyTuple_Pack(1, NB_INTERNED(copy)));
-    new_constant(p, pyobj_name::max_version_tpl,
+    new_constant(p, pyobj_name::interned_max_version_tpl,
                  PyTuple_Pack(1, NB_INTERNED(max_version)));
 
     PyObject *one = PyLong_FromLong(1), *zero = PyLong_FromLong(0);
-    new_constant(p, pyobj_name::dl_cpu_tpl, PyTuple_Pack(2, one, zero));
+    new_constant(p, pyobj_name::interned_dl_cpu_tpl, PyTuple_Pack(2, one, zero));
     Py_DECREF(zero);
     Py_DECREF(one);
 
     PyObject *major = PyLong_FromLong(dlpack::major_version),
              *minor = PyLong_FromLong(dlpack::minor_version);
-    new_constant(p, pyobj_name::dl_version_tpl, PyTuple_Pack(2, major, minor));
+    new_constant(p, pyobj_name::interned_dl_version_tpl, PyTuple_Pack(2, major, minor));
     Py_DECREF(minor);
     Py_DECREF(major);
 }
@@ -348,6 +348,8 @@ void internals_dec_ref() {
     p->nb_bound_method = nullptr;
     p->nb_static_property.store_release(nullptr);
     p->nb_ndarray.store_release(nullptr);
+    for (auto &entry : p->ndarray_export)
+        entry.store_release(nullptr);
 
     for (int i = 0; i < pyobj_name::total_count; ++i)
         static_pyobjects[i] = nullptr;

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -349,6 +349,18 @@ struct nb_maybe_atomic {
 };
 #endif
 
+/// Cache slots for `nb_internals::ndarray_export`: cached callables that build a
+/// framework's array from nanobind's DLPack/buffer wrapper.
+enum ndarray_export_slot {
+    nd_export_numpy_view, // numpy.asarray
+    nd_export_numpy_copy, // numpy.copy
+    nd_export_pytorch,    // torch.utils.dlpack.from_dlpack
+    nd_export_tensorflow, // tensorflow.experimental.dlpack.from_dlpack
+    nd_export_jax,        // jax.dlpack.from_dlpack
+    nd_export_cupy,       // cupy.from_dlpack
+    nd_export_count
+};
+
 /**
  * `nb_internals` is the central data structure storing information related to
  * function/type bindings and instances. Separate nanobind extensions within the
@@ -411,7 +423,6 @@ struct nb_maybe_atomic {
  * - `print_leak_warnings`, `print_implicit_cast_warnings`: simple boolean
  *   flags. No protection against concurrent conflicting updates.
  */
-
 struct nb_internals {
     /// Internal nanobind module
     PyObject *nb_module;
@@ -435,8 +446,9 @@ struct nb_internals {
     /// N-dimensional array wrapper (created on demand)
     nb_maybe_atomic<PyTypeObject *> nb_ndarray = nullptr;
 
-    /// Cached callables used to export an ndarray to a framework
-    nb_maybe_atomic<PyObject *> ndarray_export[8] {};
+    /// Cached callables used to export an ndarray to a framework, indexed by
+    /// `ndarray_export_slot`.
+    nb_maybe_atomic<PyObject *> ndarray_export[nd_export_count] {};
 
 #if defined(NB_FREE_THREADED)
     nb_shard *shards = nullptr;
@@ -551,8 +563,7 @@ struct pyobj_name {
         string_count,
 
         // Cached constant tuples using the same interning machinery
-        interned_copy_tpl = string_count, // tuple ("copy")
-        interned_max_version_tpl,         // tuple ("max_version")
+        interned_max_version_tpl = string_count, // tuple ("max_version")
         interned_dl_cpu_tpl,              // tuple (1, 0) == nb::device::cpu
         interned_dl_version_tpl,          // tuple (dlpack major, minor)
         total_count

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -330,7 +330,7 @@ struct NB_SHARD_ALIGNMENT nb_shard {
 #if defined(NB_FREE_THREADED)
 template<typename T>
 struct nb_maybe_atomic {
-  nb_maybe_atomic(T v) : value(v) {}
+  nb_maybe_atomic(T v = T()) : value(v) {}
 
   std::atomic<T> value;
   T load_acquire() { return value.load(std::memory_order_acquire); }
@@ -340,7 +340,7 @@ struct nb_maybe_atomic {
 #else
 template<typename T>
 struct nb_maybe_atomic {
-  nb_maybe_atomic(T v) : value(v) {}
+  nb_maybe_atomic(T v = T()) : value(v) {}
 
   T value;
   T load_acquire() { return value; }
@@ -434,6 +434,9 @@ struct nb_internals {
 
     /// N-dimensional array wrapper (created on demand)
     nb_maybe_atomic<PyTypeObject *> nb_ndarray = nullptr;
+
+    /// Cached callables used to export an ndarray to a framework
+    nb_maybe_atomic<PyObject *> ndarray_export[8] {};
 
 #if defined(NB_FREE_THREADED)
     nb_shard *shards = nullptr;
@@ -531,11 +534,9 @@ struct nb_internals {
     X(__name__)                                                                \
     X(__new__)                                                                 \
     X(__qualname__)                                                            \
-    X(array)                                                                   \
     X(clone)                                                                   \
     X(copy)                                                                    \
     X(dl_device)                                                               \
-    X(from_dlpack)                                                             \
     X(max_version)                                                             \
     X(stream)                                                                  \
     X(value)
@@ -549,17 +550,19 @@ struct pyobj_name {
         #undef NB_INTERNED_ENTRY
         string_count,
 
-        copy_tpl = string_count,  // tuple ("copy")
-        max_version_tpl, // tuple ("max_version")
-        dl_cpu_tpl,      // tuple (1, 0), which corresponds to nb::device::cpu
-        dl_version_tpl,  // tuple (dlpack::major_version, dlpack::minor_version)
+        // Cached constant tuples using the same interning machinery
+        interned_copy_tpl = string_count, // tuple ("copy")
+        interned_max_version_tpl,         // tuple ("max_version")
+        interned_dl_cpu_tpl,              // tuple (1, 0) == nb::device::cpu
+        interned_dl_version_tpl,          // tuple (dlpack major, minor)
         total_count
     };
 };
 
 extern PyObject *static_pyobjects[];
 
-/// Access the pre-interned string constant 'name', e.g. NB_INTERNED(__name__)
+/// Access a cached static PyObject (interned string or constant tuple) by name,
+/// e.g. NB_INTERNED(__name__) or NB_INTERNED(copy_tpl)
 #define NB_INTERNED(name) static_pyobjects[pyobj_name::interned_##name]
 
 extern void internals_inc_ref();

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -1043,31 +1043,34 @@ ndarray_handle *ndarray_create(void *data, size_t ndim, const size_t *shape_in,
     return result.release();
 }
 
-/// Resolve (and cache) the callable that exports an ndarray a given framework.
-static PyObject *ndarray_export_fn(nb_internals *internals_, int framework) {
-    PyObject *fn = internals_->ndarray_export[framework].load_acquire();
+/// Module + attribute of export callables, indexed by `ndarray_export_slot`.
+static constexpr struct { const char *pkg, *attr; }
+    ndarray_export_spec[nd_export_count] = {
+        { "numpy",                          "asarray"     },
+        { "numpy",                          "copy"        },
+        { "torch.utils.dlpack",             "from_dlpack" },
+        { "tensorflow.experimental.dlpack", "from_dlpack" },
+        { "jax.dlpack",                     "from_dlpack" },
+        { "cupy",                           "from_dlpack" },
+    };
+
+/// Resolve (and cache) the callable for an ``ndarray_export`` cache slot.
+static PyObject *ndarray_export_fn(nb_internals *internals_,
+                                   ndarray_export_slot slot) {
+    PyObject *fn = internals_->ndarray_export[slot].load_acquire();
     if (NB_LIKELY(fn))
         return fn;
 
     lock_internals guard(internals_);
-    fn = internals_->ndarray_export[framework].load_relaxed();
+    fn = internals_->ndarray_export[slot].load_relaxed();
     if (fn)
         return fn;
 
-    const char *pkg_name, *attr;
-    switch (framework) {
-        case numpy::value:      pkg_name = "numpy";                          attr = "array";       break;
-        case pytorch::value:    pkg_name = "torch.utils.dlpack";             attr = "from_dlpack"; break;
-        case tensorflow::value: pkg_name = "tensorflow.experimental.dlpack"; attr = "from_dlpack"; break;
-        case jax::value:        pkg_name = "jax.dlpack";                     attr = "from_dlpack"; break;
-        case cupy::value:       pkg_name = "cupy";                           attr = "from_dlpack"; break;
-        default:                fail("ndarray_export_fn(): unsupported framework!");
-    }
-
-    object obj = steal(module_import(pkg_name)).attr(attr);
+    object obj = steal(module_import(ndarray_export_spec[slot].pkg))
+                     .attr(ndarray_export_spec[slot].attr);
     fn = obj.release().ptr();
     new_object(internals_, fn);
-    internals_->ndarray_export[framework].store_release(fn);
+    internals_->ndarray_export[slot].store_release(fn);
     return fn;
 }
 
@@ -1154,40 +1157,39 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
 
     if (framework == numpy::value) {
         try {
-            // Evaluates numpy.array(o, copy=...)
-            PyObject *array_fn = ndarray_export_fn(internals_, numpy::value);
-            PyObject *stack[] = {nullptr, o.ptr(), copy ? Py_True : Py_False};
+            // Call nump.asarray(o) to create a view, and numpy.copy(o) to copy
+            PyObject *export_fn = ndarray_export_fn(
+                internals_, copy ? nd_export_numpy_copy : nd_export_numpy_view);
+            PyObject *stack[] = {nullptr, o.ptr()};
             Py_ssize_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
-            return PyObject_Vectorcall(array_fn, stack + 1, nargsf,
-                                       NB_INTERNED(copy_tpl));
+            return PyObject_Vectorcall(export_fn, stack + 1, nargsf, nullptr);
         } catch (const std::exception &e) {
             PyErr_Format(PyExc_TypeError,
-                         "could not export nanobind::ndarray: %s",
-                         e.what());
+                         "could not export nanobind::ndarray: %s", e.what());
             return nullptr;
         }
     }
 
+    // The DLPack frameworks build a view via <pkg>.from_dlpack(o); no_framework
+    // and array_api leave `o` as-is; memview returns a memoryview directly.
     try {
-        bool use_dlpack;
+        ndarray_export_slot slot;
         switch (framework) {
-            case pytorch::value:
-            case tensorflow::value:
-            case jax::value:
-            case cupy::value:
-                use_dlpack = true;
-                break;
-            case memview::value:
-                return PyMemoryView_FromObject(o.ptr());
-            default:
-                use_dlpack = false;
+            case pytorch::value:    slot = nd_export_pytorch;    break;
+            case tensorflow::value: slot = nd_export_tensorflow; break;
+            case jax::value:        slot = nd_export_jax;        break;
+            case cupy::value:       slot = nd_export_cupy;       break;
+            case memview::value:    return PyMemoryView_FromObject(o.ptr());
+            default:                slot = nd_export_count;  // no export call
         }
-        if (use_dlpack) {
-            // Evaluates <pkg>.from_dlpack(o).
-            PyObject *from_dlpack_fn = ndarray_export_fn(internals_, framework);
+
+        if (slot != nd_export_count) {
+            PyObject *export_fn = ndarray_export_fn(internals_, slot);
             PyObject *stack[] = {nullptr, o.ptr()};
             Py_ssize_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
-            o = steal(PyObject_Vectorcall(from_dlpack_fn, stack + 1, nargsf, nullptr));
+            o = steal(PyObject_Vectorcall(export_fn, stack + 1, nargsf, nullptr));
+            if (!o.is_valid())
+                return nullptr;
         }
     } catch (const std::exception &e) {
         PyErr_Format(PyExc_TypeError,
@@ -1197,12 +1199,14 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
     }
 
     if (copy) {
-        PyObject* copy_function_name = NB_INTERNED(copy);
+        PyObject* copy_fn_name = NB_INTERNED(copy);
         if (framework == pytorch::value)
-            copy_function_name = NB_INTERNED(clone);
+            copy_fn_name = NB_INTERNED(clone);
+        else
+            copy_fn_name = NB_INTERNED(copy);
 
         try {
-            o = o.attr(copy_function_name)();
+            o = o.attr(copy_fn_name)();
         } catch (std::exception &e) {
             PyErr_Format(PyExc_RuntimeError,
                          "copying nanobind::ndarray failed: %s",

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -399,7 +399,7 @@ static PyObject *nb_ndarray_dlpack_device(PyObject *self, PyObject *) {
                               : th->mt_unversioned->dltensor;
     PyObject *r;
     if (t.device.device_type == 1 && t.device.device_id == 0) {
-        r = static_pyobjects[pyobj_name::dl_cpu_tpl];
+        r = NB_INTERNED(dl_cpu_tpl);
         Py_INCREF(r);
     } else {
         r = PyTuple_New(2);
@@ -424,8 +424,7 @@ static PyMethodDef nb_ndarray_methods[] = {
    { nullptr, nullptr, 0, nullptr }
 };
 
-static PyTypeObject *nb_ndarray_tp() noexcept {
-    nb_internals *internals_ = internals;
+static PyTypeObject *nb_ndarray_tp(nb_internals *internals_) noexcept {
     PyTypeObject *tp = internals_->nb_ndarray.load_acquire();
 
     if (NB_UNLIKELY(!tp)) {
@@ -627,12 +626,12 @@ ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
         capsule = borrow(src);
     } else {
         // Try calling src.__dlpack__()
-        PyObject* args[] = {src, static_pyobjects[pyobj_name::dl_version_tpl]};
+        PyObject* args[] = {src, NB_INTERNED(dl_version_tpl)};
         Py_ssize_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
         capsule = steal(PyObject_VectorcallMethod(
                           NB_INTERNED(__dlpack__),
                           args, nargsf,
-                          static_pyobjects[pyobj_name::max_version_tpl]));
+                          NB_INTERNED(max_version_tpl)));
 
         // Python array API standard v2023 introduced max_version.
         // Try calling src.__dlpack__() without any kwargs.
@@ -1044,6 +1043,34 @@ ndarray_handle *ndarray_create(void *data, size_t ndim, const size_t *shape_in,
     return result.release();
 }
 
+/// Resolve (and cache) the callable that exports an ndarray a given framework.
+static PyObject *ndarray_export_fn(nb_internals *internals_, int framework) {
+    PyObject *fn = internals_->ndarray_export[framework].load_acquire();
+    if (NB_LIKELY(fn))
+        return fn;
+
+    lock_internals guard(internals_);
+    fn = internals_->ndarray_export[framework].load_relaxed();
+    if (fn)
+        return fn;
+
+    const char *pkg_name, *attr;
+    switch (framework) {
+        case numpy::value:      pkg_name = "numpy";                          attr = "array";       break;
+        case pytorch::value:    pkg_name = "torch.utils.dlpack";             attr = "from_dlpack"; break;
+        case tensorflow::value: pkg_name = "tensorflow.experimental.dlpack"; attr = "from_dlpack"; break;
+        case jax::value:        pkg_name = "jax.dlpack";                     attr = "from_dlpack"; break;
+        case cupy::value:       pkg_name = "cupy";                           attr = "from_dlpack"; break;
+        default:                fail("ndarray_export_fn(): unsupported framework!");
+    }
+
+    object obj = steal(module_import(pkg_name)).attr(attr);
+    fn = obj.release().ptr();
+    new_object(internals_, fn);
+    internals_->ndarray_export[framework].store_release(fn);
+    return fn;
+}
+
 PyObject *ndarray_export(ndarray_handle *th, int framework,
                          rv_policy policy, cleanup_list *cleanup) noexcept {
     if (!th)
@@ -1105,6 +1132,8 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
         return nullptr;
     }
 
+    nb_internals *internals_ = internals;
+
     object o;
     if (copy && framework == no_framework::value && th->self) {
         o = borrow(th->self);
@@ -1115,7 +1144,7 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
     } else {
         // Make a Python object providing the buffer interface and having
         // the two DLPack methods __dlpack__() and __dlpack_device__().
-        nb_ndarray *h = PyObject_New(nb_ndarray, nb_ndarray_tp());
+        nb_ndarray *h = PyObject_New(nb_ndarray, nb_ndarray_tp(internals_));
         if (!h)
             return nullptr;
         h->th = th;
@@ -1125,13 +1154,12 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
 
     if (framework == numpy::value) {
         try {
-            object pkg_mod = steal(module_import("numpy"));
-            PyObject* args[] = {pkg_mod.ptr(), o.ptr(),
-                                (copy) ? Py_True : Py_False};
-            Py_ssize_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
-            return PyObject_VectorcallMethod(
-                        NB_INTERNED(array), args, nargsf,
-                        static_pyobjects[pyobj_name::copy_tpl]);
+            // Evaluates numpy.array(o, copy=...)
+            PyObject *array_fn = ndarray_export_fn(internals_, numpy::value);
+            PyObject *stack[] = {nullptr, o.ptr(), copy ? Py_True : Py_False};
+            Py_ssize_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+            return PyObject_Vectorcall(array_fn, stack + 1, nargsf,
+                                       NB_INTERNED(copy_tpl));
         } catch (const std::exception &e) {
             PyErr_Format(PyExc_TypeError,
                          "could not export nanobind::ndarray: %s",
@@ -1141,32 +1169,25 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
     }
 
     try {
-        const char* pkg_name;
+        bool use_dlpack;
         switch (framework) {
             case pytorch::value:
-                pkg_name = "torch.utils.dlpack";
-                break;
             case tensorflow::value:
-                pkg_name = "tensorflow.experimental.dlpack";
-                break;
             case jax::value:
-                pkg_name = "jax.dlpack";
-                break;
             case cupy::value:
-                pkg_name = "cupy";
+                use_dlpack = true;
                 break;
             case memview::value:
                 return PyMemoryView_FromObject(o.ptr());
             default:
-                pkg_name = nullptr;
+                use_dlpack = false;
         }
-        if (pkg_name) {
-            object pkg_mod = steal(module_import(pkg_name));
-            PyObject* args[] = {pkg_mod.ptr(), o.ptr()};
-            Py_ssize_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
-            o = steal(PyObject_VectorcallMethod(
-                          NB_INTERNED(from_dlpack),
-                          args, nargsf, nullptr));
+        if (use_dlpack) {
+            // Evaluates <pkg>.from_dlpack(o).
+            PyObject *from_dlpack_fn = ndarray_export_fn(internals_, framework);
+            PyObject *stack[] = {nullptr, o.ptr()};
+            Py_ssize_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+            o = steal(PyObject_Vectorcall(from_dlpack_fn, stack + 1, nargsf, nullptr));
         }
     } catch (const std::exception &e) {
         PyErr_Format(PyExc_TypeError,

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -922,6 +922,35 @@ dlpack::dltensor *ndarray_inc_ref(ndarray_handle *th) noexcept {
                            : &th->mt_unversioned->dltensor;
 }
 
+// Final teardown of a handle whose refcount reached zero.
+static void ndarray_dec_ref_free(ndarray_handle *th) noexcept {
+    Py_XDECREF(th->owner);
+    Py_XDECREF(th->self);
+    if (th->versioned) {
+        managed_dltensor_versioned *mt = th->mt_versioned;
+        if (th->free_strides) {
+            PyMem_Free(mt->dltensor.strides);
+            mt->dltensor.strides = nullptr;
+        }
+        if (th->call_deleter) {
+            if (mt->deleter)
+                mt->deleter(mt);
+        } else {
+            PyMem_Free(mt);  // This also frees shape and size arrays.
+        }
+    } else {
+        managed_dltensor *mt = th->mt_unversioned;
+        if (th->free_strides) {
+            PyMem_Free(mt->dltensor.strides);
+            mt->dltensor.strides = nullptr;
+        }
+        assert(th->call_deleter);
+        if (mt->deleter)
+            mt->deleter(mt);
+    }
+    PyMem_Free(th);
+}
+
 void ndarray_dec_ref(ndarray_handle *th) noexcept {
     if (!th)
         return;
@@ -933,33 +962,16 @@ void ndarray_dec_ref(ndarray_handle *th) noexcept {
         // Don't run the cleanup if the interpreter has been shut down
         if (!is_alive())
             return;
-        gil_scoped_acquire guard;
 
-        Py_XDECREF(th->owner);
-        Py_XDECREF(th->self);
-        if (th->versioned) {
-            managed_dltensor_versioned *mt = th->mt_versioned;
-            if (th->free_strides) {
-                PyMem_Free(mt->dltensor.strides);
-                mt->dltensor.strides = nullptr;
-            }
-            if (th->call_deleter) {
-                if (mt->deleter)
-                    mt->deleter(mt);
-            } else {
-                PyMem_Free(mt);  // This also frees shape and size arrays.
-            }
-        } else {
-            managed_dltensor *mt = th->mt_unversioned;
-            if (th->free_strides) {
-                PyMem_Free(mt->dltensor.strides);
-                mt->dltensor.strides = nullptr;
-            }
-            assert(th->call_deleter);
-            if (mt->deleter)
-                mt->deleter(mt);
+#if !defined(Py_LIMITED_API)
+        // Avoid further GIL calls if we already hold it. (Slightly faster)
+        if (PyGILState_Check()) {
+            ndarray_dec_ref_free(th);
+            return;
         }
-        PyMem_Free(th);
+#endif
+        gil_scoped_acquire guard;
+        ndarray_dec_ref_free(th);
     }
 }
 

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -622,24 +622,38 @@ ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
     const bool src_is_pycapsule = PyCapsule_CheckExact(src);
     mt_unique_ptr_t mt_unique_ptr(nullptr, &mt_from_buffer_delete);
 
+    // Capsule flavor (versioned or not) to probe for first during extraction.
+    // Defaults to unversioned: the right guess for an unknown user capsule.
+    bool expect_versioned = false;
+
     if (src_is_pycapsule) {
         capsule = borrow(src);
     } else {
-        // Try calling src.__dlpack__()
         PyObject* args[] = {src, NB_INTERNED(dl_version_tpl)};
         Py_ssize_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
-        capsule = steal(PyObject_VectorcallMethod(
-                          NB_INTERNED(__dlpack__),
-                          args, nargsf,
-                          NB_INTERNED(max_version_tpl)));
 
-        // Python array API standard v2023 introduced max_version.
-        // Try calling src.__dlpack__() without any kwargs.
-        if (!capsule.is_valid() && PyErr_ExceptionMatches(PyExc_TypeError)) {
+        // Call src.__dlpack__(): max_version_kw requests a versioned capsule
+        // nullptr the cheaper unversioned one.
+        PyObject *max_version_kw = NB_INTERNED(max_version_tpl);
+        auto dlpack = [&](PyObject *kwnames) {
+            return steal(PyObject_VectorcallMethod(NB_INTERNED(__dlpack__),
+                                                   args, nargsf, kwnames));
+        };
+
+        // The unversioned path is generally faster to handle for the target
+        // framework. Try that first if the user only requested readonly input.
+        capsule = dlpack(c->ro ? nullptr : max_version_kw);
+        expect_versioned = !c->ro;
+
+        // Fall back to the other variant on failure: a read-only source
+        // refusing unversioned export raises BufferError, and producers
+        // predating max_version (array API < v2023) raise TypeError.
+        if (!capsule.is_valid() &&
+            (PyErr_ExceptionMatches(PyExc_BufferError) ||
+             PyErr_ExceptionMatches(PyExc_TypeError))) {
             PyErr_Clear();
-            capsule = steal(PyObject_VectorcallMethod(
-                              NB_INTERNED(__dlpack__),
-                              args, nargsf, nullptr));
+            capsule = dlpack(c->ro ? max_version_kw : nullptr);
+            expect_versioned = c->ro;
         }
 
         // Try creating an ndarray via the buffer protocol
@@ -682,16 +696,19 @@ ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
     }
 
     void* mt;  // can be versioned or unversioned
-    bool versioned = true;
+    bool versioned;
     if (mt_unique_ptr) {
         mt = mt_unique_ptr.get();
+        versioned = true;
     } else {
-        // Extract the managed_dltensor{_versioned} pointer from the capsule.
-        mt = PyCapsule_GetPointer(capsule.ptr(), "dltensor_versioned");
+        // Probe the expected capsule name first
+        static const char *names[2] = { "dltensor", "dltensor_versioned" };
+        versioned = expect_versioned;
+        mt = PyCapsule_GetPointer(capsule.ptr(), names[(int) versioned]);
         if (!mt) {
             PyErr_Clear();
-            versioned = false;
-            mt = PyCapsule_GetPointer(capsule.ptr(), "dltensor");
+            versioned = !versioned;
+            mt = PyCapsule_GetPointer(capsule.ptr(), names[(int) versioned]);
             if (!mt) {
                 PyErr_Clear();
                 return nullptr;

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -919,11 +919,20 @@ ndarray_handle *ndarray_import(PyObject *src, const ndarray_config *c,
     }
 
     if (capsule.is_valid()) {
-        // Mark the dltensor capsule as used, i.e., "consumed".
-        const char* used_name = (versioned) ? "used_dltensor_versioned"
-                                            : "used_dltensor";
-        if (PyCapsule_SetName(capsule.ptr(), used_name) ||
-            PyCapsule_SetDestructor(capsule.ptr(), nullptr))
+        // Neutralize the producer's capsule so its destructor won't free the
+        // DLManagedTensor that nanobind now owns. Clearing the destructor is
+        // sufficient and is the only step the common __dlpack__() path needs:
+        // nanobind holds the sole reference to that capsule and never re-reads
+        // its name. A user-supplied raw capsule, by contrast, is still
+        // referenced by the caller, so it is additionally renamed to the
+        // conventional "used" name to stop a second import from re-consuming it.
+        bool fail = PyCapsule_SetDestructor(capsule.ptr(), nullptr);
+        if (src_is_pycapsule && !fail) {
+            const char* used_name = (versioned) ? "used_dltensor_versioned"
+                                                : "used_dltensor";
+            fail = PyCapsule_SetName(capsule.ptr(), used_name);
+        }
+        if (fail)
             check(false, "ndarray_import(): could not mark capsule as used");
     }
 

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -575,7 +575,8 @@ def test20b_import_metal_dlpack():
 
     rec = Recorder(obj)
     assert t.check_metal_contig(rec) == (8, 0, 2, 2, 4, True, 0)
-    assert "max_version" in rec.kwargs
+    # A read-only import uses the cheaper unversioned __dlpack__() (no kwargs).
+    assert rec.kwargs == {}
 
     obj = t.ret_array_api_metal_byte_offset()
     assert t.check_metal_contig(obj) == (8, 0, 2, 2, 3, True, 4)


### PR DESCRIPTION
This commit bundles several performance improvements targeting the critical path of the ndarray implementation.

The following table shows performance improvements for a pair of microbenchmarks that repeatedly take (**Consume**) or return (**Produce**) a NumPy array. Most improvements are not specific to NumPy and also benefit other array frameworks. The time values are shown individually (nanoseconds per conversion) and as cumulative percentage relative to the baseline.

  | Commit | consume | produce |
  |---|---|---|
  | Cache export callable | ~same | 430.4→218.6 (−49%) |
  | Export via `asarray` | ~same | 430.4→187.7 (−56%) |
  | Maybe skip GIL acquire on free | 109.1→106.4 (−2%) | 430.4→178.8 (−58%) |
  | Don't zero moved-from descriptor | 109.1→100.2 (−8%) | ~same |
  | Populate caster in place | 109.1→98.8 (−9%) | ~same |
  | Unversioned `__dlpack__` | 109.1→89.7 (−18%) | ~same |
  | Skip capsule rename | 109.1→85.7 (−21%) | ~same |

cc @hpkfft 