### PR TITLE
Use identity comparison in stubgen cycle check (fixes #1335)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -325,7 +325,8 @@ corner cases, and free-threading.
   (issue `#1263 <https://github.com/wjakob/nanobind/issues/1263>`__, PR `#1378
   <https://github.com/wjakob/nanobind/pull/1378>`__).
 
-- Miscellaneous minor fixes and improvements. (PRs `#1301
+- Miscellaneous minor fixes and improvements. (issues `#1335
+  <https://github.com/wjakob/nanobind/issues/1335>`__, PRs `#1301
   <https://github.com/wjakob/nanobind/pull/1301>`__, `#1304
   <https://github.com/wjakob/nanobind/pull/1304>`__, `#1307
   <https://github.com/wjakob/nanobind/pull/1307>`__, `#1312

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -879,8 +879,8 @@ class StubGen:
     def put(self, value: object, name: Optional[str] = None, parent: Optional[object] = None) -> None:
         old_prefix = self.prefix
 
-        if value in self.stack:
-            # Avoid infinite recursion due to cycles
+        if any(value is v for v in self.stack):
+            # Avoid infinite recursion due to cycles ('is' since '==' may be overloaded)
             return
 
         try:

--- a/tests/py_stub_test.py
+++ b/tests/py_stub_test.py
@@ -16,6 +16,19 @@ del sys
 C = 123
 T = typing.TypeVar("T")
 
+
+class ArrayLike:
+    # Mimics a NumPy array: comparisons return an object whose truth value is
+    # ambiguous. This used to crash the stub generator's cycle check (#1335).
+    def __eq__(self, other):
+        return self
+
+    def __bool__(self):
+        raise ValueError("ambiguous truth value")
+
+
+ARRAY_LIKE = ArrayLike()
+
 def f1(a, b, c, /):
     """docstring"""
 

--- a/tests/py_stub_test.pyi.ref
+++ b/tests/py_stub_test.pyi.ref
@@ -8,6 +8,15 @@ C: int = 123
 
 T = TypeVar("T")
 
+class ArrayLike:
+    def __eq__(self, other): ...
+
+    def __bool__(self): ...
+
+    __hash__: None = None
+
+ARRAY_LIKE: ArrayLike = ...
+
 def f1(a, b, c, /):
     """docstring"""
 


### PR DESCRIPTION
The stub generator detected reference cycles with 'value in self.stack', which compares using '=='. When a module attribute's type overloads '==' to return a non-boolean (e.g. a NumPy array produced by the Eigen type casters), evaluating the result's truth value raised a ValueError and crashed stub generation. Cycle detection only cares about object identity, so use 'is' instead.