### PR TITLE
Fix abi3t detection on Windows

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -173,8 +173,12 @@ jobs:
   # abi3t extensions (PEP 803) served by a free-threaded backend module.
   # Python 3.15 is only available as a prerelease at the moment
   abi3t:
-    name: "split mode / Python 3.15t (abi3t) / ubuntu-latest"
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest']
+
+    name: "split mode / Python 3.15t (abi3t) / ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
@@ -198,6 +202,7 @@ jobs:
       run: >
         cmake -S . -B build -DNB_TEST_SPLIT_MODE=ON
         -DNB_TEST_FREE_THREADED=ON
+        -DPy_TARGET_ABI3T=1
         -DPython_EXECUTABLE="$(python -c 'import sys; print(sys.executable)')"
 
     - name: Build C++

--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -53,6 +53,11 @@ endif()
 # Extract Python version and extensions (e.g. free-threaded build)
 string(REGEX REPLACE "[^-]*-([^-]*)-.*" "\\1" NB_ABI "${NB_SOABI}")
 
+# Windows has no ABI-tagged extension suffix; scikit-build-core sets this instead
+if(Py_TARGET_ABI3T)
+  set(NB_ABI "${Python_VERSION_MAJOR}${Python_VERSION_MINOR}t")
+endif()
+
 # Determine whether the interpreter was built without the GIL using the ABI tag
 # (free-threaded builds encode this using a trailing 't').
 set(NB_FREE_THREADED 0)


### PR DESCRIPTION
## Summary

scikit-build-core currently cannot encode `abi3t` in `SKBUILD_SOABI` on Windows because Stable ABI extensions use the untagged `.pyd` suffix. It sets `Py_TARGET_ABI3T=1` instead.
See https://github.com/scikit-build/scikit-build-core/blob/5687cc3a0a6a085f87b3f378d3ed1dfdae2d544e/src/scikit_build_core/builder/builder.py#L447-L455

nanobind currently ignores that setting, leaves `NB_ABI` empty, and disables the requested `FREE_THREADED` split path. 
This PR changes the configuration so that `Py_TARGET_ABI3T` is honored when deriving `NB_ABI`.

Assisted-by: gpt-5.6-sol with Codex

(This change was prompted by us having to work around this in one of our projects; see https://github.com/munich-quantum-toolkit/core/blob/970b79a55c9fd355df5fa4a9eb8c0c029fa0a733/cmake/AddMQTPythonBinding.cmake#L13-L17)