### PR TITLE
Preserve section GC in split mode

### DIFF
--- a/cmake/nanobind-config.cmake
+++ b/cmake/nanobind-config.cmake
@@ -573,6 +573,11 @@ function(nanobind_add_module name)
       ${Python_INCLUDE_DIRS} ${NB_DIR}/include)
     target_compile_features(${name} PRIVATE cxx_std_17)
 
+    if (NOT WIN32 AND NOT APPLE AND NOT AIX)
+      target_compile_options(${name} PRIVATE $<${NB_OPT_SIZE}:-ffunction-sections -fdata-sections>)
+      target_link_options(${name} PRIVATE $<${NB_OPT_SIZE}:-Wl,--gc-sections>)
+    endif()
+
     if (WIN32)
       target_link_libraries(${name} PRIVATE Python::SABIModule)
     endif()


### PR DESCRIPTION
## Summary

Linked-mode extension targets inherit `-ffunction-sections`, `-fdata-sections`, and `--gc-sections` from nanobind's static library target. Split-mode extensions skip that library target and therefore lose these options.

This PR applies the same optimized-build options directly to split targets on the platforms where nanobind already enables section garbage collection. Add a configure-time check that protects both the compile and link options.

Assisted-by: gpt-5.6-sol with Codex

(This change was prompted by us having to work around this in one of our projects; see https://github.com/munich-quantum-toolkit/core/blob/970b79a55c9fd355df5fa4a9eb8c0c029fa0a733/cmake/AddMQTPythonBinding.cmake#L54-L59)