### PR TITLE
ndarray: support returning Apple MLX arrays (`nb::ndarray<nb::mlx>`)

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -1119,6 +1119,11 @@ convert into an equivalent representation in one of the following frameworks:
 
 .. cpp:class:: cupy
 
+.. cpp:class:: mlx
+
+   Apple ``mlx.core.array``. The constructor always copies into a
+   unified-memory buffer, so a requested copy is performed inherently.
+
 .. cpp:class:: memview
 
    Builtin Python ``memoryview`` for CPU-resident data.

--- a/docs/ndarray.rst
+++ b/docs/ndarray.rst
@@ -8,7 +8,8 @@ The ``nb::ndarray<..>`` class
 nanobind can exchange n-dimensional arrays (henceforth "**nd-arrays**") with
 popular array programming frameworks including `NumPy <https://numpy.org>`__,
 `PyTorch <https://pytorch.org>`__, `TensorFlow <https://www.tensorflow.org>`__,
-`JAX <https://jax.readthedocs.io>`__, and `CuPy <https://cupy.dev>`_. It
+`JAX <https://jax.readthedocs.io>`__, `CuPy <https://cupy.dev>`__, and
+`MLX <https://ml-explore.github.io/mlx>`__. It
 supports *zero-copy* exchange using two protocols:
 
 -  The classic `buffer
@@ -275,6 +276,7 @@ desired Python type.
 - :cpp:class:`nb::tensorflow <tensorflow>`: create a ``tensorflow.python.framework.ops.EagerTensor``.
 - :cpp:class:`nb::jax <jax>`: create a ``jaxlib.xla_extension.DeviceArray``.
 - :cpp:class:`nb::cupy <cupy>`: create a ``cupy.ndarray``.
+- :cpp:class:`nb::mlx <mlx>`: create an Apple ``mlx.core.array``.
 - :cpp:class:`nb::memview <memview>`: create a Python ``memoryview``.
 - :cpp:class:`nb::array_api <array_api>`: create an object that supports the
   Python buffer protocol (i.e., is accepted as an argument to ``memoryview()``)
@@ -471,6 +473,9 @@ nanobind itself.
 For example, ``numpy.array()`` is passed the keyword argument ``copy`` with
 value ``True``, or the PyTorch tensor's ``clone()`` method is immediately
 called to create the copy.
+MLX is a special case: ``mlx.core.array()`` always copies into a unified-memory
+buffer (and provides no ``copy()``/``clone()`` method), so a requested copy is
+satisfied inherently without an extra step.
 This design has a couple of advantages.
 First, nanobind does not have a build-time dependency on the libraries and
 frameworks (NumPy, PyTorch, CUDA, etc.) that would otherwise be necessary

--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -93,6 +93,7 @@ NB_FRAMEWORK(jax, 4, "jaxlib.xla_extension.DeviceArray");
 NB_FRAMEWORK(cupy, 5, "cupy.ndarray");
 NB_FRAMEWORK(memview, 6, "memoryview");
 NB_FRAMEWORK(array_api, 7, "ArrayLike");
+NB_FRAMEWORK(mlx, 8, "mlx.core.array");
 
 NAMESPACE_BEGIN(device)
 NB_DEVICE(none, 0); NB_DEVICE(cpu, 1); NB_DEVICE(cuda, 2);

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -358,6 +358,7 @@ enum ndarray_export_slot {
     nd_export_tensorflow, // tensorflow.experimental.dlpack.from_dlpack
     nd_export_jax,        // jax.dlpack.from_dlpack
     nd_export_cupy,       // cupy.from_dlpack
+    nd_export_mlx,        // mlx.core.array (constructor, not from_dlpack)
     nd_export_count
 };
 

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -1088,6 +1088,7 @@ static constexpr struct { const char *pkg, *attr; }
         { "tensorflow.experimental.dlpack", "from_dlpack" },
         { "jax.dlpack",                     "from_dlpack" },
         { "cupy",                           "from_dlpack" },
+        { "mlx.core",                       "array"       },
     };
 
 /// Resolve (and cache) the callable for an ``ndarray_export`` cache slot.
@@ -1215,6 +1216,7 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
             case tensorflow::value: slot = nd_export_tensorflow; break;
             case jax::value:        slot = nd_export_jax;        break;
             case cupy::value:       slot = nd_export_cupy;       break;
+            case mlx::value:        slot = nd_export_mlx;        break;
             case memview::value:    return PyMemoryView_FromObject(o.ptr());
             default:                slot = nd_export_count;  // no export call
         }
@@ -1234,13 +1236,11 @@ PyObject *ndarray_export(ndarray_handle *th, int framework,
         return nullptr;
     }
 
-    if (copy) {
-        PyObject* copy_fn_name = NB_INTERNED(copy);
-        if (framework == pytorch::value)
-            copy_fn_name = NB_INTERNED(clone);
-        else
-            copy_fn_name = NB_INTERNED(copy);
-
+    // MLX has no copy()/clone() method; mlx.core.array() already returned an
+    // owned copy, so the copy policy is satisfied without an extra step.
+    if (copy && framework != mlx::value) {
+        PyObject* copy_fn_name = framework == pytorch::value ? NB_INTERNED(clone)
+                                                             : NB_INTERNED(copy);
         try {
             o = o.attr(copy_fn_name)();
         } catch (std::exception &e) {

--- a/tests/test_ndarray.cpp
+++ b/tests/test_ndarray.cpp
@@ -370,6 +370,19 @@ NB_MODULE(test_ndarray_ext, m) {
                                                                 deleter);
     });
 
+    m.def("ret_mlx", []() {
+        float *f = new float[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        size_t shape[2] = { 2, 4 };
+
+        nb::capsule deleter(f, [](void *data) noexcept {
+           destruct_count++;
+           delete[] (float *) data;
+        });
+
+        return nb::ndarray<nb::mlx, float, nb::shape<2, 4>>(f, 2, shape,
+                                                            deleter);
+    });
+
     m.def("ret_memview", []() {
         double *d = new double[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
         size_t shape[2] = { 2, 4 };

--- a/tests/test_ndarray.py
+++ b/tests/test_ndarray.py
@@ -31,6 +31,13 @@ try:
 except:
     needs_cupy = pytest.mark.skip(reason="CuPy is required")
 
+try:
+    import mlx.core as mx
+    def needs_mlx(x):
+        return x
+except:
+    needs_mlx = pytest.mark.skip(reason="MLX is required")
+
 
 @needs_numpy
 def test01_metadata():
@@ -361,6 +368,25 @@ def test18_return_pytorch():
     x = t.ret_pytorch()
     assert x.shape == (2, 4)
     assert torch.all(x == torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]]))
+    del x
+    collect()
+    assert t.destruct_count() - dc == 1
+
+
+@needs_mlx
+def test18b_return_mlx():
+    collect()
+    dc = t.destruct_count()
+    x = t.ret_mlx()
+    assert isinstance(x, mx.array)
+    assert x.shape == (2, 4)
+    assert x.dtype == mx.float32
+    expect = mx.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=mx.float32)
+    assert bool(mx.all(x == expect))
+    # mlx.core.array() copies, so the source buffer is released immediately
+    # rather than on `del` (as with the zero-copy dlpack frameworks).
+    collect()
+    assert t.destruct_count() - dc == 1
     del x
     collect()
     assert t.destruct_count() - dc == 1

--- a/tests/test_ndarray_ext.pyi.ref
+++ b/tests/test_ndarray_ext.pyi.ref
@@ -1,5 +1,6 @@
 from typing import Annotated, overload
 
+import mlx.core
 import numpy
 from numpy.typing import NDArray
 
@@ -127,6 +128,8 @@ def ret_numpy_const_ref_f() -> Annotated[NDArray[numpy.float32], dict(shape=(2, 
 def ret_numpy_const() -> Annotated[NDArray[numpy.float32], dict(shape=(2, 4), writable=False)]: ...
 
 def ret_pytorch() -> Annotated[NDArray[numpy.float32], dict(shape=(2, 4))]: ...
+
+def ret_mlx() -> mlx.core.array[dtype=float32, shape=(2, 4)]: ...
 
 def ret_memview() -> memoryview[dtype=float64, shape=(2, 4)]: ...
 

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -17,6 +17,9 @@ def remove_platform_dependent(s):
         v = s[i]
         if v.strip().startswith('float16'):
             i += 1
+        elif v == 'import mlx.core':
+            s2.append('import mlx')
+            i += 1
         elif v.startswith('def ret_numpy_half()') or \
            v.startswith('def test_slots()') or \
            v.startswith('TypeAlias'):


### PR DESCRIPTION
Add MLX as an export framework.  One wrinkle is that `mlx.core.array()` always copies into an MLX-managed buffer, i.e., the typical zero copy approach seem to not be supported.