### PR TITLE
Gate the chrono float-to-seconds rule on 'cast_flags::convert'

### DIFF
--- a/docs/api_extra.rst
+++ b/docs/api_extra.rst
@@ -1325,14 +1325,17 @@ converting to Python.
 - ``float`` → ``std::chrono::duration``
     A floating-point value can be converted into a duration. The input is
     treated as a number of seconds, and fractional seconds are supported
-    to the extent representable.
+    to the extent representable. This is an :ref:`implicit conversion
+    <noconvert>`: it does not take place in the first pass of overload
+    resolution, nor when an argument is marked ``noconvert``.
 
 - ``float`` → ``std::chrono::[other_clock]::time_point``
     A floating-point value can be converted into a timepoint on a
     clock other than the system clock. The input is treated as a
     number of seconds, and fractional seconds are supported to the
     extent representable. The resulting timepoint will be that many
-    seconds after the target clock's epoch time.
+    seconds after the target clock's epoch time. This is an :ref:`implicit
+    conversion <noconvert>`, as above.
 
 
 Evaluating Python expressions from strings

--- a/include/nanobind/stl/chrono.h
+++ b/include/nanobind/stl/chrono.h
@@ -113,13 +113,14 @@ inline PyObject* pack_datetime(int year, int month, int day,
 
 // Casts a std::chrono type (either a duration or a time_point) to/from
 // Python timedelta objects, or from a Python float representing seconds.
+// The latter is an implicit conversion and requires 'cast_flags::convert'.
 template <typename type> class duration_caster {
 public:
     using rep = typename type::rep;
     using period = typename type::period;
     using duration_t = std::chrono::duration<rep, period>;
 
-    bool from_python(handle src, uint32_t /*flags*/,
+    bool from_python(handle src, uint32_t flags,
                      cleanup_list *cleanup) noexcept {
         namespace ch = std::chrono;
 
@@ -141,8 +142,10 @@ public:
             return true;
         }
 
-        // If invoked with a float we assume it is seconds and convert
-        if (PyFloat_Check(src.ptr())) {
+        // If invoked with a float we assume it is seconds and convert. This is
+        // an implicit conversion, so it must not run in the first pass of
+        // overload resolution.
+        if (PyFloat_Check(src.ptr()) && (flags & (uint32_t) cast_flags::convert)) {
             value = type(ch::duration_cast<duration_t>(
                              ch::duration<double>(PyFloat_AsDouble(src.ptr()))));
             return true;
@@ -182,8 +185,7 @@ public:
         return pack_timedelta(dd.count(), ss.count(), us.count(), cleanup);
     }
 
-    NB_TYPE_CASTER(type, io_name("datetime.timedelta | float",
-                                 "datetime.timedelta"))
+    NB_TYPE_CASTER(type, const_name("datetime.timedelta"))
 };
 
 template <class... Args>

--- a/tests/test_chrono.cpp
+++ b/tests/test_chrono.cpp
@@ -105,6 +105,17 @@ NB_MODULE(test_chrono_ext, m) {
         return nanobind::steal(result);
     });
 
+    // Reading a float as a number of seconds is an implicit conversion, so a
+    // caller that forbids one must not receive a duration
+    m.def("test_duration_noconvert",
+          [](std::chrono::milliseconds d) { return d.count(); },
+          nanobind::arg().noconvert());
+
+    // The duration overload comes first, but a float matches 'double' without
+    // a conversion, so the second overload must win
+    m.def("test_duration_overload", [](std::chrono::milliseconds) { return 1; });
+    m.def("test_duration_overload", [](double) { return 2; });
+
 #if !defined(NB_BACKEND_MODULE) && (defined(Py_LIMITED_API) || defined(PYPY_VERSION))
     m.attr("access_via_python") = true;
 #else

--- a/tests/test_chrono.py
+++ b/tests/test_chrono.py
@@ -351,3 +351,17 @@ def test_datetime_fields():
 
     with pytest.raises(TypeError, match="expected a datetime type"):
         m.test_datetime_fields(1)
+
+
+def test_duration_noconvert():
+    # nb::arg().noconvert() must reject the float-to-seconds rule
+    assert m.test_duration_noconvert(datetime.timedelta(seconds=2)) == 2000
+    with pytest.raises(TypeError, match="incompatible function arguments"):
+        m.test_duration_noconvert(2.0)
+
+
+def test_duration_overload():
+    # 'double' matches a float in the first pass, so it wins over the duration
+    # overload that was declared first
+    assert m.test_duration_overload(2.0) == 2
+    assert m.test_duration_overload(datetime.timedelta(seconds=2)) == 1


### PR DESCRIPTION
# Gate the chrono float-to-seconds rule on `cast_flags::convert`

`duration_caster::from_python` ignores its `flags` and reads any float as a number of seconds, including in the first pass of overload resolution. Nothing that matches a float without a conversion can win against it. The caster has discarded `flags` since it was ported from pybind11 in 1.3.0 (#175).

```cpp
m.def("f", [](std::chrono::milliseconds) { return 1; });
m.def("f", [](double) { return 2; });
```

```python
>>> f(2.0)
1     # expected 2: 'double' matches a float, while the duration only converts it
```

Both casters accept the float in the first pass, so the overload that is declared first wins.

`nb::arg().noconvert()` does not stop the rule either:

```cpp
m.def("g", [](std::chrono::milliseconds d) { return d.count(); }, nb::arg().noconvert());
```

```python
>>> g(2.0)
2000  # expected TypeError
```

The same happens inside a `std::variant`, where a float subclass such as `numpy.float64` never reaches the alternative that wants the number:

```cpp
m.def("h", [](std::variant<double, std::chrono::milliseconds> v) { return v.index(); }); // <nanobind/stl/variant.h>
```

```python
>>> h(numpy.float64(2.0))
1     # expected 0, i.e. the value became a duration of two seconds
```

## Fix

Test `cast_flags::convert` before the rule. The float is still accepted in the second pass, so a call changes behavior only in two cases: the argument is `noconvert`, or another candidate matches the float in the first pass, as in an overload set or a `std::variant`.

## The input name

The change also drops `float` from the input name of the caster:

```diff
-    NB_TYPE_CASTER(type, io_name("datetime.timedelta | float",
-                                 "datetime.timedelta"))
+    NB_TYPE_CASTER(type, const_name("datetime.timedelta"))
```

The input name lists what a caster accepts without a conversion, as `type_caster<double>` names `float` and not `int`. The signature of an existing function therefore changes from `arg: datetime.timedelta | float` to `arg: datetime.timedelta`.

## Tests

`tests/test_chrono.{cpp,py}` gain two tests, one for the overload set and one for `noconvert`. 

`docs/api_extra.rst` now marks both float entries of the chrono table as implicit conversions.
