### PR TITLE
Add missing <iterator> include from make_iterator.h.

### DIFF
--- a/include/nanobind/make_iterator.h
+++ b/include/nanobind/make_iterator.h
@@ -11,6 +11,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/pair.h>
+#include <iterator>
 #include <new>
 #include <optional>
 


### PR DESCRIPTION
Fixes compilation failures under a libc++ library that does not have this include transitively.

I gather that optional will provide `std::begin` etc under C++26, but it does not apparently under C++20.