### PR TITLE
Declare that nanobind now needs Python 3.10+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "scikit_build_core.build"
 name = "nanobind"
 version = "3.0.0"
 description = "nanobind: tiny and efficient C++/Python bindings"
+requires-python = ">=3.10"
 readme.content-type = "text/markdown"
 readme.text = """
 ![nanobind logo](


### PR DESCRIPTION
This packaging metadata is used by package installers like `pip` to avoid installing an incompatible version of the package.

Relates-to #1424 