### PR TITLE
stubgen: emit a docstring shared across overloads only once

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -277,6 +277,10 @@ corner cases, and free-threading.
 
 - **Stub generation improvements**:
 
+  - Docstrings repeated across a function's overloads are now emitted only
+    once, on the last overload. (issue `#1357
+    <https://github.com/wjakob/nanobind/issues/1357>`__).
+
   - ``classmethod`` and ``staticmethod`` members are now correctly
     recognized, producing exact signatures instead of generic
     ``*args, **kwargs`` stubs. (PR `#1302

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -1631,8 +1631,8 @@ PyObject *nb_func_get_nb_signature(PyObject *self, void *) {
         docstr = item = sigstr = defaults = nullptr;
 
         const func_data *fi = f + i;
-        if ((fi->flags & (uint32_t) func_flags::has_doc) &&
-            (!((nb_func *) self)->doc_uniform || i == 0)) {
+        // Expose each overload's docstring faithfully; stubgen deduplicates.
+        if (fi->flags & (uint32_t) func_flags::has_doc) {
             docstr = PyUnicode_FromString(fi->doc);
         } else {
             docstr = Py_None;

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -426,9 +426,20 @@ class StubGen:
             # No overloads write directly
             self.put_nb_overload(fn, sigs[0], name, is_classmethod=is_classmethod)
         else:
-            # Render an @overload-decorated chain
+            # Render an @overload-decorated chain. When several overloads share
+            # a docstring, keep it only on the last one: type checkers resolve
+            # to the first non-empty docstring regardless of position, while
+            # tools that read the final declaration (e.g. sphinx-autoapi) expect
+            # it there. This also avoids duplicating the text.
             overload = self.import_object("typing", "overload")
-            for s in sigs:
+            last_idx: Dict[str, int] = {}
+            for i, s in enumerate(sigs):
+                if s[1] is not None:
+                    last_idx[s[1]] = i
+            for i, s in enumerate(sigs):
+                docstr = s[1]
+                if docstr is not None and last_idx[docstr] != i:
+                    s = (s[0], None, s[2])
                 self.write_ln(f"@{overload}")
                 self.put_nb_overload(fn, s, name, is_classmethod=is_classmethod)
 

--- a/tests/test_functions.cpp
+++ b/tests/test_functions.cpp
@@ -126,6 +126,11 @@ NB_MODULE(test_functions_ext, m) {
     m.def("test_05c", [](int) -> int { return 1; }, "doc_1");
     m.def("test_05c", [](float) -> int { return 2; }, "");
 
+    // Test a partially repeated docstring followed by a distinct one
+    m.def("test_05d", [](int) -> int { return 1; }, "doc_1");
+    m.def("test_05d", [](float) -> int { return 2; }, "doc_1");
+    m.def("test_05d", [](const char *) -> int { return 3; }, "doc_2");
+
     /// Function raising an exception
     m.def("test_06", []() { throw std::runtime_error("oops!"); });
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -529,6 +529,17 @@ def test40_nb_signature():
         (r"def test_05(arg: int, /) -> int", "doc_1", None),
         (r"def test_05(arg: float, /) -> int", "doc_2", None),
     )
+    # Uniform and partially-repeated docstrings are exposed faithfully here;
+    # deduplication for stubs happens in stubgen (see issue #1357).
+    assert t.test_05b.__nb_signature__ == (
+        (r"def test_05b(arg: int, /) -> int", "doc_1", None),
+        (r"def test_05b(arg: float, /) -> int", "doc_1", None),
+    )
+    assert t.test_05d.__nb_signature__ == (
+        (r"def test_05d(arg: int, /) -> int", "doc_1", None),
+        (r"def test_05d(arg: float, /) -> int", "doc_1", None),
+        (r"def test_05d(arg: str, /) -> int", "doc_2", None),
+    )
     assert t.test_07.__nb_signature__ == (
         (
             r"def test_07(arg0: int, arg1: int, /, *args, **kwargs) -> tuple[int, int]",

--- a/tests/test_functions_ext.pyi.ref
+++ b/tests/test_functions_ext.pyi.ref
@@ -22,11 +22,11 @@ def test_05(arg: float, /) -> int:
     """doc_2"""
 
 @overload
-def test_05b(arg: int, /) -> int:
-    """doc_1"""
+def test_05b(arg: int, /) -> int: ...
 
 @overload
-def test_05b(arg: float, /) -> int: ...
+def test_05b(arg: float, /) -> int:
+    """doc_1"""
 
 @overload
 def test_05c(arg: int, /) -> int:
@@ -34,6 +34,17 @@ def test_05c(arg: int, /) -> int:
 
 @overload
 def test_05c(arg: float, /) -> int: ...
+
+@overload
+def test_05d(arg: int, /) -> int: ...
+
+@overload
+def test_05d(arg: float, /) -> int:
+    """doc_1"""
+
+@overload
+def test_05d(arg: str, /) -> int:
+    """doc_2"""
 
 def test_06() -> None: ...
 


### PR DESCRIPTION
The __nb_signature__ property collapsed uniform overload-docstring chains, exposing the docstring only on the first overload. This made uniform docs indistinguishable from chains where only the first overload is documented, and prevented stubgen from placing the docstring where tools expect it.

Expose each overload's docstring faithfully in __nb_signature__, and have stubgen keep a repeated docstring only on the last overload that carries it. Type checkers resolve to the first non-empty docstring regardless of position, while tools that read the final declaration (e.g. sphinx-autoapi) find it there. This also avoids duplicating the text.

Fixes #1357