### PR TITLE
ndarray: accept and ignore the ``__dlpack__`` stream argument

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -1128,6 +1128,13 @@ convert into an equivalent representation in one of the following frameworks:
    An object that both implements the buffer protocol and also has the
    ``__dlpack__`` and ``__dlpack_device__`` attributes.
 
+.. cpp:class:: no_framework
+
+   The default when no framework annotation is given. Instead of a
+   framework-specific array, the :cpp:class:`nb::ndarray <ndarray>` converts
+   into a raw `DLPack <https://github.com/dmlc/dlpack>`__ capsule wrapping a
+   ``DLManagedTensor``.
+
 Eigen convenience type aliases
 ------------------------------
 

--- a/docs/ndarray.rst
+++ b/docs/ndarray.rst
@@ -281,7 +281,8 @@ desired Python type.
   and also has the DLPack attributes  ``__dlpack__`` and ``__dlpack_device__``
   (i.e., it is accepted as an argument to a framework's ``from_dlpack()``
   function).
-- No framework annotation. In this case, nanobind will create a raw Python
+- :cpp:class:`nb::no_framework <no_framework>` (the default when no framework
+  annotation is given). In this case, nanobind will create a raw Python
   ``dltensor`` `capsule <https://docs.python.org/3/c-api/capsule.html>`__
   representing the `DLPack <https://github.com/dmlc/dlpack>`__ metadata of
   a ``DLManagedTensor``.
@@ -762,6 +763,25 @@ used to support additional parameters (e.g., to allow the caller to request a
 copy).  See
 `__dlpack__() <https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html>`__
 in the Python array API standard for details.
+
+**Stream synchronization.** The array API's ``__dlpack__`` accepts a ``stream``
+argument through which a *consumer* asks the *producer* to make the array safe
+to access on a particular compute stream (for example, via a cross-stream wait
+on CUDA or ROCm). The object nanobind returns for :cpp:class:`nb::array_api
+<array_api>` accepts this argument but performs no synchronization. nanobind has
+no build-time dependency on CUDA, ROCm, or any other backend and treats the
+device as mere metadata, so it knows neither the stream that produced the data
+nor the runtime needed to act on it. This is harmless when the memory is
+host-resident or when the producing computations are inherently serialized with
+respect to the consumer (for example, by running on CUDA's default "null"
+stream). If you instead export device memory still being produced asynchronously
+on a separate stream, you must handle synchronization yourself. Expose your own
+object providing ``__dlpack__`` and ``__dlpack_device__`` methods. The
+``__dlpack__`` method should inspect ``stream``, perform the wait via your
+backend's API, and then return a DLPack capsule, which can be obtained by
+casting an :cpp:class:`nb::ndarray\<\> <ndarray>` that has no framework
+annotation. The ``__dlpack_device__`` method should report the device as a
+``(device_type, device_id)`` pair.
 
 
 Frequently asked questions

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -355,11 +355,8 @@ static PyObject *nb_ndarray_dlpack(PyObject *self, PyObject *const *args,
                     max_major_version = a;
                 }
             } else if (compare(key, NB_INTERNED(stream))) {
-                if (value != Py_None) {
-                    PyErr_SetString(PyExc_RuntimeError,
-                            "nanobind only supports stream=None.");
-                    return -1;
-                }
+                // Accepted but ignored: nanobind tracks no producer stream and
+                // has no backend dependency, so it cannot synchronize. See docs.
             } else {
                 return i;
             }

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -536,10 +536,10 @@ def test20a_dlpack_copy_device_kwargs():
     with pytest.raises(BufferError):
         obj.__dlpack__(dl_device=(99, 0))
 
-    # stream=None is fine, other values are rejected
+    # stream is accepted and ignored
     assert 'dltensor' in repr(obj.__dlpack__(stream=None))
-    with pytest.raises(RuntimeError):
-        obj.__dlpack__(stream=0)
+    assert 'dltensor' in repr(obj.__dlpack__(stream=0))
+    assert 'dltensor' in repr(obj.__dlpack__(stream=1))
 
     # Keyword names passed via f(**d) need not be interned/identical to the
     # internal references; equal-but-distinct strings must behave identically.
@@ -547,8 +547,7 @@ def test20a_dlpack_copy_device_kwargs():
         obj.__dlpack__(**{''.join(['co', 'py']): True})
     with pytest.raises(BufferError):
         obj.__dlpack__(**{''.join(['dl_', 'device']): (99, 0)})
-    with pytest.raises(RuntimeError):
-        obj.__dlpack__(**{''.join(['str', 'eam']): "0"})
+    assert 'dltensor' in repr(obj.__dlpack__(**{''.join(['str', 'eam']): "0"}))
     assert 'dltensor' in repr(obj.__dlpack__(**{''.join(['co', 'py']): False}))
 
     # Unrecognized keyword names (e.g., misspellings) are rejected


### PR DESCRIPTION
This commit adapts ``nb_ndarray`` so that its ``__dlpack__()`` method ignores the ``stream`` argument. The documentation explains the rationale and explains how to deal with situations requiring synchronization.