### PR TITLE
Add missing <cstdio> includes for C-stdio symbols for pyoxide(emscripten)

### DIFF
--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -1,0 +1,73 @@
+name: pyodide
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable
+      - v*
+
+concurrency:
+  group: pyodide-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # See tests/wasm/README.md.
+  wasm32-emscripten:
+    name: "wasm32-emscripten (Pyodide) smoke test"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Setup host Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+
+    - name: Install pyodide-build
+      run: |
+        # wheel>=0.46 dropped 'wheel.cli', which auditwheel_emscripten needs.
+        python -m pip install pyodide-build "wheel<0.46"
+
+    - name: Install the Pyodide cross-build environment
+      run: |
+        pyodide xbuildenv install
+        pyodide config list
+
+    - name: Install the matching (Pyodide-patched) Emscripten SDK
+      run: |
+        pyodide xbuildenv install-emscripten
+
+    - name: Install the latest CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Cross-compile the smoke test extension for wasm32-emscripten
+      run: |
+        source "$(pyodide config get emsdk_dir)/emsdk_env.sh"
+        # -O0 avoids a wasm-opt/binaryen SIDE_MODULE bug ("Imported mutable
+        # global requires mutable-globals") unrelated to nanobind's code.
+        CFLAGS=-O0 CXXFLAGS=-O0 LDFLAGS=-O0 \
+          pyodide build tests/wasm --outdir tests/wasm/dist
+
+    - name: Create a Pyodide virtual environment
+      run: |
+        # Pyodide's python/pip run through Node.js, so emsdk needs to be on
+        # PATH in every step that uses them, not just the one above.
+        source "$(pyodide config get emsdk_dir)/emsdk_env.sh"
+        pyodide venv .venv-pyodide
+
+    - name: Install the smoke test wheel and pytest
+      run: |
+        source "$(pyodide config get emsdk_dir)/emsdk_env.sh"
+        .venv-pyodide/bin/pip install tests/wasm/dist/*.whl pytest
+
+    - name: Run the extension under Pyodide (pytest)
+      run: |
+        source "$(pyodide config get emsdk_dir)/emsdk_env.sh"
+        .venv-pyodide/bin/python -m pytest tests/wasm/test_smoke.py -v

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ py\.typed
 .mypy_cache
 nanobind-backend/build/
 nanobind-backend/dist/
+tests/wasm/build/
+tests/wasm/dist/
+/.pyodide-xbuildenv
+/.venv-pyodide

--- a/include/nanobind/nb_backend.h
+++ b/include/nanobind/nb_backend.h
@@ -38,6 +38,8 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
+#include <cstdio>
+
 /// Major version of the backend ABI. Advances after ABI-breaking backend
 /// changes. Such changes are to be avoided at all costs.
 #define NB_BACKEND_ABI_MAJOR 1

--- a/include/nanobind/nb_defs.h
+++ b/include/nanobind/nb_defs.h
@@ -137,7 +137,18 @@
 
 /* python_error is unusable with libc++ on ELF platforms, where typeinfo is
    compared by pointer. Python imports extensions with RTLD_LOCAL, so the
-   weak symbols of the extensions are not correctly merged. */
+   weak symbols of the extensions are not correctly merged.
+
+   wasm32-emscripten is not ELF, but do not exempt it here without fixing
+   the underlying problem first: verified experimentally that a C++
+   exception thrown in the backend module and caught in an extension
+   module (both dlopen()'d with RTLD_LOCAL, like Python's own extension
+   loading) is not caught at all -- not even by `catch (...)` -- and
+   crashes the Pyodide runtime. A minimal reproduction (two side modules
+   wired via dlsym() function pointers, one throwing a plain exception
+   type and the other catching it by exact type) works fine, so this is
+   specific to nanobind's actual split-mode call path, not a blanket
+   Emscripten limitation. */
 #if defined(NB_BACKEND_MODULE) && defined(_LIBCPP_VERSION) && !defined(__APPLE__)
 #    error "nanobind's split mode requires libstdc++ on ELF platforms"
 #endif

--- a/include/nanobind/nb_types.h
+++ b/include/nanobind/nb_types.h
@@ -7,6 +7,8 @@
     BSD-style license that can be found in the LICENSE file.
 */
 
+#include <cstdio>
+
 NAMESPACE_BEGIN(NB_NAMESPACE)
 
 inline namespace NB_BACKEND_ABI_NS { class NB_EXPORT python_error; }

--- a/include/nanobind/ndarray.h
+++ b/include/nanobind/ndarray.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <nanobind/nanobind.h>
+#include <cstdio>
 #include <initializer_list>
 
 NAMESPACE_BEGIN(NB_NAMESPACE)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -9,6 +9,7 @@
 
 #include <nanobind/nanobind.h>
 #include <memory>
+#include <cstdio>
 #include "nb_internals.h"
 
 #if defined(_MSC_VER)

--- a/src/nb_internals.cpp
+++ b/src/nb_internals.cpp
@@ -10,6 +10,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include "nb_internals.h"
+#include <cstdio>
 #include <thread>
 
 #if defined(NB_FREE_THREADED)

--- a/src/nb_ndarray.cpp
+++ b/src/nb_ndarray.cpp
@@ -1,5 +1,6 @@
 #include <nanobind/ndarray.h>
 #include <atomic>
+#include <cstdio>
 #include <memory>
 #include "nb_internals.h"
 

--- a/src/nb_type.cpp
+++ b/src/nb_type.cpp
@@ -10,6 +10,7 @@
 #include "nb_internals.h"
 #include "nb_ft.h"
 
+#include <cstdio>
 
 #if defined(_MSC_VER)
 #  pragma warning(disable: 4706) // assignment within conditional expression

--- a/tests/wasm/CMakeLists.txt
+++ b/tests/wasm/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.15...3.30)
+project(nanobind_wasm_smoke LANGUAGES CXX)
+
+# Builds against the surrounding nanobind checkout. See tests/wasm/README.md.
+set(NB_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/nanobind-config.cmake)
+if (NOT EXISTS ${NB_CONFIG})
+  message(FATAL_ERROR "tests/wasm builds only from a full nanobind "
+    "repository checkout.")
+endif()
+
+find_package(Python 3.10
+  REQUIRED COMPONENTS Interpreter Development.Module
+  OPTIONAL_COMPONENTS Development.SABIModule)
+
+include(${NB_CONFIG})
+
+nanobind_add_module(smoke_ext smoke.cpp STABLE_ABI)
+
+install(TARGETS smoke_ext LIBRARY DESTINATION .)

--- a/tests/wasm/README.md
+++ b/tests/wasm/README.md
@@ -1,0 +1,31 @@
+# wasm32-emscripten (Pyodide) build smoke test
+
+This directory is not part of the regular native test suite (`tests/`). It
+cross-compiles a minimal nanobind extension for `wasm32-emscripten`, `pip
+install`s the resulting wheel into a `pyodide venv` (a virtualenv whose
+`python`/`pip` transparently run through a real Pyodide runtime), and runs
+`test_smoke.py` with `pytest` inside it -- an ordinary Python packaging and
+testing workflow, just targeting Pyodide instead of the host platform. Driven
+by the `wasm32-emscripten (Pyodide)` CI job in
+`.github/workflows/pyodide.yml`.
+
+It exists to guard against a specific class of regression: nanobind headers
+that use C stdio symbols (`fprintf`, `stderr`, `snprintf`, ...) without
+including `<cstdio>` themselves, relying instead on an accidental transitive
+include through `<Python.h>`. That transitive include is not available when
+targeting Python's stable ABI (`Py_LIMITED_API`, which CPython's `Python.h`
+stops pulling `<stdio.h>` in for as of Python 3.11), which is exactly the
+configuration a portable Pyodide wheel needs -- so a regression here silently
+passes on a normal desktop build and only breaks under Emscripten. See the PR
+that introduced this test for a real-world report of this failure mode
+(found while cross-compiling [onnxsim](https://github.com/onnxsim/onnxsim)
+for Pyodide).
+
+`smoke.cpp` targets `STABLE_ABI` and fails to compile if nanobind's own CMake
+logic ever silently drops the stable ABI (e.g. because the Pyodide/Emscripten
+Python version regresses below 3.12, the floor `nanobind_add_module`
+requires for `STABLE_ABI` in linked mode) -- that would make the test pass
+without exercising the code path it exists to cover.
+
+Building this locally requires a matching Emscripten SDK and a Pyodide
+cross-build environment; see the CI job for the exact commands.

--- a/tests/wasm/pyproject.toml
+++ b/tests/wasm/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["scikit-build-core >=0.10"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "nanobind-wasm-smoke"
+version = "0.0.0"
+description = "wasm32-emscripten (Pyodide) build smoke test, not published"
+requires-python = ">=3.10"
+
+[tool.scikit-build]
+minimum-version = "build-system.requires"
+build-dir = "build/{wheel_tag}"
+wheel.packages = []

--- a/tests/wasm/smoke.cpp
+++ b/tests/wasm/smoke.cpp
@@ -1,0 +1,17 @@
+// tests/wasm/smoke.cpp: minimal stable-ABI extension for wasm32-emscripten
+// (Pyodide) CI. See tests/wasm/README.md.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+NB_MODULE(smoke_ext, m) {
+    m.def("add", [](int a, int b) { return a + b; });
+    m.attr("platform_abi_tag") = NB_PLATFORM_ABI_TAG;
+
+    // Fail loudly rather than silently testing nothing if STABLE_ABI ever
+    // gets dropped (e.g. the Pyodide Python version regresses below 3.12).
+#if !defined(Py_LIMITED_API)
+#    error "smoke_ext must be compiled against the stable ABI (Py_LIMITED_API undefined)"
+#endif
+    m.attr("targeted_stable_abi") = true;
+}

--- a/tests/wasm/test_smoke.py
+++ b/tests/wasm/test_smoke.py
@@ -1,0 +1,13 @@
+import smoke_ext
+
+
+def test_add():
+    assert smoke_ext.add(2, 3) == 5
+
+
+def test_targeted_stable_abi():
+    assert smoke_ext.targeted_stable_abi is True
+
+
+def test_platform_abi_tag():
+    assert "libcpp" in smoke_ext.platform_abi_tag


### PR DESCRIPTION
## Summary

nanobind's own `.cpp` files and, as of a recent upstream header reorganization, three public headers (`nb_backend.h`, `nb_types.h`, `ndarray.h`) use `fprintf`/`stderr`/etc. without including `<cstdio>`. They build only because `<Python.h>` transitively pulls in `<stdio.h>` — but CPython excludes that transitive include once `Py_LIMITED_API` targets Python ≥ 3.11, which is exactly what this project's stable-ABI CMake support (`STABLE_ABI`) sets. A stable-ABI build — needed for a portable Pyodide wasm wheel — therefore fails with `use of undeclared identifier 'stderr'`/`'fprintf'`.

Found while cross-compiling [onnxsim](https://github.com/onnxsim/onnxsim) for `wasm32-emscripten` via Pyodide.

**Fix:** add `#include <cstdio>` to the affected files:
- `src/common.cpp`, `src/nb_internals.cpp`, `src/nb_ndarray.cpp`, `src/nb_type.cpp`
- `include/nanobind/nb_backend.h`, `include/nanobind/nb_types.h`, `include/nanobind/ndarray.h` (public headers — this also affects any user extension targeting the stable ABI, not just nanobind's own build)

**Regression test:** a new `wasm32-emscripten (Pyodide)` CI job (`tests/wasm/`, `.github/workflows/pyodide.yml`) cross-compiles a minimal stable-ABI extension for wasm32-emscripten, `pip install`s it into a `pyodide venv`, and runs it with `pytest` — an ordinary Python packaging workflow, just targeting Pyodide. See `tests/wasm/README.md`.

**Aside, documented but not fixed:** while checking whether the wasm test could reuse the existing `nanobind-backend` package via split mode, I found split mode genuinely crashes on Emscripten (an uncaught, `catch (...)`-proof exception across the `dlopen(RTLD_LOCAL)` module boundary) even though it isn't ELF. Left the existing `nb_defs.h` guard as-is and expanded its comment with this finding so a future attempt to narrow it doesn't have to rediscover it.

## Verification

Reproduced the exact compiler error (`-DPy_LIMITED_API=0x030b0000` against real CPython 3.11 headers, and separately under a real Emscripten/Pyodide toolchain) on the pre-fix tree, confirmed `#include <cstdio>` resolves it on the fixed tree, and confirmed no regression in the normal (non-limited-API) desktop build. The new CI job passes end-to-end on GitHub Actions, with `pytest` reporting `platform emscripten`.
