### PR TITLE
Add nb::DRef1 / nb::DMap1 with a fixed unit inner stride

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -1152,6 +1152,26 @@ The following helper type aliases require an additional include directive:
    This templated type alias creates an ``Eigen::Map<..>`` with flexible strides for
    zero-copy data exchange between Eigen and NumPy.
 
+.. cpp:type:: DStride1 = Eigen::Stride<Eigen::Dynamic, 1>
+
+   Like :cpp:type:`DStride`, but with a *unit inner stride* fixed at compile
+   time. It accepts an arbitrary outer stride while requiring a contiguous inner
+   dimension. Fixing the inner stride this way preserves Eigen's vectorization,
+   which is otherwise disabled when the inner stride is dynamic. See the section
+   on :ref:`auto-vectorization <eigen_vectorization>` for details.
+
+.. cpp:type:: template <typename T> DRef1 = Eigen::Ref<T, 0, DStride1>
+
+   Variant of :cpp:type:`DRef` that uses :cpp:type:`DStride1`. Use it instead of
+   :cpp:type:`DRef` in performance-critical bindings to retain Eigen's
+   vectorization. The contiguous inner dimension must match the storage order of
+   ``T`` (a row-major ``T`` for C-contiguous arrays, a column-major ``T`` for
+   F-contiguous arrays).
+
+.. cpp:type:: template <typename T> DMap1 = Eigen::Map<T, 0, DStride1>
+
+   Variant of :cpp:type:`DMap` that uses :cpp:type:`DStride1`.
+
 .. _chrono_conversions:
 
 Timestamp and duration conversions

--- a/docs/eigen.rst
+++ b/docs/eigen.rst
@@ -145,6 +145,38 @@ apply:
 
      void f4(nb::DRef<Eigen::MatrixXf> x) { x *= 2; }
 
+.. _eigen_vectorization:
+
+Auto-vectorization
+------------------
+
+The flexibility of :cpp:type:`nb::DRef <DRef>` comes at a cost: because its
+inner stride is only known at runtime, Eigen conservatively turns off its
+``PacketAccessBit`` and falls back to a non-vectorized evaluation of
+operations involving such arguments, which can lead to reduced performance.
+
+If a function operates on contiguous data and performance matters, prefer
+:cpp:type:`nb::DRef1 <DRef1>` instead. It fixes the inner stride to ``1`` at
+compile time, which re-enables Eigen's vectorization, while still accepting an
+arbitrary *outer* stride (e.g. a row-padded matrix or a sliced row range).
+
+.. code-block:: cpp
+
+   // NumPy's default (C-contiguous) layout needs a *row-major* Eigen type:
+   using RowMatrixXf =
+       Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+   void f5(nb::DRef1<RowMatrixXf> x) { ... }
+
+   // Eigen's default (column-major) type matches *F-contiguous* input instead:
+   void f6(nb::DRef1<Eigen::MatrixXf> x) { ... }
+
+The Eigen type's storage order must match the input layout: *row-major* for
+C-contiguous arrays (the NumPy default), *column-major* for F-contiguous ones.
+A writable ``nb::DRef1<T>`` (as in ``f5``/``f6``) only binds inputs that already
+have a unit inner stride and otherwise raises a ``TypeError``. For a read-only
+argument that should accept any layout, use ``nb::DRef1<const T>``, which copies
+when needed.
+
 Maps
 ----
 

--- a/include/nanobind/eigen/dense.h
+++ b/include/nanobind/eigen/dense.h
@@ -23,6 +23,11 @@ using DStride = Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>;
 template <typename T> using DRef = Eigen::Ref<T, 0, DStride>;
 template <typename T> using DMap = Eigen::Map<T, 0, DStride>;
 
+/// Variants with a fixed unit inner stride
+using DStride1 = Eigen::Stride<Eigen::Dynamic, 1>;
+template <typename T> using DRef1 = Eigen::Ref<T, 0, DStride1>;
+template <typename T> using DMap1 = Eigen::Map<T, 0, DStride1>;
+
 NAMESPACE_BEGIN(detail)
 
 /// Determine the number of dimensions of the given Eigen type

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -139,6 +139,18 @@ NB_MODULE(test_eigen_ext, m) {
 
     m.def("mutate_DRefMXuC", [](nb::DRef<MatrixXuC> a) { a *= 2; }, nb::arg().noconvert());
 
+    // DRef1: fixed unit inner stride (keeps Eigen vectorization enabled).
+    // The const variants copy when the layout has a non-unit inner stride.
+    m.def("addDRef1MXuRR",
+          [](const nb::DRef1<const MatrixXuR> &a,
+             const nb::DRef1<const MatrixXuR> &b) -> MatrixXuR { return a + b; });
+    m.def("addDRef1MXuCC",
+          [](const nb::DRef1<const MatrixXuC> &a,
+             const nb::DRef1<const MatrixXuC> &b) -> MatrixXuC { return a + b; });
+    // The mutable variants reject a non-unit inner stride instead.
+    m.def("mutate_DRef1MXuR", [](nb::DRef1<MatrixXuR> a) { a *= 2; }, nb::arg().noconvert());
+    m.def("mutate_DRef1MXuC", [](nb::DRef1<MatrixXuC> a) { a *= 2; }, nb::arg().noconvert());
+
     m.def("updateRefV3i", [](Eigen::Ref<Eigen::Vector3i> a) { a[2] = 123; });
     m.def("updateRefV3i_nc", [](Eigen::Ref<Eigen::Vector3i> a) { a[2] = 123; }, nb::arg().noconvert());
     m.def("updateRefVXi", [](Eigen::Ref<Eigen::VectorXi> a) { a[2] = 123; });

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -228,6 +228,37 @@ def test07_mutate_arg():
     assert_array_equal(A, 2*A2)
 
 
+@needs_numpy_and_eigen
+def test07b_dref1():
+    # DRef1 fixes the inner stride to 1. It binds zero-copy when the layout
+    # matches the storage order, copies (const) or rejects (mutable) otherwise.
+    base = np.uint32(np.vander(np.arange(10)))
+    A_c = np.ascontiguousarray(base)   # C-contiguous  -> row-major
+    A_f = np.asfortranarray(base)      # F-contiguous  -> column-major
+    A_s = base[:, ::2]                 # strided inner  -> neither
+    expected = base + base
+
+    # const: correct for every layout (copying where needed)
+    assert_array_equal(t.addDRef1MXuRR(A_c, A_c), expected)
+    assert_array_equal(t.addDRef1MXuCC(A_f, A_f), expected)
+    assert_array_equal(t.addDRef1MXuRR(A_f, A_f), expected)        # copy fallback
+    assert_array_equal(t.addDRef1MXuRR(A_s, A_s), base[:, ::2] * 2)  # copy fallback
+
+    # mutable: zero-copy write-back on a matching layout
+    M = A_c.copy()
+    t.mutate_DRef1MXuR(M)
+    assert_array_equal(M, 2 * A_c)
+    Mf = A_f.copy(order='F')
+    t.mutate_DRef1MXuC(Mf)
+    assert_array_equal(Mf, 2 * A_f)
+
+    # mutable: a mismatched layout is rejected rather than silently copied
+    with pytest.raises(TypeError, match="incompatible function arguments"):
+        t.mutate_DRef1MXuR(A_f)
+    with pytest.raises(TypeError, match="incompatible function arguments"):
+        t.mutate_DRef1MXuC(A_c)
+
+
 def create_spmat_unsorted():
     import scipy.sparse as sparse
     # Create a small matrix with explicit indices and indptr


### PR DESCRIPTION
nb::DRef uses a fully dynamic stride (Stride<Dynamic, Dynamic>), which causes Eigen to clear its PacketAccessBit and evaluate operations without vectorization. GCC in particular cannot recover from this, so such bindings can be several times slower than the same code built with Clang (see issue #1263).

This adds DStride1/DRef1/DMap1 variants with a compile-time unit inner stride (Stride<Dynamic, 1>). They keep Eigen's vectorization enabled while still accepting an arbitrary outer stride. The contiguous inner dimension must match the storage order of the Eigen type (row-major for C-contiguous input, column-major for F-contiguous input); mismatched layouts fall back to a copy for const refs or raise a TypeError for mutable refs.

Documented in docs/eigen.rst and docs/api_extra.rst, with tests in tests/test_eigen.{cpp,py}.