### PR TITLE
Take the address of a dllimport slot at run time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,3 +299,46 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         cd build
         python -m pytest
+
+  clang-cl:
+    runs-on: windows-2022
+    name: "Python ${{ matrix.python }} / clang-cl"
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.12']
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Setup Python ${{ matrix.python }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+        cache: 'pip'
+
+    - name: Install the latest CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Install test dependencies
+      run: |
+        python -m pip install pytest pytest-github-actions-annotate-failures typing_extensions
+
+    - name: Configure
+      run: >
+        cmake -S . -B build -G "Visual Studio 17 2022" -T ClangCL
+
+    - name: Build C++
+      run: cmake --build build -j 2
+
+    - name: Check ABI tag
+      run: >
+        cd build/tests/Debug;
+        python -c 'import test_functions_ext as t; print(f"ABI tag is \"{ t.abi_tag() }\"")'
+
+    - name: Run tests
+      run: >
+        cd build;
+        python -m pytest

--- a/include/nanobind/nb_backend.h
+++ b/include/nanobind/nb_backend.h
@@ -611,9 +611,11 @@ struct error_payload {
 #if !defined(NB_BACKEND_MODULE) || defined(NB_BUILD)
 #define NB_SLOT(ret, name, args) NB_CORE ret name args;
 // NB_SLOT_ALIAS resolves to the CPython function itself, which every mode
-// that reaches this branch has access to.
+// that reaches this branch has access to. The pointer is 'const' but not
+// 'constexpr': Windows declares a CPython function '__declspec(dllimport)',
+// and its address is then not a constant expression.
 #define NB_SLOT_ALIAS(ret, name, args, target)                                 \
-    inline constexpr ret (*name) args = &target;
+    inline ret (*const name) args = &target;
 #include "nb_backend_slots.h"
 #endif
 


### PR DESCRIPTION
# Take the address of a dllimport slot at run time

`NB_SLOT_ALIAS` initializes a `constexpr` pointer with the address of a CPython function (`nb_backend.h:615`):

```cpp
#define NB_SLOT_ALIAS(ret, name, args, target) \
    inline constexpr ret (*name) args = &target;
```

Windows declares a CPython function with `__declspec(dllimport)`, so its address is the content of an import slot that the loader fills, and not a constant expression. Clang rejects the initializer:

```cpp
// The declaration that Python.h produces on Windows
extern "C" __declspec(dllimport) int PyObject_Vectorcall(int);
inline constexpr int (*vectorcall)(int) = &PyObject_Vectorcall;
```

```
> clang-cl /std:c++17 /c repro.cpp
repro.cpp(2,24): error: constexpr variable 'vectorcall' must be initialized by a constant expression
```

Every Windows target of Clang fails, both `--target=x86_64-pc-windows-msvc` and `--target=x86_64-w64-windows-gnu`, so no extension builds with clang-cl. MSVC accepts the initializer as an extension, which is why the `windows-2022` job of the CI stays green.

The macro arrived with the vector call slots in 9219167 and reached its first release in 3.0.0.

## Fix

Make the pointer `const` instead of `constexpr`:

```diff
-    inline constexpr ret (*name) args = &target;
+    inline ret (*const name) args = &target;
```


## Tests

The error appears at compile time on one platform, so the test is a CI job. `.github/workflows/ci.yml` gains a `clang-cl` job.
