### PR TITLE
Provide tp_call slot for metaclass with stable ABI (fixes #1286)

### DIFF
--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -1183,6 +1183,7 @@ PyTypeObject *nb_type_create_metaclass(nb_internals *p,
         { Py_tp_setattro, (void *) nb_type_setattro },
         { Py_tp_init, (void *) nb_type_init },
         { 0, nullptr },
+        { 0, nullptr },
         { 0, nullptr }
     };
 
@@ -1205,6 +1206,7 @@ PyTypeObject *nb_type_create_metaclass(nb_internals *p,
 
     if (NB_DYNAMIC_VERSION < 0x030E0000) {
         slots[4] = { Py_tp_members, (void *) members };
+        slots[5] = { Py_tp_call, PyType_GetSlot(&PyType_Type, Py_tp_call) };
         spec.flags |= Py_TPFLAGS_HAVE_VECTORCALL;
     }
 #endif


### PR DESCRIPTION
When targeting the stable ABI on Python < 3.14, the nanobind metaclass sets Py_TPFLAGS_HAVE_VECTORCALL along with a __vectorcalloffset__ member. CPython requires that any type with this flag also provide a tp_call slot and checks this before inheriting slots from the base, which tripped an assertion in debug builds. Supply type.__call__ explicitly, matching the slot that would otherwise be inherited from PyType_Type.