### PR TITLE
Make stubgen independent of minor python version

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -641,7 +641,7 @@ endfunction()
 # ---------------------------------------------------------------------------
 
 function (nanobind_add_stub name)
-  cmake_parse_arguments(PARSE_ARGV 1 ARG "VERBOSE;INCLUDE_PRIVATE;EXCLUDE_DOCSTRINGS;EXCLUDE_VALUES;INSTALL_TIME;RECURSIVE;EXCLUDE_FROM_ALL" "MODULE;COMPONENT;PATTERN_FILE;OUTPUT_PATH" "PYTHON_PATH;DEPENDS;MARKER_FILE;OUTPUT")
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "VERBOSE;INCLUDE_PRIVATE;EXCLUDE_DOCSTRINGS;EXCLUDE_VALUES;INSTALL_TIME;RECURSIVE;EXCLUDE_FROM_ALL" "MODULE;COMPONENT;PATTERN_FILE;OUTPUT_PATH;MIN_PYTHON_VERSION" "PYTHON_PATH;DEPENDS;MARKER_FILE;OUTPUT")
 
   if (EXISTS ${NB_DIR}/src/stubgen.py)
     set(NB_STUBGEN "${NB_DIR}/src/stubgen.py")
@@ -679,6 +679,10 @@ function (nanobind_add_stub name)
 
   if (ARG_PATTERN_FILE)
     list(APPEND NB_STUBGEN_ARGS -p "${ARG_PATTERN_FILE}")
+  endif()
+
+  if (ARG_MIN_PYTHON_VERSION)
+    list(APPEND NB_STUBGEN_ARGS --min-python-version "${ARG_MIN_PYTHON_VERSION}")
   endif()
 
   if (ARG_MARKER_FILE)

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -98,6 +98,39 @@ SKIP_LIST = [
     "_unhashable_values_map_", "_value_repr_",
 ]
 
+# Python version in which various ``typing.*`` members were first introduced
+TYPING_INTRODUCED: Dict[str, Tuple[int, int]] = {
+    "Annotated": (3, 9),
+    "Concatenate": (3, 10),
+    "ParamSpec": (3, 10),
+    "ParamSpecArgs": (3, 10),
+    "ParamSpecKwargs": (3, 10),
+    "TypeAlias": (3, 10),
+    "TypeGuard": (3, 10),
+    "is_typeddict": (3, 10),
+    "LiteralString": (3, 11),
+    "Never": (3, 11),
+    "NotRequired": (3, 11),
+    "Required": (3, 11),
+    "Self": (3, 11),
+    "TypeVarTuple": (3, 11),
+    "Unpack": (3, 11),
+    "assert_never": (3, 11),
+    "assert_type": (3, 11),
+    "clear_overloads": (3, 11),
+    "dataclass_transform": (3, 11),
+    "get_overloads": (3, 11),
+    "reveal_type": (3, 11),
+    "TypeAliasType": (3, 12),
+    "override": (3, 12),
+    "NoDefault": (3, 13),
+    "ReadOnly": (3, 13),
+    "TypeIs": (3, 13),
+    "get_protocol_members": (3, 13),
+    "is_protocol": (3, 13),
+    "evaluate_forward_ref": (3, 14),
+}
+
 # Interpreter-internal types.
 TYPES_TYPES = {
     getattr(types, name): name for name in [
@@ -212,7 +245,8 @@ class StubGen:
         max_expr_length: int = 50,
         patterns: List[ReplacePattern] = [],
         quiet: bool = True,
-        output_file: Optional[Path] = None
+        output_file: Optional[Path] = None,
+        min_python: Optional[Tuple[int, int]] = None
     ) -> None:
         # Module to check for name conflicts when adding helper imports
         self.module = module
@@ -243,6 +277,9 @@ class StubGen:
 
         # Target filename, only needed for recursive stub generation
         self.output_file = output_file
+
+        # Oldest target Python version (e.g. ``(3, 9)``)
+        self.min_python = min_python
 
         # ---------- Internal fields ----------
 
@@ -583,10 +620,7 @@ class StubGen:
 
             if same_module:
                 # This is an alias of a type in the same module or same top-level module
-                if sys.version_info >= (3, 10, 0):
-                    alias_tp = self.import_object("typing", "TypeAlias")
-                else:
-                    alias_tp = self.import_object("typing_extensions", "TypeAlias")
+                alias_tp = self.import_object(self.typing_module((3, 10)), "TypeAlias")
                 self.write_ln(f"{name}: {alias_tp} = {tp.__qualname__}\n")
             elif self.include_external_imports or (same_toplevel_module and self.include_internal_imports):
                 # Import from a different module
@@ -608,6 +642,14 @@ class StubGen:
                     if tp_bases is None:
                         tp_bases = tp.__bases__
                     tp_bases = [self.type_str(base) for base in tp_bases]
+
+                # 'enum.StrEnum' only exists on Python 3.11+. When targeting
+                # older versions, emit the equivalent bases that nanobind
+                # itself uses there for string-valued enumerations
+                if self.min_python and self.min_python < (3, 11) \
+                        and "enum.StrEnum" in tp_bases:
+                    pos = tp_bases.index("enum.StrEnum")
+                    tp_bases[pos:pos + 1] = ["str", "enum.Enum"]
 
                 if tp_bases != ["object"]:
                     self._replace_tail(2, "(")
@@ -690,10 +732,7 @@ class StubGen:
             if self.is_type_var(tp):
                 types = ""
             elif typing.get_origin(value):
-                if sys.version_info >= (3, 10, 0):
-                    types = ": " + self.import_object("typing", "TypeAlias")
-                else:
-                    types = ": " + self.import_object("typing_extensions", "TypeAlias")
+                types = ": " + self.import_object(self.typing_module((3, 10)), "TypeAlias")
             else:
                 types = f": {self.type_str(tp)}"
 
@@ -747,6 +786,15 @@ class StubGen:
         s = self.ndarray_re.sub(lambda m: self._format_ndarray(m.group(2)), s)
 
         s = self.abc_re.sub(r'collections.abc.\1', s)
+
+        # Normalize 'CapsuleType', it's baked into extension signatures
+        if self.min_python:
+            if self.min_python < (3, 13):
+                s = s.replace("types.CapsuleType", "typing_extensions.CapsuleType")
+            else:
+                s = s.replace("typing_extensions.CapsuleType", "types.CapsuleType")
+            if self.min_python < (3, 10):
+                s = s.replace("types.EllipsisType", "ellipsis")
 
         # Process other type names and add suitable import statements
         def process_general(m: Match[str]) -> str:
@@ -1023,6 +1071,15 @@ class StubGen:
             self.stack.pop()
             self.prefix = old_prefix
 
+    def typing_module(self, introduced: Tuple[int, int]) -> str:
+        """
+        Return ``typing`` or ``typing_extensions`` depending on the minimum 
+        Python version (defaults to currently executing Python version).
+
+        """
+        version = self.min_python or sys.version_info[:2]
+        return "typing" if version >= introduced else "typing_extensions"
+
     def import_object(
         self, module: str, name: Optional[str], as_name: Optional[str] = None
     ) -> str:
@@ -1035,6 +1092,28 @@ class StubGen:
         """
         if module == "builtins" and name and (not as_name or name == as_name):
             return name
+
+        # When targeting an explicit minimum Python version, import members
+        # that ``typing`` does not provide from ``typing_extensions``
+        if self.min_python and module == "typing" and name:
+            introduced = TYPING_INTRODUCED.get(name)
+            module = module if not introduced else self.typing_module(introduced)
+
+        # ``typing_extensions`` re-exports the ``typing`` API. Avoid conflicts by
+        # moving the import to ``typing_extensions`` if it was already imported
+        if name and not as_name:
+            if module == "typing":
+                te_name = self.imports.get("typing_extensions", {}).get((name, None))
+                if te_name:
+                    return te_name
+            elif module == "typing_extensions":
+                # Check if this was already imported from ``typing``
+                # and move it to ``typing_extensions`` if so                
+                t_imports = self.imports.get("typing", None)
+                if t_imports and (name, None) in t_imports:
+                    moved = t_imports.pop((name, None))
+                    self.imports.setdefault("typing_extensions", {})[(name, None)] = moved
+                    return moved if moved else ""
 
         # Rewrite module name if this is relative import from a submodule
         if module.startswith(self.module.__name__ + '.') and module != self.module.__name__:
@@ -1113,12 +1192,13 @@ class StubGen:
             return self.type_str(tp) + '.' + e._name_
         elif (sys.version_info >= (3, 10) and issubclass(tp, typing.ParamSpec)) \
             or (typing_extensions is not None and issubclass(tp, typing_extensions.ParamSpec)):
-            tv = self.import_object(tp.__module__, "ParamSpec")
+            mod = tp.__module__ if tp.__module__ != "typing" else self.typing_module((3, 10))
+            tv = self.import_object(mod, "ParamSpec")
             return f'{tv}("{e.__name__}")'
         elif (sys.version_info >= (3, 11) and issubclass(tp, typing.TypeVarTuple)) \
             or (typing_extensions is not None and issubclass(tp, typing_extensions.TypeVarTuple)):
-            tv = self.import_object(tp.__module__, "TypeVarTuple")
-            s = f'{tv}("{e.__name__}"'
+            introduced = (3, 11)
+            s = f'("{e.__name__}"'
             if sys.version_info >= (3, 13):
                 v = e.__default__
                 if v is not typing.NoDefault:
@@ -1126,10 +1206,13 @@ class StubGen:
                     if v is None:
                         return None
                     s += ", default=" + v
-            return s + ')'
+                    introduced = (3, 13)
+            mod = tp.__module__ if tp.__module__ != "typing" else self.typing_module(introduced)
+            tv = self.import_object(mod, "TypeVarTuple")
+            return tv + s + ')'
         elif issubclass(tp, typing.TypeVar):
-            tv = self.import_object("typing", "TypeVar")
-            s = f'{tv}("{e.__name__}"'
+            introduced = (3, 0)
+            s = f'("{e.__name__}"'
             for v in getattr(e, "__constraints__", ()):
                 v = self.type_str(v)
                 assert v
@@ -1145,6 +1228,8 @@ class StubGen:
                     if v is None:
                         return None
                     s += f", {k}=" + v
+                    if k == "infer_variance":
+                        introduced = (3, 12)
             if sys.version_info >= (3, 13):
                 v = e.__default__
                 if v is not typing.NoDefault:
@@ -1152,8 +1237,10 @@ class StubGen:
                     if v is None:
                         return None
                     s += ", default=" + v
+                    introduced = (3, 13)
             s += ")"
-            return s
+            tv = self.import_object(self.typing_module(introduced), "TypeVar")
+            return tv + s
         elif issubclass(tp, str):
             s = repr(e)
             if len(s) < self.max_expr_length or not abbrev:
@@ -1451,6 +1538,15 @@ def parse_options(args: List[str]) -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--min-python-version",
+        metavar="VERSION",
+        dest="min_python",
+        default=None,
+        help="ensure that generated stubs are valid for Python >= VERSION "
+        "(e.g. '3.9') independent of the interpreter running stubgen",
+    )
+
+    parser.add_argument(
         "-q",
         "--quiet",
         default=False,
@@ -1469,6 +1565,11 @@ def parse_options(args: List[str]) -> argparse.Namespace:
         parser.error(
             "The -o option is not compatible with recursive stub generation (-r)."
         )
+    if opt.min_python is not None:
+        version_match = re.match(r"^3\.(\d+)$", opt.min_python)
+        if not version_match:
+            parser.error("--min-python-version: expected a version of the form '3.X'.")
+        opt.min_python = (3, int(version_match.group(1)))
     return opt
 
 
@@ -1595,7 +1696,8 @@ def main(args: Optional[List[str]] = None) -> None:
             include_private=opt.include_private,
             max_expr_length=0 if opt.exclude_values else 50,
             patterns=patterns,
-            output_file=file
+            output_file=file,
+            min_python=opt.min_python
         )
 
         if not opt.quiet:

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -1102,22 +1102,6 @@ class StubGen:
             introduced = TYPING_INTRODUCED.get(name)
             module = module if not introduced else self.typing_module(introduced)
 
-        # ``typing_extensions`` re-exports the ``typing`` API. Avoid conflicts by
-        # moving the import to ``typing_extensions`` if it was already imported
-        if name and not as_name:
-            if module == "typing":
-                te_name = self.imports.get("typing_extensions", {}).get((name, None))
-                if te_name:
-                    return te_name
-            elif module == "typing_extensions":
-                # Check if this was already imported from ``typing``
-                # and move it to ``typing_extensions`` if so                
-                t_imports = self.imports.get("typing", None)
-                if t_imports and (name, None) in t_imports:
-                    moved = t_imports.pop((name, None))
-                    self.imports.setdefault("typing_extensions", {})[(name, None)] = moved
-                    return moved if moved else ""
-
         # Rewrite module name if this is relative import from a submodule
         if module.startswith(self.module.__name__ + '.') and module != self.module.__name__:
             module_short = module[len(self.module.__name__) :]
@@ -1397,6 +1381,17 @@ class StubGen:
     def get(self) -> str:
         """Generate the final stub output"""
         s = ""
+
+        # ``typing_extensions`` re-exports the ``typing`` API. Keep  copy,
+        # import names are identical
+        typing_imports = self.imports.get("typing")
+        te_imports = self.imports.get("typing_extensions")
+        if typing_imports and te_imports:
+            for key in list(typing_imports):
+                name, as_name = key
+                # keep "as" import names in ``typing``
+                if name and not as_name and key in te_imports:
+                    del typing_imports[key]
 
         # Potentially add a module docstring
         doc = getattr(self.module, '__doc__', None)

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -131,6 +131,9 @@ TYPING_INTRODUCED: Dict[str, Tuple[int, int]] = {
     "evaluate_forward_ref": (3, 14),
 }
 
+# Oldest Python version that stubgen supports targeting.
+MIN_PYTHON_VERSION = (3, 9)
+
 # Interpreter-internal types.
 TYPES_TYPES = {
     getattr(types, name): name for name in [
@@ -1440,6 +1443,9 @@ class StubGen:
         return s.rstrip() + "\n"
 
 def parse_options(args: List[str]) -> argparse.Namespace:
+    # Render a ``(major, minor)`` version tuple as e.g. ``'3.9'``.
+    format_version: Callable[[Tuple[int, int]], str] = lambda v: f"{v[0]}.{v[1]}"
+
     parser = argparse.ArgumentParser(
         prog="python -m nanobind.stubgen",
         description="Generate stubs for nanobind-based extensions.",
@@ -1540,9 +1546,10 @@ def parse_options(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--min-python-version",
         metavar="VERSION",
-        default="3.9",
+        default=format_version(MIN_PYTHON_VERSION),
         help="ensure that generated stubs are valid for Python >= VERSION "
-        "(e.g. '3.9') independent of the interpreter running stubgen",
+        f"(e.g. '{format_version(MIN_PYTHON_VERSION)}') independent of the "
+        "interpreter running stubgen",
     )
 
     parser.add_argument(
@@ -1565,14 +1572,20 @@ def parse_options(args: List[str]) -> argparse.Namespace:
             "The -o option is not compatible with recursive stub generation (-r)."
         )
 
-    # determine if have the correct version
+    # determine if it's a supported python version
     version_match = re.match(r"^(\d+)\.(\d+)$", opt.min_python_version)
     if not version_match:
-        parser.error("--min-python-version: expected a version of the form '3.X'.")
-    major, minor = int(version_match.group(1)), int(version_match.group(2))
-    if major != 3 or minor < 9:
-        parser.error("--min-python-version: the oldest supported version is '3.9'.")
-    opt.min_python_version = (major, minor)
+        parser.error(
+            f"--min-python-version: expected a version of the form "
+            f"'{MIN_PYTHON_VERSION[0]}.X'."
+        )
+    version = (int(version_match.group(1)), int(version_match.group(2)))
+    if version[0] != MIN_PYTHON_VERSION[0] or version < MIN_PYTHON_VERSION:
+        parser.error(
+            f"--min-python-version: the oldest supported version is "
+            f"'{format_version(MIN_PYTHON_VERSION)}'."
+        )
+    opt.min_python_version = version
 
     return opt
 

--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -246,7 +246,7 @@ class StubGen:
         patterns: List[ReplacePattern] = [],
         quiet: bool = True,
         output_file: Optional[Path] = None,
-        min_python: Optional[Tuple[int, int]] = None
+        min_python_version: Optional[Tuple[int, int]] = None
     ) -> None:
         # Module to check for name conflicts when adding helper imports
         self.module = module
@@ -279,7 +279,7 @@ class StubGen:
         self.output_file = output_file
 
         # Oldest target Python version (e.g. ``(3, 9)``)
-        self.min_python = min_python
+        self.min_python_version = min_python_version
 
         # ---------- Internal fields ----------
 
@@ -646,7 +646,7 @@ class StubGen:
                 # 'enum.StrEnum' only exists on Python 3.11+. When targeting
                 # older versions, emit the equivalent bases that nanobind
                 # itself uses there for string-valued enumerations
-                if self.min_python and self.min_python < (3, 11) \
+                if self.min_python_version < (3, 11) \
                         and "enum.StrEnum" in tp_bases:
                     pos = tp_bases.index("enum.StrEnum")
                     tp_bases[pos:pos + 1] = ["str", "enum.Enum"]
@@ -788,12 +788,12 @@ class StubGen:
         s = self.abc_re.sub(r'collections.abc.\1', s)
 
         # Normalize 'CapsuleType', it's baked into extension signatures
-        if self.min_python:
-            if self.min_python < (3, 13):
+        if self.min_python_version:
+            if self.min_python_version < (3, 13):
                 s = s.replace("types.CapsuleType", "typing_extensions.CapsuleType")
             else:
                 s = s.replace("typing_extensions.CapsuleType", "types.CapsuleType")
-            if self.min_python < (3, 10):
+            if self.min_python_version < (3, 10):
                 s = s.replace("types.EllipsisType", "ellipsis")
 
         # Process other type names and add suitable import statements
@@ -1077,7 +1077,7 @@ class StubGen:
         Python version (defaults to currently executing Python version).
 
         """
-        version = self.min_python or sys.version_info[:2]
+        version = self.min_python_version or sys.version_info[:2]
         return "typing" if version >= introduced else "typing_extensions"
 
     def import_object(
@@ -1095,7 +1095,7 @@ class StubGen:
 
         # When targeting an explicit minimum Python version, import members
         # that ``typing`` does not provide from ``typing_extensions``
-        if self.min_python and module == "typing" and name:
+        if self.min_python_version and module == "typing" and name:
             introduced = TYPING_INTRODUCED.get(name)
             module = module if not introduced else self.typing_module(introduced)
 
@@ -1540,8 +1540,7 @@ def parse_options(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--min-python-version",
         metavar="VERSION",
-        dest="min_python",
-        default=None,
+        default="3.9",
         help="ensure that generated stubs are valid for Python >= VERSION "
         "(e.g. '3.9') independent of the interpreter running stubgen",
     )
@@ -1565,11 +1564,16 @@ def parse_options(args: List[str]) -> argparse.Namespace:
         parser.error(
             "The -o option is not compatible with recursive stub generation (-r)."
         )
-    if opt.min_python is not None:
-        version_match = re.match(r"^3\.(\d+)$", opt.min_python)
-        if not version_match:
-            parser.error("--min-python-version: expected a version of the form '3.X'.")
-        opt.min_python = (3, int(version_match.group(1)))
+
+    # determine if have the correct version
+    version_match = re.match(r"^(\d+)\.(\d+)$", opt.min_python_version)
+    if not version_match:
+        parser.error("--min-python-version: expected a version of the form '3.X'.")
+    major, minor = int(version_match.group(1)), int(version_match.group(2))
+    if major != 3 or minor < 9:
+        parser.error("--min-python-version: the oldest supported version is '3.9'.")
+    opt.min_python_version = (major, minor)
+
     return opt
 
 
@@ -1697,7 +1701,7 @@ def main(args: Optional[List[str]] = None) -> None:
             max_expr_length=0 if opt.exclude_values else 50,
             patterns=patterns,
             output_file=file,
-            min_python=opt.min_python
+            min_python_version=opt.min_python_version
         )
 
         if not opt.quiet:


### PR DESCRIPTION
I figured I'd see what this looks like: https://github.com/wjakob/nanobind/issues/1346#issuecomment-4728046059.

main reasoning:
- I'd like to optionally check in the output stubs to my repo, to e.g. build docs via e.g. `mkdocs` without cmake, so:
- any (supported) python interpreter version should generate byte-identical stubs

was surprisingly few code changes to surprisingly sane python logic:) 

> [!NOTE]
> - this is intentionally only the src changes; I also have tests, most importantly to fail "new" `typing` definitions in >= 3.15 so they can be manually added
> - it does work nicely according to tests; still, of course feel free to reject, not much work lost
> - this is mostly claude, though I did understand, tweak and approve the changes
