### PR TITLE
Make TypeError message more helpful when subclasses forget to call __init__

### DIFF
--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -520,24 +520,14 @@ PyObject *nb_func_new(const func_data_prelim_base *f) noexcept {
     }
 }
 
-static void nb_func_put_uninitialized_arg_hint(PyObject *const *args,
-                                                size_t nargs,
-                                                size_t start) noexcept {
-    for (size_t i = start; i < nargs; ++i) {
-        PyObject *arg = args[i];
-        if (!nb_type_check((PyObject *) Py_TYPE(arg)))
-            continue;
+static void nb_func_put_arg_type(PyObject *arg) noexcept {
+    str name = steal<str>(nb_inst_name(arg));
+    buf.put_dstr(name.c_str());
 
+    if (nb_type_check((PyObject *) Py_TYPE(arg))) {
         nb_inst *inst = (nb_inst *) arg;
-        if (inst->state.state != nb_inst_state::state_uninitialized)
-            continue;
-
-        str name = steal<str>(nb_inst_name(arg));
-        buf.put("\n\nHint: instance is not initialized (of type ");
-        buf.put_dstr(name.c_str());
-        buf.put("). This can happen when a Python subclass overrides ");
-        buf.put("`__init__` but does not call `super().__init__()`.");
-        return;
+        if (inst->state.state == nb_inst_state::state_uninitialized)
+            buf.put(" (__init__() not called)");
     }
 }
 
@@ -575,8 +565,7 @@ nb_func_error_overload(PyObject *self, PyObject *const *args_in,
 
     buf.put("\nInvoked with types: ");
     for (size_t i = 0; i < nargs_in; ++i) {
-        str name = steal<str>(nb_inst_name(args_in[i]));
-        buf.put_dstr(name.c_str());
+        nb_func_put_arg_type(args_in[i]);
         if (i + 1 < nargs_in)
             buf.put(", ");
     }
@@ -598,19 +587,12 @@ nb_func_error_overload(PyObject *self, PyObject *const *args_in,
             }
             buf.put_dstr(key_cstr);
             buf.put(": ");
-            str name = steal<str>(nb_inst_name(value));
-            buf.put_dstr(name.c_str());
+            nb_func_put_arg_type(value);
             buf.put(", ");
         }
         buf.rewind(2);
         buf.put(" }");
     }
-
-    size_t nargs_total = nargs_in;
-    if (kwargs_in)
-        nargs_total += (size_t) NB_TUPLE_GET_SIZE(kwargs_in);
-    size_t hint_start = (f->flags & (uint32_t) func_flags::is_constructor) ? 1 : 0;
-    nb_func_put_uninitialized_arg_hint(args_in, nargs_total, hint_start);
 
     PyErr_SetString(PyExc_TypeError, buf.get());
     return nullptr;

--- a/src/nb_func.cpp
+++ b/src/nb_func.cpp
@@ -520,6 +520,27 @@ PyObject *nb_func_new(const func_data_prelim_base *f) noexcept {
     }
 }
 
+static void nb_func_put_uninitialized_arg_hint(PyObject *const *args,
+                                                size_t nargs,
+                                                size_t start) noexcept {
+    for (size_t i = start; i < nargs; ++i) {
+        PyObject *arg = args[i];
+        if (!nb_type_check((PyObject *) Py_TYPE(arg)))
+            continue;
+
+        nb_inst *inst = (nb_inst *) arg;
+        if (inst->state.state != nb_inst_state::state_uninitialized)
+            continue;
+
+        str name = steal<str>(nb_inst_name(arg));
+        buf.put("\n\nHint: instance is not initialized (of type ");
+        buf.put_dstr(name.c_str());
+        buf.put("). This can happen when a Python subclass overrides ");
+        buf.put("`__init__` but does not call `super().__init__()`.");
+        return;
+    }
+}
+
 /// Used by nb_func_vectorcall: generate an error when overload resolution fails
 static NB_NOINLINE PyObject *
 nb_func_error_overload(PyObject *self, PyObject *const *args_in,
@@ -584,6 +605,12 @@ nb_func_error_overload(PyObject *self, PyObject *const *args_in,
         buf.rewind(2);
         buf.put(" }");
     }
+
+    size_t nargs_total = nargs_in;
+    if (kwargs_in)
+        nargs_total += (size_t) NB_TUPLE_GET_SIZE(kwargs_in);
+    size_t hint_start = (f->flags & (uint32_t) func_flags::is_constructor) ? 1 : 0;
+    nb_func_put_uninitialized_arg_hint(args_in, nargs_total, hint_start);
 
     PyErr_SetString(PyExc_TypeError, buf.get());
     return nullptr;

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -250,16 +250,28 @@ def test10b_missing_super_init_hint():
         with pytest.raises(TypeError) as excinfo:
             s.value()
 
-    assert "instance is not initialized" in str(excinfo.value)
-    assert "super().__init__()" in str(excinfo.value)
+    msg = str(excinfo.value)
+    assert "test_classes.MissingInit (__init__() not called)" in msg
+    assert "instance is not initialized" not in msg
+    assert "super().__init__()" not in msg
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        with pytest.raises(TypeError) as excinfo:
+            t.none_2(arg=s)
+
+    msg = str(excinfo.value)
+    assert "arg: test_classes.MissingInit (__init__() not called)" in msg
 
 
-def test10c_constructor_error_no_missing_super_hint():
+def test10c_constructor_error_reports_uninitialized_self():
     with pytest.raises(TypeError) as excinfo:
         t.Struct("bad")
 
-    assert "instance is not initialized" not in str(excinfo.value)
-    assert "super().__init__()" not in str(excinfo.value)
+    msg = str(excinfo.value)
+    assert "test_classes_ext.Struct (__init__() not called)" in msg
+    assert "instance is not initialized" not in msg
+    assert "super().__init__()" not in msg
 
 
 def test11_trampoline_failures():

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 import test_classes_ext as t
 import pytest
 from common import skip_on_pypy, collect, parallelize
@@ -236,6 +237,29 @@ def test10_trampoline(clean):
     d = GenericDog("GenericDog")
     assert t.dog_passthrough(d) is d
     assert t.animal_passthrough(d) is d
+
+
+def test10b_missing_super_init_hint():
+    class MissingInit(t.Struct):
+        def __init__(self):
+            pass
+
+    s = MissingInit()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        with pytest.raises(TypeError) as excinfo:
+            s.value()
+
+    assert "instance is not initialized" in str(excinfo.value)
+    assert "super().__init__()" in str(excinfo.value)
+
+
+def test10c_constructor_error_no_missing_super_hint():
+    with pytest.raises(TypeError) as excinfo:
+        t.Struct("bad")
+
+    assert "instance is not initialized" not in str(excinfo.value)
+    assert "super().__init__()" not in str(excinfo.value)
 
 
 def test11_trampoline_failures():


### PR DESCRIPTION
Alternative implementation of a fix for #1210. Created via AI, but I tested it manually and it works.
```python
import sys
sys.path += ["./build/tests"]

import test_classes_ext as t

class MissingInit(t.Struct):
    def __init__(self):
        pass

s = MissingInit()
s.value()
```

```
# python3 t.py 
/home/virtuald/nanobind/t.py:11: RuntimeWarning: nanobind: attempted to access an uninitialized instance of type '__main__.MissingInit'!

  s.value()
Traceback (most recent call last):
  File "/home/virtuald/nanobind/t.py", line 11, in <module>
    s.value()
    ~~~~~~~^^
TypeError: value(): incompatible function arguments. The following argument types are supported:
    1. value(self) -> int

Invoked with types: __main__.MissingInit

Hint: instance is not initialized (of type __main__.MissingInit). This can happen when a Python subclass overrides `__init__` but does not call `super().__init__()`.
```

One thing that's different from #1224 and pybind11 is that it doesn't attempt to tell the user they messed up immediately since that adds a performance hit for each constructor and I couldn't find a way to avoid that. Instead, since there's already an (unhelpful) error message that throws a type error, this just adds the detection there so the performance hit is only in potential error cases.

... I don't actually like how it implemented this (nor do I like the hint message..), but posting it for @wjakob to see what you think of the approach. If this seems like an acceptable approach, I can iterate on it some more.