### PR TITLE
Keep the qualified name of a nested class in a stub

### DIFF
--- a/src/stubgen.py
+++ b/src/stubgen.py
@@ -841,14 +841,6 @@ class StubGen:
             mod_prefix = self.module.__name__ + "."
             if full_name.startswith(mod_prefix) and \
                     (result := full_name[len(mod_prefix) :]).split(".")[0] in self.module.__dict__:
-                # Inside a class body, also strip the immediate enclosing class
-                # prefix (e.g. "ErrorEnum.Value" -> "Value"). Only that scope
-                # is stripped: class scopes don't nest, so an outer class's
-                # members aren't visible by short name in a nested class body.
-                scope = self.prefix[len(mod_prefix) :]
-                enclosing = scope.rpartition(".")[0]
-                if enclosing and result.startswith(enclosing + "."):
-                    result = result[len(enclosing) + 1 :]
                 return result
             elif mod_name in ("typing", "typing_extensions", "collections.abc"):
                 # Import frequently-occurring typing classes and ABCs directly

--- a/tests/test_classes.cpp
+++ b/tests/test_classes.cpp
@@ -610,14 +610,18 @@ NB_MODULE(test_classes_ext, m) {
     // test17_name_qualname_module()
     m.def("f", []{});
     struct MyClass { struct NestedClass { }; struct Sibling { }; };
+    struct TopLevelSibling { };
     nb::class_<MyClass> mcls(m, "MyClass");
+    nb::class_<TopLevelSibling>(m, "Sibling");
     nb::class_<MyClass::Sibling> sib_cls(mcls, "Sibling");
     nb::class_<MyClass::NestedClass> ncls(mcls, "NestedClass");
     mcls.def(nb::init<>());
     mcls.def("f", [](MyClass&){});
+    // A reference to a nested class must keep its qualified name: a type
+    // checker reads a short name in a stub as the module level one, and the
+    // module also holds a class called "Sibling".
+    mcls.def("g", [](MyClass&, MyClass::Sibling){});
     ncls.def("f", [](MyClass::NestedClass&){});
-    // A sibling reference must keep its qualified name ("MyClass.Sibling"):
-    // class scopes don't nest, so "Sibling" is not in NestedClass's scope.
     ncls.def("g", [](MyClass::NestedClass&, MyClass::Sibling){});
 
     // test18_static_properties

--- a/tests/test_classes_ext.pyi.ref
+++ b/tests/test_classes_ext.pyi.ref
@@ -270,6 +270,11 @@ class MyClass:
 
     def f(self) -> None: ...
 
+    def g(self, arg: MyClass.Sibling, /) -> None: ...
+
+class Sibling:
+    pass
+
 class StaticProperties:
     value: ClassVar[int] = ...
     """Static property docstring"""

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -114,8 +114,8 @@ NB_MODULE(test_enum_ext, m) {
 
     m.def("item_to_int", [](Item i) { return (int) i; }, nb::arg("item") = Item::name);
 
-    // Wrapper class with nested enum — tests that stubgen uses short names
-    // (e.g. "Value" not "EnumWrapper.Value") inside the class body.
+    // Wrapper class with nested enum — tests that stubgen keeps the qualified
+    // name (e.g. "EnumWrapper.Value") inside the class body.
     nb::class_<EnumWrapper> ew(m, "EnumWrapper");
 
     nb::enum_<EnumWrapper::Value> ew_enum(ew, "Value");

--- a/tests/test_enum_ext.pyi.ref
+++ b/tests/test_enum_ext.pyi.ref
@@ -131,7 +131,7 @@ class Item(enum.Enum):
 def item_to_int(item: Item = Item.name) -> int: ...
 
 class EnumWrapper:
-    def __init__(self, arg: Value, /) -> None: ...
+    def __init__(self, arg: EnumWrapper.Value, /) -> None: ...
 
     class Value(enum.Enum):
         Alpha = 0
@@ -140,15 +140,15 @@ class EnumWrapper:
 
         Gamma = 2
 
-    Alpha: Value = Value.Alpha
+    Alpha: EnumWrapper.Value = EnumWrapper.Value.Alpha
 
-    Beta: Value = Value.Beta
+    Beta: EnumWrapper.Value = EnumWrapper.Value.Beta
 
-    Gamma: Value = Value.Gamma
+    Gamma: EnumWrapper.Value = EnumWrapper.Value.Gamma
 
-    def __eq__(self, arg: Value, /) -> bool: ...
+    def __eq__(self, arg: EnumWrapper.Value, /) -> bool: ...
 
-    def get_value(self) -> Value: ...
+    def get_value(self) -> EnumWrapper.Value: ...
 
 class Color(enum.StrEnum):
     """string-valued enum"""


### PR DESCRIPTION
Inside a class body, `stubgen` strips the prefix of the enclosing class and writes the short name of a nested class (`stubgen.py:844`). The two type checkers do not agree on what that name means:

```python
# m.pyi
class Sibling:
    top: int

class MyClass:
    class Sibling:
        nested: str
    def g(self, arg: Sibling, /) -> None: ...
```

```python
MyClass().g(MyClass.Sibling())
```

```
> mypy       Success: no issues found
> pyright    error: Argument of type "Sibling" cannot be assigned to parameter "arg" of type "Sibling"
             "m.MyClass.Sibling" is not assignable to "m.Sibling"
```

mypy reads the short name in the scope of the class, and pyright reads it as the module level name. Nothing in the message points at the stub, and the type is silently wrong whenever the module holds a class of that name.

A qualified name has no such ambiguity, and both checkers accept it:

```python
    def g(self, arg: MyClass.Sibling, /) -> None: ...
```

## Relation to #1333

The rule came from #1333, which states that a type checker cannot resolve `EnumWrapper.Value` inside the body of `EnumWrapper` and reports `Unknown`. A stub is never executed, so neither checker has that problem today:

```python
class EnumWrapper:
    class Value(enum.Enum):
        Alpha = 0
    Alpha: EnumWrapper.Value = EnumWrapper.Value.Alpha
    def get_value(self) -> EnumWrapper.Value: ...
```

```
> pyright    Type of "EnumWrapper.Alpha" is "Value"
> mypy       Revealed type is "q.EnumWrapper.Value"
```

The generated `test_enum_ext.pyi` gives the same result: pyright reports the identical set of 8 diagnostics with the short and the qualified name, and mypy the same 4. Both sets are unrelated to the names of the nested classes.
