### PR TITLE
Fix conversion warning with 32-bit Eigen::Index

### DIFF
--- a/include/nanobind/eigen/dense.h
+++ b/include/nanobind/eigen/dense.h
@@ -340,11 +340,11 @@ private:
     Eigen::Index inner_stride() const {
         if constexpr (StrideType::InnerStrideAtCompileTime == Eigen::Dynamic)
             if constexpr (ndim_v<T> == 1)
-                return caster.value.stride(0);
+                return (Eigen::Index) caster.value.stride(0);
             else if constexpr (T::IsRowMajor)
-                return caster.value.stride(1);
+                return (Eigen::Index) caster.value.stride(1);
             else
-                return caster.value.stride(0);
+                return (Eigen::Index) caster.value.stride(0);
         else
             return StrideType::InnerStrideAtCompileTime;
     }
@@ -354,9 +354,9 @@ private:
             if constexpr (ndim_v<T> == 1)
                 return (Eigen::Index) caster.value.shape(0);
             else if constexpr (T::IsRowMajor)
-                return caster.value.stride(0);
+                return (Eigen::Index) caster.value.stride(0);
             else
-                return caster.value.stride(1);
+                return (Eigen::Index) caster.value.stride(1);
         else
             return StrideType::OuterStrideAtCompileTime;
     }


### PR DESCRIPTION
```
/tmp/src/nanobind-3.0.1/include/nanobind/eigen/dense.h:343:43: error: conversion from 'int64_t' {aka 'long long int'} to 'Eigen::Index' {aka 'int'} may change value [-Werror=conversion]
  343 |                 return caster.value.stride(0);
      |                        ~~~~~~~~~~~~~~~~~~~^~~
```