### PR TITLE
Fix a compile error when a method's only parameter is 'self'

### DIFF
--- a/include/nanobind/nb_func.h
+++ b/include/nanobind/nb_func.h
@@ -160,6 +160,12 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
     static constexpr bool has_arg_annotations = has_arg_defaults ||
         (nargs_provided > 0 && !is_getter_det);
 
+    // Number of 'arg_data_init' records in the function record below. Note
+    // that this can be zero even when 'has_arg_annotations' is set, e.g. for a
+    // method whose only parameter is a 'self' of type 'std::optional<T>'.
+    constexpr size_t nrec =
+        has_arg_defaults ? (nargs - is_method_det) : nargs_provided;
+
     // Determine the number of potentially-locked function arguments
     static constexpr bool lock_self_det =
         (std::is_same_v<lock_self, Extra> + ... + 0) != 0;
@@ -244,7 +250,7 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
     };
 
     // The following temporary record will describe the function in detail
-    func_data_init<has_arg_defaults ? (nargs - is_method_det) : nargs_provided> f;
+    func_data_init<nrec> f;
 
     f.flags = NB_ABI_MINOR_TAG |
               (args_pos_1   < nargs ? (uint32_t) func_flags::has_var_args   : 0) |
@@ -375,13 +381,12 @@ NB_INLINE PyObject *func_create(Func &&func, Return (*)(Args...),
     // Store information (flags, defaults) about annotated parameters. Skips
     // getters. When 'has_arg_defaults' is set (e.g. due to the presence of
     // ``std::optional<T>``), we provide an implicit annotation for every
-    // parameter, which is initialized by the loop below.
-    if constexpr (has_arg_annotations) {
+    // parameter, which is initialized by the loop below. Note that 'f' has no
+    // 'args' member when 'nrec' is zero.
+    if constexpr (has_arg_annotations && nrec > 0) {
         constexpr auto arg_flags =
             arg_flags_static<is_method_det, has_arg_annotations, Extra...>(
                 (Return (*)(Args...)) nullptr);
-        constexpr size_t nrec =
-            has_arg_defaults ? (nargs - is_method_det) : nargs_provided;
         for (size_t i = 0; i < nrec; ++i) {
             arg_data_init &a = f.args[i];
             a.name = nullptr;

--- a/tests/test_typing.cpp
+++ b/tests/test_typing.cpp
@@ -79,6 +79,15 @@ NB_MODULE(test_typing_ext, m) {
                 nb::for_getter("docstring for getter"),
                 nb::for_setter("docstring for setter"));
 
+    // An overload that only exists in the stub. A 'self' of type
+    // 'std::nullptr_t' never matches an instance, so the call falls through to
+    // the implementation, whose signature is less precise.
+    struct StubOnlyOverload { };
+    nb::class_<StubOnlyOverload>(m, "StubOnlyOverload")
+        .def(nb::init<>())
+        .def("value", [](std::nullptr_t) { return nb::none(); }, nb::sig("def value(self) -> int"))
+        .def("value", [](StubOnlyOverload&) { return nb::cast(42); });
+
     // Stubification of simple constants
     nb::dict d;
     nb::list l;

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -10,3 +10,8 @@ def test01_parameterize_generic():
         assert t.WrapperFoo.__bases__ == (t.Wrapper,)
         assert t.WrapperFoo.__orig_bases__ == (t.Wrapper[t.Foo],)
 
+
+def test02_stub_only_overload():
+    # The overload whose 'self' is a 'std::nullptr_t' never matches, so the
+    # implementation answers the call while the stub keeps both signatures
+    assert t.StubOnlyOverload().value() == 42

--- a/tests/test_typing_ext.pyi.ref
+++ b/tests/test_typing_ext.pyi.ref
@@ -61,6 +61,15 @@ class CustomSignature(Iterable[int]):
     def value(self, value: Optional[int], /) -> None:
         """docstring for setter"""
 
+class StubOnlyOverload:
+    def __init__(self) -> None: ...
+
+    @overload
+    def value(self) -> int: ...
+
+    @overload
+    def value(self) -> object: ...
+
 pytree: dict = ...
 
 T = TypeVar("T", contravariant=True)


### PR DESCRIPTION
A method whose only parameter is `self` stops compiling in 3.0.0 when the type of `self` sets `has_arg_defaults`, i.e. `std::nullptr_t`, `std::optional<T>`, or `std::monostate`. The same binding compiles with 2.9.2.

```cpp
struct Foo { };

NB_MODULE(repro, m) {
    nb::class_<Foo>(m, "Foo")
        .def("f", [](std::nullptr_t) { return 0; });
}
```

```
nb_func.h:386:34: error: 'struct nanobind::detail::func_data_init<0>' has no member named 'args'
```

## Motivation

I hit this while moving a binding-heavy project of mine from 2.9.2 to 3.0.0. The project declares typing-only overloads so that the generated stubs carry types that the C++ signature cannot express, and it writes the placeholder `self` as `std::nullptr_t` so that the overload never matches at runtime. Such an overload does nothing except shape the stub.

Every one of them that takes arguments still compiles. Only the ones that take `self` alone, such as `__next__`, stopped.

## Cause

`func_create` initializes one `arg_data_init` record per argument when `has_arg_defaults` holds. The count is `nargs - is_method_det`, which is zero for the binding above. `func_data_init<0>` has no `args` member, so the loop body
fails to compile even though it never runs.

The failure is limited to this one shape: `[](std::nullptr_t, int)` as a method still compiles, and so does `[](std::nullptr_t)` as a free function.

## Fix

Hoist the record count into `nrec`, next to the other compile-time properties of the signature, reuse it for the type of `f`, and discard the loop when it is zero.

## Test

`tests/test_typing.{cpp,py}` gain a regression test. It does not compile without the fix.

The binding it uses is a `self` that no instance can match, which declares an overload that only exists in the stub, next to an implementation with a less precise signature:

```cpp
nb::class_<StubOnlyOverload>(m, "StubOnlyOverload")
    .def(nb::init<>())
    .def("value", [](std::nullptr_t) { return nb::none(); }, nb::sig("def value(self) -> int"))
    .def("value", [](StubOnlyOverload&) { return nb::cast(42); });
```

```python
class StubOnlyOverload:
    def __init__(self) -> None: ...

    @overload
    def value(self) -> int: ...

    @overload
    def value(self) -> object: ...
```

This extends the `.def("method", []{}, nb::sig(...))` pattern that `test_typing.cpp` already uses to the case where the placeholder must also carry arguments and a return value.