### PR TITLE
Initial AIX port

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -230,7 +230,7 @@ function (nanobind_build_library TARGET_NAME)
     nanobind_lto(${TARGET_NAME})
 
     nanobind_strip(${TARGET_NAME})
-  elseif(NOT WIN32 AND NOT APPLE)
+  elseif(NOT WIN32 AND NOT APPLE AND NOT AIX)
     target_compile_options(${TARGET_NAME} PUBLIC $<${NB_OPT_SIZE}:-ffunction-sections -fdata-sections>)
     target_link_options(${TARGET_NAME} PUBLIC $<${NB_OPT_SIZE}:-Wl,--gc-sections>)
   endif()

--- a/src/nb_internals.h
+++ b/src/nb_internals.h
@@ -24,6 +24,10 @@
 #include <functional>
 #include "hash.h"
 
+#if defined(_AIX) && defined(func_data)
+# undef func_data
+#endif
+
 #if TSL_RH_VERSION_MAJOR != 1 || TSL_RH_VERSION_MINOR < 3
 #  error nanobind depends on tsl::robin_map, in particular version >= 1.3.0, <2.0.0
 #endif


### PR DESCRIPTION
This patch resolves some macro redefinition errors and linker flag errors on AIX.