### PR TITLE
cmake: only require Python::Interpreter for non-cross builds

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -1,6 +1,15 @@
 include_guard(GLOBAL)
 
-if (NOT TARGET Python::Interpreter OR NOT TARGET Python::Module)
+if (NOT TARGET Python::Module)
+  message(FATAL_ERROR "You must invoke 'find_package(Python COMPONENTS Interpreter Development REQUIRED)' prior to including nanobind.")
+endif()
+
+# A runnable interpreter is not required to configure nanobind: the ABI/SOABI
+# information used below comes from 'python-config' (a text script that runs
+# fine even for a foreign-architecture Python) rather than from executing the
+# target interpreter, so this is only enforced for non-cross builds, where its
+# purpose is catching an incomplete find_package(Python) call (see #1350).
+if (NOT TARGET Python::Interpreter AND NOT CMAKE_CROSSCOMPILING)
   message(FATAL_ERROR "You must invoke 'find_package(Python COMPONENTS Interpreter Development REQUIRED)' prior to including nanobind.")
 endif()
 
@@ -63,6 +72,15 @@ endif()
 
 # If either suffix is missing, call Python to compute it
 if(NOT DEFINED NB_SUFFIX OR NOT DEFINED NB_SUFFIX_S)
+  if(NOT TARGET Python::Interpreter OR NOT Python_EXECUTABLE)
+    message(FATAL_ERROR "nanobind: could not determine the extension module "
+      "suffix because no runnable Python interpreter is available (this can "
+      "happen when cross-compiling). Either arrange for 'Python_SOABI' (or "
+      "'SKBUILD_SOABI', if using scikit-build-core) to be set before "
+      "including nanobind, or provide a working 'Python::Interpreter' target "
+      "(with a valid 'Python_EXECUTABLE').")
+  endif()
+
   # Query Python directly to get the right suffix.
   execute_process(
     COMMAND "${Python_EXECUTABLE}" "-c"
@@ -942,6 +960,16 @@ function (nanobind_add_stub name)
     endif()
     list(APPEND NB_STUBGEN_OUTPUTS "${OUTPUT}")
   endforeach()
+
+  if (NOT TARGET Python::Interpreter OR NOT Python_EXECUTABLE)
+    message(FATAL_ERROR "nanobind_add_stub(): generating stubs requires "
+      "running the Python interpreter, but no runnable 'Python::Interpreter' "
+      "target (with a valid 'Python_EXECUTABLE') is available (this can "
+      "happen when cross-compiling). Re-run find_package(Python COMPONENTS "
+      "Interpreter ...) with an interpreter that can execute on the build "
+      "machine, e.g. via 'CMAKE_CROSSCOMPILING_EMULATOR', before calling "
+      "nanobind_add_stub().")
+  endif()
 
   file(TO_CMAKE_PATH ${Python_EXECUTABLE} NB_Python_EXECUTABLE)
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -37,6 +37,20 @@ conditional check.
 
     find_package(Python 3.10 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
 
+.. note::
+
+    Cross-compilation is not officially supported, but nanobind does not
+    require a *runnable* ``Interpreter`` component when
+    ``CMAKE_CROSSCOMPILING`` is set: querying the extension module suffix
+    only relies on information that CMake's ``FindPython`` module can obtain
+    without executing the target Python (e.g. via a ``python-config``
+    script), so it is enough to request the ``Development.Module`` component
+    for the target Python. If that information cannot be determined this way,
+    set ``Python_SOABI`` (or ``SKBUILD_SOABI`` when using scikit-build-core)
+    manually before including nanobind. Generating stubs with
+    :cmake:command:`nanobind_add_stub` still requires an interpreter that can
+    run on the build machine.
+
 Add the following lines below. They configure CMake to perform an optimized
 *release* build by default unless another build type is specified. Without this
 addition, binding code may run slowly and produce large binaries.


### PR DESCRIPTION
Fixes #1412.

# Problem

`cmake/nanobind-config.cmake` has unconditionally required a `Python::Interpreter` target since #1351. That change was meant to catch an incomplete `find_package(Python)` call in native builds (#1350), but it also blocks legitimate cross-compilation setups that never have a runnable interpreter for the target architecture — forcing users to fabricate a fake `Python::Interpreter INTERFACE` target just to satisfy the check (see the workaround described in #1412).

# Why this is safe

Looking at CMake's own `FindPython/Support.cmake`: when only the `Development.Module` component is requested (no Interpreter), CMake computes `Python_SOABI` via `python-config --extension-suffix` — a text script that runs fine on the build host even for a foreign-architecture Python — rather than by executing the target interpreter. So the ABI/version information nanobind needs at configure time (Python_SOABI, Python_VERSION) is already obtainable without a runnable interpreter when cross-compiling. The blanket check doesn't add real safety in that case; it only helps catch mistakes in ordinary (non-cross) builds, which is what #1350 was actually about.

# Changes
- Split the top-level check in `cmake/nanobind-config.cmake`: `Python::Module` is still always required. `Python::Interpreter` is only required when `NOT CMAKE_CROSSCOMPILING`, preserving the original #1350 protection for native builds unchanged.
- Added a targeted error in the `EXT_SUFFIX` fallback query (only reached when Python_SOABI/SKBUILD_SOABI aren't already known) when no runnable interpreter (`Python::Interpreter` target and a valid `Python_EXECUTABLE`) is available, explaining how to resolve it.
- Added the same targeted error in `nanobind_add_stub()`, which genuinely needs to execute Python to generate stubs and has no way around that. Also checks `Python_EXECUTABLE`, not just the target, so a leftover/fake `Python::Interpreter` target (e.g. from the workaround people currently use) still gets a clear message instead of a cryptic internal CMake error `(file(TO_CMAKE_PATH ...) argument-count failure)`.
- Documented the behavior in `docs/building.rst`.

# Testing
- Real end-to-end native build: configured, compiled, and ran a nanobind extension against the system Python (3.12), including nanobind_add_stub — confirms zero regression on the ordinary path.
- Native build missing `Python::Interpreter`: still fails with the original error message — confirms the #1350 protection is untouched.
- Simulated cross-compiling configure (`Python::Module` + Python_SOABI/Python_SOSABI set, no `Python::Interpreter`): configures successfully, correct NB_SUFFIX/NB_SUFFIX_S computed.
- Simulated cross-compiling + `nanobind_add_stub()` with no interpreter, and with a fake `Python::Interpreter` target (the existing workaround): both now report a clear, actionable error instead of failing deep inside CMake internals.